### PR TITLE
fix: non-connected points are a fatal error

### DIFF
--- a/apps/morph_check
+++ b/apps/morph_check
@@ -32,7 +32,7 @@
 from neurom.io.utils import load_neuron, get_morph_files
 from neurom.check import ok as chk_ok
 from neurom.check import morphology as morph_chk
-from neurom.exceptions import SomaError, IDSequenceError
+from neurom.exceptions import SomaError, IDSequenceError, DisconnectedPointError
 import argparse
 import logging
 import yaml
@@ -57,6 +57,7 @@ have a soma and no format errors.
 Default errors checked for
 ------------------
 * No soma
+* Disconnected points
 * No axon
 * No apical dendrite
 * No basal dendrite
@@ -140,9 +141,14 @@ def test_file(f, config):
     try:
         nrn = load_neuron(f)
         log_msg(True, 'Has valid soma?')
+        log_msg(True, 'All points connected?')
     except SomaError:
         log_msg(False, 'Has valid soma?')
         L.warning('Cannot continue without a soma... Aborting')
+        return False
+    except DisconnectedPointError as e:
+        log_msg(False, 'All points connected')
+        L.warning(e.message)
         return False
 
     result = True

--- a/doc/source/quick.rst
+++ b/doc/source/quick.rst
@@ -76,6 +76,7 @@ For example,
     INFO: ========================================
     INFO: Check file test_data/swc/Neuron.swc...
     INFO:                     Has valid soma? PASS
+    INFO:               All points connected? PASS
     INFO:                 Has basal dendrite? PASS
     INFO:                           Has axon? PASS
     INFO:                Has apical dendrite? PASS

--- a/neurom/exceptions.py
+++ b/neurom/exceptions.py
@@ -42,3 +42,8 @@ class SomaError(NeuroMError):
 class IDSequenceError(NeuroMError):
     '''Exception for raw data with illegal point ID sequence'''
     pass
+
+
+class DisconnectedPointError(NeuroMError):
+    '''Exception for raw data with disconnected points'''
+    pass

--- a/neurom/io/check.py
+++ b/neurom/io/check.py
@@ -44,6 +44,22 @@ def has_sequential_ids(raw_data):
     return len(steps) == 0, steps
 
 
+def all_points_connected(raw_data):
+    '''Check that all points are connected
+
+    Point's parent ID must exist and parent must be declared
+    before child.
+
+    Returns:
+        tuple (bool, list of IDs that have no parent)
+    '''
+    ids = raw_data.get_col(COLS.ID)
+    bad_ids = [int(ids[i]) for i in xrange(1, len(ids))
+               if raw_data.data_block[i][COLS.P] not in ids[:i]]
+
+    return len(bad_ids) == 0, bad_ids
+
+
 def has_increasing_ids(raw_data):
     '''Check that IDs are increasing
 

--- a/neurom/io/tests/test_check.py
+++ b/neurom/io/tests/test_check.py
@@ -68,6 +68,24 @@ def test_has_sequential_ids_bad_data():
     nt.ok_(ids == [6, 217, 428, 639])
 
 
+def test_has_all_points_connected_bad_data():
+
+    f = os.path.join(SWC_PATH, 'Neuron_missing_ids.swc')
+
+    ok, ids = io.check.all_points_connected(io.load_data(f))
+    nt.ok_(not ok)
+    nt.eq_(ids, [6, 217, 428, 639])
+
+
+def test_has_all_points_connected_good_data():
+
+    f = os.path.join(SWC_PATH, 'Neuron.swc')
+
+    ok, ids = io.check.all_points_connected(io.load_data(f))
+    nt.ok_(ok)
+    nt.eq_(len(ids), 0)
+
+
 def test_has_soma_points_good_data():
     files = [os.path.join(SWC_PATH, f)
              for f in ['Neuron.swc',

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -33,7 +33,7 @@ from neurom import io
 from neurom.io import utils
 from neurom.core.dataformat import COLS
 from neurom.core import tree
-from neurom.exceptions import SomaError, IDSequenceError
+from neurom.exceptions import SomaError, IDSequenceError, DisconnectedPointError
 from nose import tools as nt
 
 
@@ -53,6 +53,8 @@ FILES = [os.path.join(SWC_PATH, f)
                    'Neuron_no_missing_ids_no_zero_segs.swc']]
 
 NO_SOMA_FILE = os.path.join(SWC_PATH, 'Single_apical_no_soma.swc')
+
+DISCONNECTED_POINTS_FILE = os.path.join(SWC_PATH, 'Neuron_missing_ids.swc')
 
 NON_CONSECUTIVE_ID_FILE = os.path.join(SWC_PATH,
                                        'non_sequential_trunk_off_1_16pt.swc')
@@ -165,7 +167,7 @@ def test_load_neuron_deep_neuron():
        recursion limit can be loaded)
     '''
     deep_neuron = os.path.join(DATA_PATH, 'h5/v1/deep_neuron.h5')
-    nrn = utils.load_neuron(deep_neuron)
+    utils.load_neuron(deep_neuron)
 
 
 def test_get_morph_files():
@@ -176,6 +178,11 @@ def test_get_morph_files():
     files = set(os.path.basename(f) for f in utils.get_morph_files(FILE_PATH))
 
     nt.assert_equal(ref, files)
+
+
+@nt.raises(DisconnectedPointError)
+def test_load_neuron_disconnected_points_raises():
+    utils.load_neuron(DISCONNECTED_POINTS_FILE)
 
 
 @nt.raises(SomaError)

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -33,7 +33,7 @@ from neurom.core.dataformat import POINT_TYPE
 from neurom.core.dataformat import ROOT_ID
 from neurom.core.tree import Tree
 from neurom.core.neuron import Neuron, make_soma
-from neurom.exceptions import IDSequenceError
+from neurom.exceptions import IDSequenceError, DisconnectedPointError
 from . import load_data
 from . import check
 from neurom.utils import memoize
@@ -115,6 +115,9 @@ def load_neuron(filename, tree_action=None):
     data = load_data(filename)
     if not check.has_increasing_ids(data)[0]:
         raise IDSequenceError('Invald ID sequence found in raw data')
+    if not check.all_points_connected(data)[0]:
+        raise DisconnectedPointError('Disconnected point detected')
+
     nrn = make_neuron(data, tree_action)
     nrn.name = os.path.splitext(os.path.basename(filename))[0]
 


### PR DESCRIPTION
neuron loading was ignoring disconnected points, simply
truncating trees at the point of disconnection. This is
now an error that makes the loading fail.