### PR TITLE
morph_stats now can treat multiple directories as populations of neurons

### DIFF
--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -73,7 +73,7 @@ def parse_args():
 
     parser.add_argument('datapaths',
                         nargs='+',
-                        help='Paths to morphology data file or directory')
+                        help='Paths to morphology data files or directories')
 
     parser.add_argument('-v', '--verbose', action='count', dest='verbose', default=0,
                         help='-v for INFO, -vv for DEBUG')
@@ -82,8 +82,8 @@ def parse_args():
                         action='store_true',
                         default=False,
                         help='If more than one directories are specified in the \
-                              datapaths and this flag is enabled the cells in the \
-                              will be treated a population')
+                              datapaths and this flag is enabled the cells in each dir\
+                              will be treated as a population')
     return parser.parse_args()
 
 

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -87,12 +87,20 @@ def extract_stats(files):
                 value = getattr(nrn, ns)(n)
                 L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
                 if isinstance(value, np.ndarray):
-                    value = {
-                        'mean': np.mean(value),
-                        'std': np.std(value),
-                        'min': np.min(value),
-                        'max': np.max(value),
-                    }
+                    if len(value) > 0:
+                        value = {
+                            'mean': np.mean(value),
+                            'std': np.std(value),
+                            'min': np.min(value),
+                            'max': np.max(value),
+                        }
+                    else:
+                        value = {
+                            'mean': 0.,
+                            'std': 0.,
+                            'min': 0.,
+                            'max': 0.,
+                        }                        
                 stats[stat_name][n.name] = value
 
         for ns in SCALAR_STATS:

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -69,14 +69,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Morphology statistics extractor',
                                      epilog='Note: Outputs json')
 
-<<<<<<< HEAD
-    parser.add_argument('datapaths',
-                        nargs='+',
-                        help='Path to a morphology data file or a directory')
-=======
     parser.add_argument('datapath',
-                        help='Paths to morphology data files or directories')
->>>>>>> f796db8d941a11295db13413d92b48fd089086d2
+                        help='Path to a morphology data file or a directory')
 
     parser.add_argument('-v', '--verbose', action='count', dest='verbose', default=0,
                         help='-v for INFO, -vv for DEBUG')

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -35,22 +35,28 @@ import logging
 import os
 import sys
 
+from itertools import chain
 import numpy as np
 
 from neurom.core.types import NEURITES
-from neurom.ezy import load_neuron
+from neurom.ezy import load_neuron, load_population
 from neurom.io.utils import get_morph_files
 
 L = logging.getLogger(__name__)
+
 
 NEURITE_STATS = [
     'get_section_lengths',
     'get_segment_lengths',
     'get_local_bifurcation_angles',
     'get_remote_bifurcation_angles',
-    'get_n_sections',
-    'get_n_neurites',
     'get_n_sections_per_neurite'
+]
+
+
+NEURITE_STATS_INT = [
+    'get_n_sections',
+    'get_n_neurites'
 ]
 
 
@@ -65,46 +71,94 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Morphology statistics extractor',
                                      epilog='Note: Outputs json')
 
-    parser.add_argument('datapath',
-                        help='Path to morphology data file or directory')
+    parser.add_argument('datapaths',
+                        nargs='+',
+                        help='Paths to morphology data file or directory')
 
     parser.add_argument('-v', '--verbose', action='count', dest='verbose', default=0,
                         help='-v for INFO, -vv for DEBUG')
 
+    parser.add_argument('--dir_as_pop',
+                        action='store_true',
+                        default=False,
+                        help='If more than one directories are specified in the \
+                              datapaths and this flag is enabled the cells in the \
+                              will be treated a population')
     return parser.parse_args()
 
 
-def extract_stats(files):
+def calculate_stats(values):
+    '''Calculate basic stats
+    '''
+    # check if array is empty
+    if len(values) > 0:
+        stats = {
+            'mean': np.mean(values),
+            'std': np.std(values),
+            'min': np.min(values),
+            'max': np.max(values),
+        }
+    else:
+        stats = {
+            'mean': 0.,
+            'std': 0.,
+            'min': 0.,
+            'max': 0.,
+        }
+    return stats
+
+
+def extract_neurons_stats(files):
     '''Extract stats from files'''
     results = {}
     for _f in files:
         nrn = load_neuron(_f)
         stats = results[_f] = {}
-        for ns in NEURITE_STATS:
+        for ns in NEURITE_STATS + NEURITE_STATS_INT:
             stat_name = ns[4:]
             stats[stat_name] = {}
             for n in NEURITES:
                 value = getattr(nrn, ns)(n)
                 L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
                 if isinstance(value, np.ndarray):
-                    if len(value) > 0:
-                        value = {
-                            'mean': np.mean(value),
-                            'std': np.std(value),
-                            'min': np.min(value),
-                            'max': np.max(value),
-                        }
-                    else:
-                        value = {
-                            'mean': 0.,
-                            'std': 0.,
-                            'min': 0.,
-                            'max': 0.,
-                        }                        
+                    value = calculate_stats(value)
                 stats[stat_name][n.name] = value
 
         for ns in SCALAR_STATS:
             stats[ns[4:]] = getattr(nrn, ns)()
+    return results
+
+
+def extract_populations_stats(files):
+    '''Extract stats from directories treated as populations'''
+    results = {}
+
+    for _f in files:
+        pop = load_population(_f)
+        stats = results[_f] = {}
+        for ns in NEURITE_STATS:
+            stat_name = ns[4:]
+            stats[stat_name] = {}
+            for n in NEURITES:
+                value = np.fromiter(chain.from_iterable(getattr(nrn, ns)(n) for nrn in pop.neurons),
+                                    np.float)
+                L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
+                value = calculate_stats(value)
+                stats[stat_name][n.name] = value
+
+        for ns in NEURITE_STATS_INT:
+            stat_name = ns[4:]
+            stats[stat_name] = {}
+            for n in NEURITES:
+                value = np.array([getattr(nrn, ns)(n) for nrn in pop.neurons])
+                L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
+                value = calculate_stats(value)
+                stats[stat_name][n.name] = value
+
+        for ns in SCALAR_STATS:
+            value = np.array([getattr(nrn, ns)() for nrn in pop.neurons])
+            value = calculate_stats(value)
+            stats[stat_name][n.name] = value
 
     return results
 
@@ -115,15 +169,26 @@ if __name__ == '__main__':
                                logging.INFO,
                                logging.DEBUG)[min(args.verbose, 2)])
 
-    data_path = args.datapath
+    data_paths = args.datapaths
 
-    if os.path.isfile(data_path):
-        _files = [data_path]
-    elif os.path.isdir(data_path):
-        _files = get_morph_files(data_path)
+    # treat a directory as a population
+    if args.dir_as_pop:
+
+        _stats = extract_populations_stats(data_paths)
+
+    # otherwise concatenate all the found files
     else:
-        L.error('Invalid data path %s', data_path)
-        sys.exit(1)
 
-    _stats = extract_stats(_files)
+        _files = []
+        for data_path in data_paths:
+
+            if os.path.isfile(data_path):
+                _files.append(data_path)
+            elif os.path.isdir(data_path):
+                _files.extend(get_morph_files(data_path))
+            else:
+                L.error('Invalid data path %s', data_path)
+                sys.exit(1)
+        _stats = extract_neurons_stats(_files)
+
     print json.dumps(_stats, indent=2, separators=(',', ':'))

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -157,6 +157,7 @@ def extract_populations_stats(files):
 
         for ns in SCALAR_STATS:
             value = np.array([getattr(nrn, ns)() for nrn in pop.neurons])
+            L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
             value = calculate_stats(value)
             stats[stat_name][n.name] = value
 

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -29,17 +29,19 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 '''Examples of extracting basic statistics'''
+import collections
 import argparse
 import json
 import logging
 import os
 import sys
 
-from itertools import chain
+from functools import partial
 import numpy as np
 
+from neurom.stats import scalar_stats
 from neurom.core.types import NEURITES
-from neurom.ezy import load_neuron, load_population
+from neurom.ezy import load_neuron, load_neurons
 from neurom.io.utils import get_morph_files
 
 L = logging.getLogger(__name__)
@@ -50,17 +52,13 @@ NEURITE_STATS = [
     'get_segment_lengths',
     'get_local_bifurcation_angles',
     'get_remote_bifurcation_angles',
-    'get_n_sections_per_neurite'
-]
-
-
-NEURITE_STATS_INT = [
+    'get_n_sections_per_neurite',
     'get_n_sections',
     'get_n_neurites'
 ]
 
 
-SCALAR_STATS = [
+NEURON_STATS = [
     'get_soma_radius',
     'get_soma_surface_area',
 ]
@@ -78,90 +76,78 @@ def parse_args():
     parser.add_argument('-v', '--verbose', action='count', dest='verbose', default=0,
                         help='-v for INFO, -vv for DEBUG')
 
-    parser.add_argument('--dir_as_pop',
+    parser.add_argument('--as-population',
                         action='store_true',
                         default=False,
                         help='If more than one directories are specified in the \
                               datapaths and this flag is enabled the cells in each dir\
                               will be treated as a population')
+
+    parser.add_argument('--single-group',
+                        action='store_true',
+                        default=False,
+                        help='If more than one directories are specified in the \
+                              datapaths, as-population is enabled, then all the \
+                              directories will be treated as a single population')
+
     return parser.parse_args()
 
 
-def calculate_stats(values):
-    '''Calculate basic stats
+def _flatten_array(l):
+    '''Flattens an array of any depth.
     '''
-    # check if array is empty
-    if len(values) > 0:
-        stats = {
-            'mean': np.mean(values),
-            'std': np.std(values),
-            'min': np.min(values),
-            'max': np.max(values),
-        }
+    if isinstance(l, collections.Iterable):
+        for el in l:
+            if isinstance(el, collections.Iterable) and not isinstance(el, basestring):
+                for sub in _flatten_array(el):
+                    yield sub
+            else:
+                yield el
     else:
-        stats = {
-            'mean': 0.,
-            'std': 0.,
-            'min': 0.,
-            'max': 0.,
-        }
+        yield l
+
+
+def pfunc(ns, n=None):
+    ''' Partially fills the arguments of the function that is applied on
+    neurons
+    '''
+    if n is None:
+        return partial(lambda x, ns: getattr(x, ns)(), ns=ns)
+    else:
+        return partial(lambda x, ns, n: getattr(x, ns)(n), ns=ns, n=n)
+
+
+def eval_stats(func, neurons):
+    ''' Apply the input function on the neuron objects, flatten the array if nested,
+    make it a single element array if the result is not iterable and extract the stats
+    '''
+
+    value = np.fromiter(_flatten_array(func(nrn) for nrn in neurons), np.float)
+
+    stat_functions = ('min', 'max', 'median', 'mean', 'std')
+    try:
+        value = scalar_stats(value)
+    except ValueError:
+        value = {key: 0. for key in stat_functions}
+
+    return value
+
+
+def extract_stats(neurons):
+    '''Extract stats from neurons'''
+
+    stats = {}
+    for ns in NEURITE_STATS:
+        stat_name = ns[4:]
+        stats[stat_name] = {}
+        for n in NEURITES:
+            stats[stat_name][n.name] = eval_stats(pfunc(ns, n), neurons)
+            L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(stats[stat_name][n.name]))
+
+    for ns in NEURON_STATS:
+        stats[ns[4:]] = eval_stats(pfunc(ns), neurons)
+
     return stats
-
-
-def extract_neurons_stats(files):
-    '''Extract stats from files'''
-    results = {}
-    for _f in files:
-        nrn = load_neuron(_f)
-        stats = results[_f] = {}
-        for ns in NEURITE_STATS + NEURITE_STATS_INT:
-            stat_name = ns[4:]
-            stats[stat_name] = {}
-            for n in NEURITES:
-                value = getattr(nrn, ns)(n)
-                L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
-                if isinstance(value, np.ndarray):
-                    value = calculate_stats(value)
-                stats[stat_name][n.name] = value
-
-        for ns in SCALAR_STATS:
-            stats[ns[4:]] = getattr(nrn, ns)()
-    return results
-
-
-def extract_populations_stats(files):
-    '''Extract stats from directories treated as populations'''
-    results = {}
-
-    for _f in files:
-        pop = load_population(_f)
-        stats = results[_f] = {}
-        for ns in NEURITE_STATS:
-            stat_name = ns[4:]
-            stats[stat_name] = {}
-            for n in NEURITES:
-                value = np.fromiter(chain.from_iterable(getattr(nrn, ns)(n) for nrn in pop.neurons),
-                                    np.float)
-                L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
-                value = calculate_stats(value)
-                stats[stat_name][n.name] = value
-
-        for ns in NEURITE_STATS_INT:
-            stat_name = ns[4:]
-            stats[stat_name] = {}
-            for n in NEURITES:
-                value = np.array([getattr(nrn, ns)(n) for nrn in pop.neurons])
-                L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
-                value = calculate_stats(value)
-                stats[stat_name][n.name] = value
-
-        for ns in SCALAR_STATS:
-            value = np.array([getattr(nrn, ns)() for nrn in pop.neurons])
-            L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(value))
-            value = calculate_stats(value)
-            stats[stat_name][n.name] = value
-
-    return results
 
 
 if __name__ == '__main__':
@@ -172,24 +158,27 @@ if __name__ == '__main__':
 
     data_paths = args.datapaths
 
-    # treat a directory as a population
-    if args.dir_as_pop:
+    _results = {}
 
-        _stats = extract_populations_stats(data_paths)
+    for _path in data_paths:
 
-    # otherwise concatenate all the found files
-    else:
+        # if the path is not a directory then parse it as a single neuron
+        if os.path.isfile(_path):
 
-        _files = []
-        for data_path in data_paths:
+            _results[_path] = extract_stats((load_neuron(_path),))
 
-            if os.path.isfile(data_path):
-                _files.append(data_path)
-            elif os.path.isdir(data_path):
-                _files.extend(get_morph_files(data_path))
+        elif os.path.isdir(_path):
+
+            # treat the directory as a single population
+            if args.as_population:
+                _results[_path] = extract_stats(load_neurons(_path))
+
+            # otherwise process each neuron file separately
             else:
-                L.error('Invalid data path %s', data_path)
-                sys.exit(1)
-        _stats = extract_neurons_stats(_files)
+                for _f in get_morph_files(_path):
+                    _results[_f] = extract_stats((load_neuron(_f),))
+        else:
+            L.error('Invalid data path %s', _path)
+            sys.exit(1)
 
-    print json.dumps(_stats, indent=2, separators=(',', ':'))
+    print json.dumps(_results, indent=2, separators=(',', ':'))

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -71,7 +71,7 @@ def parse_args():
 
     parser.add_argument('datapaths',
                         nargs='+',
-                        help='Paths to morphology data files or directories')
+                        help='Path to a morphology data file or a directory')
 
     parser.add_argument('-v', '--verbose', action='count', dest='verbose', default=0,
                         help='-v for INFO, -vv for DEBUG')

--- a/examples/features_graph_table.py
+++ b/examples/features_graph_table.py
@@ -31,6 +31,34 @@
 '''
 import pylab as pl
 from itertools import product
+import sys
+import argparse
+
+
+def parse_args():
+    '''Parse command line arguments'''
+    parser = argparse.ArgumentParser(description='Feature Comparison Between Different Cells')
+
+    parser.add_argument('-d',
+                        '--datapath',
+                        help='Data directory')
+
+    parser.add_argument('-c',
+                        '--collapsible',
+                        action='store_true',
+                        default=False)
+
+    parser.add_argument('-o',
+                        '--odir',
+                        default='.',
+                        help='Output path')
+
+    parser.add_argument('-f',
+                        '--features',
+                        nargs='+',
+                        help='List features separated by spaces')
+
+    return parser.parse_args()
 
 
 def _stylize(ax, cell, feature, row, col):
@@ -90,7 +118,7 @@ def plot_feature_comparison(features, cells, function=histogram, collapsible=Fal
     Nf = len(features)
     Nc = len(cells) if not collapsible else 1
 
-    _, axes = pl.subplots(nrows=Nf, ncols=Nc, squeeze=False)
+    f, axes = pl.subplots(nrows=Nf, ncols=Nc, squeeze=False)
 
     for i, j in product(range(Nf), range(Nc)):
 
@@ -105,15 +133,20 @@ def plot_feature_comparison(features, cells, function=histogram, collapsible=Fal
         if collapsible:
             ax.legend(loc='best', fontsize='small')
 
+    return f
 
 if __name__ == '__main__':
     from neurom.ezy import load_neurons
 
-    nrns = load_neurons('test_data/valid_set')
+    args = parse_args()
 
-    FEATURES = ['segment_lengths', 'section_lengths',
-                'section_radial_distances', 'local_bifurcation_angles']
+    try:
+        nrns = load_neurons(args.datapath)
+    except OSError:
+        print "path not existing: {0}".format(args.datapath)
+        sys.exit()
 
-    plot_feature_comparison(FEATURES, nrns, histogram, collapsible=True)
+    fig = plot_feature_comparison(args.features, nrns, histogram, collapsible=args.collapsible)
 
+    fig.savefig('output.png')
     pl.show()

--- a/neurom/stats.py
+++ b/neurom/stats.py
@@ -33,6 +33,7 @@ Nothing fancy. Just commonly used functions using scipy functionality.'''
 from collections import namedtuple
 from collections import OrderedDict
 from scipy import stats as _st
+import numpy as np
 
 
 FitResults = namedtuple('FitResults', ['params', 'errs', 'type'])
@@ -110,3 +111,24 @@ def optimal_distribution(data, distr_to_check=('norm', 'expon', 'uniform')):
     '''
     fit_results = [fit(data, d) for d in distr_to_check]
     return min(fit_results, key=lambda fit: fit.errs[0])
+
+
+def scalar_stats(data, functions=('min', 'max', 'mean', 'std')):
+    '''Calculate the stats from the given numpy functions
+
+    Parameters:
+        data: array of data points to be used for the stats
+
+    Options:
+        functions: tuple of numpy stat functions to apply on data
+
+    Returns:
+        Dictionary with tha name of the function as key and the result
+        as the respective value
+    '''
+    stats = {}
+    for func in functions:
+
+        stats[func] = getattr(np, func)(data)
+
+    return stats

--- a/neurom/tests/test_stats.py
+++ b/neurom/tests/test_stats.py
@@ -140,3 +140,16 @@ def test_fit_results_dict_exponential_min_max():
     nt.assert_equal(d['min'], -100)
     nt.assert_equal(d['max'], 100)
     nt.assert_equal(d['type'], 'exponential')
+
+def test_scalar_stats():
+
+    data = np.array([1.,2.,3.,4.,5.])
+
+    result = st.scalar_stats(data)
+
+    RESULT = {'mean': 3.,
+              'max': 5.,
+              'min': 1.,
+              'std': 1.4142135623730951}
+
+    nt.assert_true(RESULT == result)


### PR DESCRIPTION
Multiple directories can be provided as args in morph_stats. if --dir_as_pop is enabled then each directory is treated as a population and the stats are extracted population-wise.

Otherwise, a list with all the filenames in all directories is created and the stats that are extracted are neuron-wise.