### PR TITLE
Add section_length alias for analysis.morphmath.path_distance

### DIFF
--- a/neurom/analysis/morphmath.py
+++ b/neurom/analysis/morphmath.py
@@ -190,3 +190,7 @@ def segment_taper_rate(seg):
         distance between them.
     '''
     return taper_rate(seg[0], seg[1])
+
+
+# Useful alias for path_distance
+section_length = path_distance

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -219,7 +219,7 @@ def i_section_length(tree):
     """
     Return an iterator of tree section lengths
     """
-    return tr.imap_val(mm.path_distance, tr.isection(tree))
+    return tr.imap_val(mm.section_length, tr.isection(tree))
 
 
 def n_sections(tree):

--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -36,7 +36,7 @@ from neurom.core.tree import isegment
 from neurom.core.tree import isection
 from neurom.core.tree import val_iter
 from neurom.core.dataformat import COLS
-from neurom.analysis.morphmath import path_distance
+from neurom.analysis.morphmath import section_length
 from neurom.analysis.morphmath import segment_length
 from neurom.analysis.morphtree import find_tree_type
 from itertools import chain
@@ -102,7 +102,7 @@ def nonzero_section_lengths(neuron, threshold=0.0):
     Return: list of ids of first point in bad sections
     '''
     l = [[s for s in val_iter(isection(t))
-          if path_distance(s) <= threshold]
+          if section_length(s) <= threshold]
          for t in neuron.neurites]
     return [i[0][COLS.ID] for i in chain(*l)]
 

--- a/neurom/ezy/neuron.py
+++ b/neurom/ezy/neuron.py
@@ -36,7 +36,7 @@ from neurom.core.tree import ipreorder
 from neurom.core.tree import isection
 from neurom.core.tree import isegment
 from neurom.core.tree import i_chain as i_neurites
-from neurom.analysis.morphmath import path_distance
+from neurom.analysis.morphmath import section_length
 from neurom.analysis.morphmath import segment_length
 from neurom.analysis.morphtree import set_tree_type
 from neurom.analysis.morphtree import i_local_bifurcation_angle
@@ -114,7 +114,7 @@ class Neuron(object):
 
     def get_section_lengths(self, neurite_type=TreeType.all):
         '''Get an iterable containing the lengths of all sections of a given type'''
-        return self._pkg(self.iter_sections(path_distance, neurite_type))
+        return self._pkg(self.iter_sections(section_length, neurite_type))
 
     def get_segment_lengths(self, neurite_type=TreeType.all):
         '''Get an iterable containing the lengths of all segments of a given type'''


### PR DESCRIPTION
In neuron morphology contexts, section_length is more descriptive than path_distance.