### PR TITLE
Add axon and apical dendrites information in synthesis_json

### DIFF
--- a/examples/synthesis_json.py
+++ b/examples/synthesis_json.py
@@ -131,7 +131,11 @@ if __name__ == '__main__':
 
     flist = [["soma_radius", "radius", "soma", None, None, None],
              ["n_neurites", "number", "basal_dendrite", 1, None,
-              {"neurite_type": ezy.TreeType.basal_dendrite}]]
+              {"neurite_type": ezy.TreeType.basal_dendrite}],
+             ["n_neurites", "number", "apical_dendrite", 0, None,
+              {"neurite_type": ezy.TreeType.apical_dendrite}],
+             ["n_neurites", "number", "axon", 1, None,
+              {"neurite_type": ezy.TreeType.axon}]]
 
     comps = ["soma"]
 

--- a/examples/synthesis_json.py
+++ b/examples/synthesis_json.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
              ["n_neurites", "number", "axon", 1, None,
               {"neurite_type": ezy.TreeType.axon}]]
 
-    comps = ["soma"]
+    comps = ["soma", "basal_dendrite", "apical_dendrite", "axon"]
 
     for d in data_dirs:
         for f in get_morph_files(d):


### PR DESCRIPTION
TODO: synthesis_json is not working for biological data as it is, as it expects a prefix of mtype.
TODO: there is a bug when the input is multiple files, that generates the same json more than once.