### PR TITLE
Add default options to morph_checks

### DIFF
--- a/apps/config.yaml
+++ b/apps/config.yaml
@@ -59,8 +59,8 @@ options :
     
     # threshold
     nonzero_neurite_radii   : 0.007
-    nonzero_segment_lengths : 0.007
-    nonzero_section_lengths : 0.007
+    nonzero_segment_lengths : 0.01
+    nonzero_section_lengths : 0.01
 
     # tolerance/ratio, method
     has_flat_neurites       : [0.1, 'ratio']

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -54,7 +54,7 @@ morphology files.
 Files are unloaded into neuron objects before testing. This means they must
 have a soma and no format errors.
 
-Errors checked for
+Default errors checked for
 ------------------
 * No soma
 * No axon
@@ -63,6 +63,12 @@ Errors checked for
 * Zero radius points
 * Zero length segments
 * Zero length sections
+
+Default options
+--------------
+* nonzero_neurite_radii: 0.007
+* nonzero_segment_lengths: 0.01
+* nonzero_section_lengths: 0.01
 
 Examples
 --------

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -193,7 +193,7 @@ if __name__ == '__main__':
     yaml_path = args.config
     SEPARATOR = '=' * 40
 
-    config = {'neuron_checks': [], 'options': []}
+    config = {'neuron_checks': [], 'options': {}}
 
     if yaml_path:
         try:
@@ -206,12 +206,16 @@ if __name__ == '__main__':
     else:
 
         # set default checks
-        config['neuron_checks'].extend(['has_basal_dendrite',
-                                        'has_axon',
-                                        'has_apical_dendrite',
-                                        'nonzero_segment_lengths',
-                                        'nonzero_section_lengths',
-                                        'nonzero_neurite_radii'])
+        config['neuron_checks'] = ['has_basal_dendrite',
+                                   'has_axon',
+                                   'has_apical_dendrite',
+                                   'nonzero_segment_lengths',
+                                   'nonzero_section_lengths',
+                                   'nonzero_neurite_radii']
+
+        config['options'] = {"nonzero_neurite_radii"   : 0.007,
+                             "nonzero_segment_lengths" : 0.01,
+                             "nonzero_section_lengths" : 0.01}
 
     if 'color' in config:
         import functools

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -199,8 +199,6 @@ if __name__ == '__main__':
     yaml_path = args.config
     SEPARATOR = '=' * 40
 
-    config = {'neuron_checks': [], 'options': {}}
-
     if yaml_path:
         try:
             with open(yaml_path, 'r') as stream:

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -64,7 +64,7 @@ Default errors checked for
 * Zero length segments
 * Zero length sections
 
-Default options
+Default values for options
 --------------
 * nonzero_neurite_radii: 0.007
 * nonzero_segment_lengths: 0.01
@@ -210,18 +210,16 @@ if __name__ == '__main__':
             L.error('Invalid yaml file : \n %s', str(e))
             sys.exit(1)
     else:
-
         # set default checks
-        config['neuron_checks'] = ['has_basal_dendrite',
+        config = {'neuron_checks': ['has_basal_dendrite',
                                    'has_axon',
                                    'has_apical_dendrite',
                                    'nonzero_segment_lengths',
                                    'nonzero_section_lengths',
-                                   'nonzero_neurite_radii']
-
-        config['options'] = {"nonzero_neurite_radii": 0.007,
-                             "nonzero_segment_lengths": 0.01,
-                             "nonzero_section_lengths": 0.01}
+                                   'nonzero_neurite_radii'],
+                  'options': {"nonzero_neurite_radii": 0.007,
+                              "nonzero_segment_lengths": 0.01,
+                              "nonzero_section_lengths": 0.01}}
 
     if 'color' in config:
         import functools

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -213,9 +213,9 @@ if __name__ == '__main__':
                                    'nonzero_section_lengths',
                                    'nonzero_neurite_radii']
 
-        config['options'] = {"nonzero_neurite_radii"   : 0.007,
-                             "nonzero_segment_lengths" : 0.01,
-                             "nonzero_section_lengths" : 0.01}
+        config['options'] = {"nonzero_neurite_radii": 0.007,
+                             "nonzero_segment_lengths": 0.01,
+                             "nonzero_section_lengths": 0.01}
 
     if 'color' in config:
         import functools

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -212,11 +212,11 @@ if __name__ == '__main__':
     else:
         # set default checks
         config = {'neuron_checks': ['has_basal_dendrite',
-                                   'has_axon',
-                                   'has_apical_dendrite',
-                                   'nonzero_segment_lengths',
-                                   'nonzero_section_lengths',
-                                   'nonzero_neurite_radii'],
+                                    'has_axon',
+                                    'has_apical_dendrite',
+                                    'nonzero_segment_lengths',
+                                    'nonzero_section_lengths',
+                                    'nonzero_neurite_radii'],
                   'options': {"nonzero_neurite_radii": 0.007,
                               "nonzero_segment_lengths": 0.01,
                               "nonzero_section_lengths": 0.01}}


### PR DESCRIPTION
Make default options of checks more clear. Note that this could be replaced by a default yaml file.