### PR TITLE
Do not install requirements_dev.txt in HBP CI.

### DIFF
--- a/Makefile.hbp_ci
+++ b/Makefile.hbp_ci
@@ -7,7 +7,7 @@ COVER_PACKAGES=neurom
 # documentation to build, separated by spaces
 DOC_MODULES=doc
 # optional requirements will be taken from requirements_hbp.txt
-OPTIONAL_FEATURES:='[hbp, dev]'
+OPTIONAL_FEATURES:='[hbp]'
 
 ##### DO NOT MODIFY BELOW #####################
 


### PR DESCRIPTION
These dependencies should already get installed by the
ContinuousIntegration package.