### PR TITLE
Add Cython to RTD requirements.

### DIFF
--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -30,4 +30,5 @@
 sphinx>=1.3.0
 sphinxcontrib-napoleon>=0.3.0
 sphinx_rtd_theme>=0.1.0
+Cython
 h5py>=2.2.1


### PR DESCRIPTION
It seems h5py needs it and pip fails to pick up the dependency.