### PR TITLE
New structure for neurite segment morphometrics calculators.

### DIFF
--- a/neurom/segments.py
+++ b/neurom/segments.py
@@ -38,13 +38,14 @@ iter_type = tr.isegment
 
 
 def itr(neuron, mapping=None, filt=None):
-    '''Iterator to neuron's segments
+    '''Iterator to a neuron or neuron population's segments
 
-    Applies a filter function and a mapping.
+    Applies a neurite filter function and a segment mapping.
 
     Example:
         Get the lengths of segments in a neuron and a population
 
+        >>> from neurom import segments as seg
         >>> neuron_lengths = [l for l in seg.itr(nrn, seg.length)]
         >>> population_lengths = [l for l in seg.itr(pop, seg.length)]
 

--- a/neurom/segments.py
+++ b/neurom/segments.py
@@ -37,8 +37,8 @@ import neurom.analysis.morphmath as mm
 iter_type = tr.isegment
 
 
-def itr(neuron, mapping=None, filt=None):
-    '''Iterator to a neuron or neuron population's segments
+def itr(obj, mapping=None, filt=None):
+    '''Iterator to a neurite, neuron or neuron population's segments
 
     Applies a neurite filter function and a segment mapping.
 
@@ -48,9 +48,12 @@ def itr(neuron, mapping=None, filt=None):
         >>> from neurom import segments as seg
         >>> neuron_lengths = [l for l in seg.itr(nrn, seg.length)]
         >>> population_lengths = [l for l in seg.itr(pop, seg.length)]
-
+        >>> neurite = nrn.neurites[0]
+        >>> tree_lengths = [l for l in seg.itr(neurite, seg.length)]
     '''
-    return tr.i_chain(neuron.neurites, iter_type, mapping, filt)
+    #  TODO: optimize case of single neurite and move code to neurom.core.tree
+    neurites = [obj] if isinstance(obj, tr.Tree) else obj.neurites
+    return tr.i_chain(neurites, iter_type, mapping, filt)
 
 
 length = mm.segment_length

--- a/neurom/segments.py
+++ b/neurom/segments.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Basic functions and iterators for neuron neurite segment morphometrics
+
+'''
+import functools
+from neurom.core import tree as tr
+import neurom.analysis.morphmath as mm
+
+
+iter_type = tr.isegment
+
+
+def itr(neuron, mapping=None, filt=None):
+    '''Iterator to neuron's segments
+
+    Applies a filter function and a mapping.
+
+    Example:
+        Get the lengths of segments in a neuron and a population
+
+        >>> neuron_lengths = [l for l in seg.itr(nrn, seg.length)]
+        >>> population_lengths = [l for l in seg.itr(pop, seg.length)]
+
+    '''
+    return tr.i_chain(neuron.neurites, iter_type, mapping, filt)
+
+
+length = mm.segment_length
+radius = mm.segment_radius
+volume = mm.segment_volume
+area = mm.segment_area
+
+
+def radial_dist(pos):
+    '''Return a function that calculates radial distance for a segment
+
+    Radial distance calculater WRT pos
+    '''
+    return functools.partial(mm.segment_radial_dist, pos=pos)
+
+
+def n_segments(neuron):
+    """
+    Return number of segments in neuron or population
+    """
+    return sum(1 for _ in itr(neuron))

--- a/neurom/tests/test_segments.py
+++ b/neurom/tests/test_segments.py
@@ -110,17 +110,18 @@ def _form_branching_tree():
 BRANCHING_TREE = _form_branching_tree()
 
 
-def test_segment_lengths():
 
 
-    lg = [l for l in seg.itr(NEURON, seg.length)]
+def _check_segment_lengths(obj):
+
+    lg = [l for l in seg.itr(obj, seg.length)]
 
     nt.eq_(lg, [1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 2.0, 1.0, 1.0])
 
 
-def test_segment_volumes():
+def _check_segment_volumes(obj):
 
-    sv = (l/math.pi for l in seg.itr(NEURON, seg.volume))
+    sv = (l/math.pi for l in seg.itr(obj, seg.volume))
 
     ref = (1.0, 1.0, 4.6666667, 4.0, 4.6666667, 0.7708333,
            0.5625, 4.6666667, 0.7708333, 0.5625)
@@ -129,9 +130,9 @@ def test_segment_volumes():
         nt.assert_almost_equal(a, b)
 
 
-def test_segment_areas():
+def _check_segment_areas(obj):
 
-    sa = (l/math.pi for l in seg.itr(NEURON, seg.area))
+    sa = (l/math.pi for l in seg.itr(obj, seg.area))
 
     ref = (2.0, 2.0, 6.7082039, 4.0, 6.7082039, 1.8038587,
            1.5, 6.7082039, 1.8038587, 1.5)
@@ -140,25 +141,57 @@ def test_segment_areas():
         nt.assert_almost_equal(a, b)
 
 
-def test_segment_radius():
+def _check_segment_radius(obj):
 
-    rad = [r for r in seg.itr(NEURON, seg.radius)]
+    rad = [r for r in seg.itr(obj, seg.radius)]
 
     nt.eq_(rad,
            [1.0, 1.0, 1.5, 2.0, 1.5, 0.875, 0.75, 1.5, 0.875, 0.75])
 
 
-def test_n_segments():
-    nt.eq_(seg.n_segments(NEURON), 10)
-    neuron_b = MockNeuron()
-    neuron_b.neurites = [NEURON_TREE, NEURON_TREE, NEURON_TREE]
-    nt.eq_(seg.n_segments(neuron_b), 30)
+def _check_n_segments(obj, n):
+    nt.eq_(seg.n_segments(obj), n)
 
 
-def test_segment_radial_dists():
+def _check_segment_radial_dists(obj):
 
     origin = [0.0, 0.0, 0.0]
 
     rd = [d for d in seg.itr(SIMPLE_NEURON, seg.radial_dist(origin))]
 
     nt.eq_(rd, [1.0, 3.0, 5.0, 7.0, 1.0, 3.0, 5.0, 7.0])
+
+
+def test_segment_volumes():
+    _check_segment_volumes(NEURON)
+    _check_segment_volumes(NEURON_TREE)
+
+
+def test_segment_lengths():
+    _check_segment_lengths(NEURON)
+    _check_segment_lengths(NEURON_TREE)
+
+
+def test_segment_areas():
+    _check_segment_areas(NEURON)
+    _check_segment_areas(NEURON_TREE)
+
+
+def test_segment_radius():
+    _check_segment_radius(NEURON)
+    _check_segment_radius(NEURON_TREE)
+
+
+def test_n_segments():
+    _check_n_segments(NEURON, 10)
+    _check_n_segments(NEURON_TREE, 10)
+
+    neuron_b = MockNeuron()
+    neuron_b.neurites = [NEURON_TREE, NEURON_TREE, NEURON_TREE]
+
+    _check_n_segments(neuron_b, 30)
+
+
+def test_segment_radial_dists():
+    _check_segment_radial_dists(SIMPLE_NEURON)
+    _check_segment_radial_dists(SIMPLE_TREE)

--- a/neurom/tests/test_segments.py
+++ b/neurom/tests/test_segments.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from nose import tools as nt
+import os
+from neurom.io.utils import make_neuron
+from neurom import io
+from neurom.core.tree import Tree
+from neurom import segments as seg
+
+import math
+from itertools import izip
+
+
+class MockNeuron(object):
+    pass
+
+
+DATA_PATH = './test_data'
+SWC_PATH = os.path.join(DATA_PATH, 'swc/')
+
+data    = io.load_data(SWC_PATH + 'Neuron.swc')
+neuron0 = make_neuron(data)
+tree0   = neuron0.neurites[0]
+
+def _form_neuron_tree():
+    p = [0.0, 0.0, 0.0, 1.0, 1, 1, 2]
+    T = Tree(p)
+    T1 = T.add_child(Tree([0.0, 1.0, 0.0, 1.0, 1, 1, 2]))
+    T2 = T1.add_child(Tree([0.0, 2.0, 0.0, 1.0, 1, 1, 2]))
+    T3 = T2.add_child(Tree([0.0, 4.0, 0.0, 2.0, 1, 1, 2]))
+    T4 = T3.add_child(Tree([0.0, 5.0, 0.0, 2.0, 1, 1, 2]))
+    T5 = T4.add_child(Tree([2.0, 5.0, 0.0, 1.0, 1, 1, 2]))
+    T6 = T4.add_child(Tree([0.0, 5.0, 2.0, 1.0, 1, 1, 2]))
+    T7 = T5.add_child(Tree([3.0, 5.0, 0.0, 0.75, 1, 1, 2]))
+    T8 = T7.add_child(Tree([4.0, 5.0, 0.0, 0.75, 1, 1, 2]))
+    T9 = T6.add_child(Tree([0.0, 5.0, 3.0, 0.75, 1, 1, 2]))
+    T10 = T9.add_child(Tree([0.0, 6.0, 3.0, 0.75, 1, 1, 2]))
+    return T
+
+
+def _form_simple_tree():
+    p = [0.0, 0.0, 0.0, 1.0, 1, 1, 1]
+    T = Tree(p)
+    T1 = T.add_child(Tree([0.0, 2.0, 0.0, 1.0, 1, 1, 1]))
+    T2 = T1.add_child(Tree([0.0, 4.0, 0.0, 1.0, 1, 1, 1]))
+    T3 = T2.add_child(Tree([0.0, 6.0, 0.0, 1.0, 1, 1, 1]))
+    T4 = T3.add_child(Tree([0.0, 8.0, 0.0, 1.0, 1, 1, 1]))
+
+    T5 = T.add_child(Tree([0.0, 0.0, 2.0, 1.0, 1, 1, 1]))
+    T6 = T5.add_child(Tree([0.0, 0.0, 4.0, 1.0, 1, 1, 1]))
+    T7 = T6.add_child(Tree([0.0, 0.0, 6.0, 1.0, 1, 1, 1]))
+    T8 = T7.add_child(Tree([0.0, 0.0, 8.0, 1.0, 1, 1, 1]))
+
+    return T
+
+
+NEURON_TREE = _form_neuron_tree()
+SIMPLE_TREE = _form_simple_tree()
+
+NEURON = MockNeuron()
+NEURON.neurites = [NEURON_TREE]
+
+SIMPLE_NEURON = MockNeuron()
+SIMPLE_NEURON.neurites = [SIMPLE_TREE]
+
+def _form_branching_tree():
+    p = [0.0, 0.0, 0.0, 1.0, 1, 1, 2]
+    T = Tree(p)
+    T1 = T.add_child(Tree([0.0, 1.0, 0.0, 1.0, 1, 1, 2]))
+    T2 = T1.add_child(Tree([0.0, 2.0, 0.0, 1.0, 1, 1, 2]))
+    T3 = T2.add_child(Tree([0.0, 4.0, 0.0, 2.0, 1, 1, 2]))
+    T4 = T3.add_child(Tree([0.0, 5.0, 0.0, 2.0, 1, 1, 2]))
+    T5 = T4.add_child(Tree([2.0, 5.0, 0.0, 1.0, 1, 1, 2]))
+    T6 = T4.add_child(Tree([0.0, 5.0, 2.0, 1.0, 1, 1, 2]))
+    T7 = T5.add_child(Tree([3.0, 5.0, 0.0, 0.75, 1, 1, 2]))
+    T8 = T7.add_child(Tree([4.0, 5.0, 0.0, 0.75, 1, 1, 2]))
+    T9 = T6.add_child(Tree([0.0, 5.0, 3.0, 0.75, 1, 1, 2]))
+    T10 = T9.add_child(Tree([0.0, 6.0, 3.0, 0.75, 1, 1, 2]))
+    T11 = T9.add_child(Tree([0.0, 6.0, 4.0, 0.75, 1, 1, 2]))
+    T33 = T3.add_child(Tree([1.0, 5.0, 0.0, 2.0, 1, 1, 2]))
+    T331 = T33.add_child(Tree([15.0, 15.0, 0.0, 2.0, 1, 1, 2]))
+    return T
+
+BRANCHING_TREE = _form_branching_tree()
+
+
+def test_segment_lengths():
+
+
+    lg = [l for l in seg.itr(NEURON, seg.length)]
+
+    nt.eq_(lg, [1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 2.0, 1.0, 1.0])
+
+
+def test_segment_volumes():
+
+    sv = (l/math.pi for l in seg.itr(NEURON, seg.volume))
+
+    ref = (1.0, 1.0, 4.6666667, 4.0, 4.6666667, 0.7708333,
+           0.5625, 4.6666667, 0.7708333, 0.5625)
+
+    for a, b in izip(sv, ref):
+        nt.assert_almost_equal(a, b)
+
+
+def test_segment_areas():
+
+    sa = (l/math.pi for l in seg.itr(NEURON, seg.area))
+
+    ref = (2.0, 2.0, 6.7082039, 4.0, 6.7082039, 1.8038587,
+           1.5, 6.7082039, 1.8038587, 1.5)
+
+    for a, b in izip(sa, ref):
+        nt.assert_almost_equal(a, b)
+
+
+def test_segment_radius():
+
+    rad = [r for r in seg.itr(NEURON, seg.radius)]
+
+    nt.eq_(rad,
+           [1.0, 1.0, 1.5, 2.0, 1.5, 0.875, 0.75, 1.5, 0.875, 0.75])
+
+
+def test_n_segments():
+    nt.eq_(seg.n_segments(NEURON), 10)
+    neuron_b = MockNeuron()
+    neuron_b.neurites = [NEURON_TREE, NEURON_TREE, NEURON_TREE]
+    nt.eq_(seg.n_segments(neuron_b), 30)
+
+
+def test_segment_radial_dists():
+
+    origin = [0.0, 0.0, 0.0]
+
+    rd = [d for d in seg.itr(SIMPLE_NEURON, seg.radial_dist(origin))]
+
+    nt.eq_(rd, [1.0, 3.0, 5.0, 7.0, 1.0, 3.0, 5.0, 7.0])


### PR DESCRIPTION
General idea: put functions and their compatible iterators
under the same module to add some kind of semantic association
between them. Iteration source is a neuron or population, not
a single tree.

Initial test case:
* module neurom.segments with functors and a segment iterator.

Examples:

    import neurom.segments as seg
    nrn = ... # core or ezy neuron, or population
    # simple case
    seg_len = [l for l in seg.itr(nrn, seg.length)]
    # less simple: radial_dist requires an origin WRT which the distance is calculated
    seg_rad_dist = [d for d in seg.itr(nrn, seg.radial_dist(nrn.soma.center()))]