### PR TITLE
Restrict pylint version to < 1.5

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,8 @@
 
 mock>=1.3.0
 pep8>=1.6.0
-pylint>=1.4.0
+astroid>=1.3,<1.4
+pylint>=1.4.0,<1.5
 nose>=1.3.0
 coverage==3.7
 nosexcover>=1.0.8


### PR DESCRIPTION
New version 1.5 is causing new problems and seems itself to
have unstable builds. Restrict version to be in the 1.4 series.
Requires explicitly restricting astroid to versions < 1.4.