### PR TITLE
Add magic option to pylint to try to fix numpy errors.

### DIFF
--- a/Makefile.travis_ci
+++ b/Makefile.travis_ci
@@ -41,7 +41,7 @@ run_pep8:
 	pep8 --config=pep8rc $(LINT_PYFILES)
 
 run_pylint:
-	pylint --rcfile=pylintrc $(LINT_PYFILES)
+	pylint --rcfile=pylintrc --extension-pkg-whitelist=numpy $(LINT_PYFILES)
 
 run_tests:
 	nosetests -v --with-coverage --cover-min-percentage=$(MIN_COV) --cover-package neurom


### PR DESCRIPTION
Option --extension-pkg-whitelist=numpy
See
https://bitbucket.org/logilab/pylint/issues/397/pylint-and-numpy-produce-e1101-messages