### PR TITLE
fix: morphmath.angle_3points could not cope with collinear vectors

### DIFF
--- a/neurom/analysis/morphmath.py
+++ b/neurom/analysis/morphmath.py
@@ -83,12 +83,11 @@ def angle_3points(p0, p1, p2):
 
     Returns:
         Angle in radians between (p1-p0) and (p2-p0).
-        nan if p0==p1 or p0==p2.
+        0.0 if p0==p1 or p0==p2.
     '''
     vec1 = vector(p1, p0)
     vec2 = vector(p2, p0)
-    return math.acos(np.dot(vec1, vec2) /
-                     (np.linalg.norm(vec1) * np.linalg.norm(vec2)))
+    return math.atan2(np.linalg.norm(np.cross(vec1, vec2)), np.dot(vec1, vec2))
 
 
 def polygon_diameter(points):

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -78,16 +78,16 @@ def test_angle_3points_half_pi():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (0.0, 2.0, 0.0)
-    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec2 = (0.0, 0.0, 3.0)
-    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec2 = (0.0, 0.0, -3.0)
-    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec1 = (0.0, 4.0, 0.0)
-    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
 
 
 def test_angle_3points_quarter_pi():

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -74,34 +74,42 @@ def test_point_dist():
     nt.ok_(dist==sqrt(3))
 
 
-def test_angle_3points():
+def test_angle_3points_half_pi():
+    orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
-    vec2 = (0.0, 1.0, 0.0)
-    orig = (0.0,0.0,0.0)
-    angle=angle_3points(orig, vec1, vec2)
-    nt.ok_(angle==pi/2.0)
+    vec2 = (0.0, 2.0, 0.0)
+    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+
+    vec2 = (0.0, 0.0, 3.0)
+    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+
+    vec2 = (0.0, 0.0, -3.0)
+    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
+
+    vec1 = (0.0, 4.0, 0.0)
+    nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
 
 
 def test_angle_3points_equal_points_returns_zero():
+    orig = (0.0, 1.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (0.0, 1.0, 0.0)
-    orig = (0.0,1.0,0.0)
-    a = angle_3points(orig,vec1,vec2)
+    a = angle_3points(orig, vec1, vec2)
     nt.assert_equal(a, 0.0)
 
 
 def test_angle_3points_opposing_returns_pi():
+    orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 1.0, 1.0)
     vec2 = (-2.0, -2.0, -2.0)
-    orig = (0.0,0.0,0.0)
     angle=angle_3points(orig, vec1, vec2)
     nt.assert_equal(angle, pi)
 
 
 def test_angle_3points_collinear_returns_zero():
+    orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 1.0, 1.0)
     vec2 = (2.0, 2.0, 2.0)
-    orig = (0.0,0.0,0.0)
     angle=angle_3points(orig, vec1, vec2)
     nt.assert_equal(angle, 0.0)
 

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -90,6 +90,44 @@ def test_angle_3points_half_pi():
     nt.ok_(angle_3points(orig, vec1, vec2)==pi/2.0)
 
 
+def test_angle_3points_quarter_pi():
+    orig = (0.0, 0.0, 0.0)
+    vec1 = (1.0, 0.0, 0.0)
+    vec2 = (2.0, 2.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+
+    vec2 = (3.0, 3.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+
+    vec2 = (3.0, -3.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+
+    vec2 = (3.0, 0.0, 3.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+
+    vec2 = (3.0, 0.0, -3.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+
+
+def test_angle_3points_three_quarter_pi():
+    orig = (0.0, 0.0, 0.0)
+    vec1 = (1.0, 0.0, 0.0)
+    vec2 = (-2.0, 2.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+
+    vec2 = (-3.0, 3.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), 3* pi / 4.0)
+
+    vec2 = (-3.0, -3.0, 0.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+
+    vec2 = (-3.0, 0.0, 3.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+
+    vec2 = (-3.0, 0.0, -3.0)
+    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+
+
 def test_angle_3points_equal_points_returns_zero():
     orig = (0.0, 1.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -82,13 +82,28 @@ def test_angle_3points():
     nt.ok_(angle==pi/2.0)
 
 
-def test_angle_3points_equal_points_returns_nan():
+def test_angle_3points_equal_points_returns_zero():
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (0.0, 1.0, 0.0)
     orig = (0.0,1.0,0.0)
     a = angle_3points(orig,vec1,vec2)
-    nt.ok_(np.isnan(a))
-    nt.ok_(math.isnan(a))
+    nt.assert_equal(a, 0.0)
+
+
+def test_angle_3points_opposing_returns_pi():
+    vec1 = (1.0, 1.0, 1.0)
+    vec2 = (-2.0, -2.0, -2.0)
+    orig = (0.0,0.0,0.0)
+    angle=angle_3points(orig, vec1, vec2)
+    nt.assert_equal(angle, pi)
+
+
+def test_angle_3points_collinear_returns_zero():
+    vec1 = (1.0, 1.0, 1.0)
+    vec2 = (2.0, 2.0, 2.0)
+    orig = (0.0,0.0,0.0)
+    angle=angle_3points(orig, vec1, vec2)
+    nt.assert_equal(angle, 0.0)
 
 
 def soma_points(radius=5,number_points=20):
@@ -215,13 +230,13 @@ def test_pca():
     p = np.array([[4., 2., 0.6],
                  [4.2, 2.1, 0.59],
                  [3.9, 2.0, 0.58],
-                 [4.3, 2.1, 0.62], 
+                 [4.3, 2.1, 0.62],
                  [4.1, 2.2, 0.63]])
 
-    RES_COV = np.array([[0.025, 0.0075, 0.00175], 
-                        [0.0075, 0.0070, 0.00135], 
+    RES_COV = np.array([[0.025, 0.0075, 0.00175],
+                        [0.0075, 0.0070, 0.00135],
                         [0.00175, 0.00135, 0.00043]])
-    
+
     RES_EIGV = np.array([[ 0.93676841,  0.34958469, -0.0159843 ],
                         [ 0.34148069, -0.92313136, -0.1766902 ],
                         [ 0.0765238 , -0.16005947,  0.98413672]])


### PR DESCRIPTION
Add new tests for pi radians and zero angles and change the
implementation of angle calculation to a more robust one
using atan2 instead of acos..