### PR TITLE
doc: Change TOC build location from _build to avoid readthedocs.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean_test_venv:
 
 clean_doc:
 	@test -x $(ROOT_DIR)/$(VENV_BIN)/sphinx-build && make SPHINXBUILD=$(ROOT_DIR)/$(VENV_BIN)/sphinx-build  -C doc clean || true
-	@rm -rf $(ROOT_DIR)/doc/source/_build
+	@rm -rf $(ROOT_DIR)/doc/source/_neurom_build
 
 clean: clean_doc clean_test_venv
 	@rm -f pep8.txt

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -30,7 +30,7 @@ API Documentation
 =================
 
 .. autosummary::
-   :toctree: _build
+   :toctree: _neurom_build
 
    neurom.ezy
    neurom.ezy.neuron


### PR DESCRIPTION
clash.