### PR TITLE
added requirement* in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include requirements.txt
+include requirements_dev.txt
+include requirements_hbp.txt
 include README.rst


### PR DESCRIPTION
I cannot properly install Neurom[hbp] package since it will not fetch the corresponding requirements because they are not included in the package.