### PR TITLE
Remove unused iterator functions from analysis.morphtree

### DIFF
--- a/examples/meander_angles.py
+++ b/examples/meander_angles.py
@@ -33,7 +33,8 @@ import numpy as np
 from neurom.core.dataformat import COLS
 from neurom.io.readers import load_data
 from neurom.io.utils import make_neuron
-from neurom.analysis.morphtree import i_segment_meander_angle
+from neurom import triplets as trip
+from neurom import iter_neurites
 
 
 # root level logger. This would be a top level application logger.
@@ -52,7 +53,7 @@ if __name__ == '__main__':
 
     for tt in nrn.neurites:
         print 'Tree ID: {0}, type: {1}'.format(tt.value[COLS.ID], tt.value[COLS.TYPE])
-        for a in i_segment_meander_angle(tt):
+        for a in iter_neurites(tt, trip.meander_angle):
             LOG.debug('Angle %f', a)
             if np.isnan(a):
                 LOG.warn('Found NaN angle. Check for zero length segments!')

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -31,7 +31,7 @@
 These functions all depend on the internal structure of the tree or its
 different iteration modes.
 '''
-from itertools import imap, izip, product
+from itertools import izip, product
 from neurom.core import tree as tr
 from neurom.core.types import TreeType
 from neurom.core.tree import ipreorder
@@ -70,76 +70,6 @@ def branch_order(tree_section):
     return bo - 2 if tr.is_forking_point(node) else bo - 1
 
 
-def i_segment_length(tree):
-    ''' return an iterator of tree segment lengths
-    '''
-    return tr.imap_val(mm.segment_length, tr.isegment(tree))
-
-
-def i_segment_radius(tree):
-    ''' return an iterator of tree segment radii
-    '''
-    return tr.imap_val(mm.segment_radius, tr.isegment(tree))
-
-
-def i_segment_volume(tree):
-    ''' return an iterator of tree segment volumes
-    '''
-    return tr.imap_val(mm.segment_volume, tr.isegment(tree))
-
-
-def i_segment_area(tree):
-    ''' return an iterator of tree segment areas
-    '''
-    return tr.imap_val(mm.segment_area, tr.isegment(tree))
-
-
-def i_segment_radial_dist(pos, tree):
-    '''Return an iterator of radial distances of tree segments to a given point
-
-    The radial distance is the euclidian distance between the mid-point of
-    the segment and the point in question.
-
-    Parameters:
-        pos: origin to which disrances are measured. It must have at least 3
-        components. The first 3 components are (x, y, z).
-
-        tree: tree of raw data rows.
-
-    '''
-    return tr.imap_val(lambda s: mm.segment_radial_dist(s, pos), tr.isegment(tree))
-
-
-def i_segment_meander_angle(tree):
-    '''Return an iterator to a tree meander angle
-
-    The meander angle is defined as the angle between to adjacent  segments.
-    Applies neurom.morphmath.angle_3points to triplets of
-    '''
-
-    return tr.imap_val(lambda t: mm.angle_3points(t[1], t[0], t[2]), tr.itriplet(tree))
-
-
-def i_local_bifurcation_angle(tree):
-    '''Return the opening angle between two out-going segments
-    in a bifurcation point
-    '''
-    return imap(local_bifurcation_angle,
-                tr.ibifurcation_point(tree))
-
-
-def i_remote_bifurcation_angle(tree):
-    '''Return the opening angle between the last segments of two out-going
-    sections of a bifurcation point
-    '''
-    def _remangle(t):
-        '''Helper to calculate the remote angle'''
-        end_points = tuple(p for p in tr.i_branch_end_points(t))
-        return mm.angle_3points(t.value, end_points[0].value, end_points[1].value)
-
-    return imap(_remangle, tr.ibifurcation_point(tree))
-
-
 def i_section_radial_dist(tree, pos=None, use_start_point=False):
     '''Return an iterator of radial distances of tree sections to a given point
 
@@ -159,21 +89,6 @@ def i_section_radial_dist(tree, pos=None, use_start_point=False):
     pos = tree.value if pos is None else pos
     sec_idx = 0 if use_start_point else -1
     return tr.imap_val(lambda s: mm.point_dist(s[sec_idx], pos), tr.isection(tree))
-
-
-def i_section_path_length(tree, use_start_point=False):
-    '''Return an iterator of path lengths of tree sections
-
-    Path lengths are measured to the tree's root.
-
-    Parameters:
-        tree: tree object
-        use_start_point: If true, calculate path length from section start point,\
-            else from end-point (default, False)
-
-    '''
-    sec_idx = 0 if use_start_point else -1
-    return imap(lambda s: path_length(s[sec_idx]), tr.isection(tree))
 
 
 def find_tree_type(tree):
@@ -212,13 +127,6 @@ def get_tree_type(tree):
         set_tree_type(tree)
 
     return tree.type
-
-
-def i_section_length(tree):
-    """
-    Return an iterator of tree section lengths
-    """
-    return tr.imap_val(mm.section_length, tr.isection(tree))
 
 
 def n_sections(tree):
@@ -261,7 +169,8 @@ def trunk_section_length(tree):
         Length of first section of tree or 0 if single point tree
     '''
     try:
-        return i_section_length(tree).next()
+        _it = tr.imap_val(mm.section_length, tr.isection(tree))
+        return _it.next()
     except StopIteration:
         return 0.0
 

--- a/neurom/analysis/tests/test_morphtree.py
+++ b/neurom/analysis/tests/test_morphtree.py
@@ -153,62 +153,6 @@ def _form_branching_tree():
 BRANCHING_TREE = _form_branching_tree()
 
 
-def test_segment_lengths():
-
-    T = NEURON_TREE
-
-    lg = [l for l in mtr.i_segment_length(T)]
-
-    nt.assert_equal(lg, [1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 2.0, 1.0, 1.0])
-
-
-def test_segment_volumes():
-
-    T = NEURON_TREE
-
-    sv = (l/math.pi for l in mtr.i_segment_volume(T))
-
-    ref = (1.0, 1.0, 4.6666667, 4.0, 4.6666667, 0.7708333,
-           0.5625, 4.6666667, 0.7708333, 0.5625)
-
-    for a, b in izip(sv, ref):
-        nt.assert_almost_equal(a, b)
-
-
-def test_segment_areas():
-
-    T = NEURON_TREE
-
-    sa = (l/math.pi for l in mtr.i_segment_area(T))
-
-    ref = (2.0, 2.0, 6.7082039, 4.0, 6.7082039, 1.8038587,
-           1.5, 6.7082039, 1.8038587, 1.5)
-
-    for a, b in izip(sa, ref):
-        nt.assert_almost_equal(a, b)
-
-
-
-def test_segment_radiuss():
-
-    T = NEURON_TREE
-
-    rad = [r for r in mtr.i_segment_radius(T)]
-
-    nt.assert_equal(rad,
-                    [1.0, 1.0, 1.5, 2.0, 1.5, 0.875, 0.75, 1.5, 0.875, 0.75])
-
-
-def test_segment_radial_dists():
-    T = SIMPLE_TREE
-
-    p= [0.0, 0.0, 0.0]
-
-    rd = [d for d in mtr.i_segment_radial_dist(p,T)]
-
-    nt.assert_equal(rd, [1.0, 3.0, 5.0, 7.0, 1.0, 3.0, 5.0, 7.0])
-
-
 def test_segment_path_length():
     leaves = [l for l in tr.ileaf(NEURON_TREE)]
     for l in leaves:
@@ -240,12 +184,6 @@ def test_get_tree_type():
         # tree.type should already exists here, from previous action.
         nt.ok_(mtr.get_tree_type(test_tree) == tree_types[en_tree])
 
-def test_i_section_length():
-    T = SIMPLE_TREE
-    nt.assert_equal([l for l in mtr.i_section_length(T)], [8.0, 8.0])
-    T2 = NEURON_TREE
-    nt.ok_([l for l in mtr.i_section_length(T2)] == [5.0, 4.0, 4.0])
-
 
 def test_i_section_radial_dists():
     T1 = SIMPLE_TREE
@@ -276,56 +214,6 @@ def test_i_section_radial_dists():
 
     nt.assert_equal([d for d in mtr.i_section_radial_dist(T2, p0, use_start_point=True)],
                     [0.0, 5.0, 5.0])
-
-
-def test_i_section_path_length():
-    T1 = SIMPLE_TREE
-    T2 = NEURON_TREE
-
-    nt.assert_equal([d for d in mtr.i_section_path_length(T1)],
-                    [8.0, 8.0])
-
-    nt.assert_equal([d for d in mtr.i_section_path_length(T1, use_start_point=True)],
-                    [0.0, 0.0])
-
-    nt.assert_equal([d for d in mtr.i_section_path_length(T2)], [5.0, 9.0, 9.0])
-
-    nt.assert_equal([d for d in mtr.i_section_path_length(T2, use_start_point=True)],
-                    [0.0, 5.0, 5.0])
-
-
-def test_i_segment_meander_angles():
-    T = NEURON_TREE
-    ref = [math.pi * a for a in (1.0, 1.0, 1.0, 0.5, 0.5, 1.0, 1.0, 1.0, 0.5)]
-    for i, m in enumerate(mtr.i_segment_meander_angle(T)):
-        nt.assert_almost_equal(m, ref[i])
-
-
-def test_i_local_bifurcation_angles():
-    T = BRANCHING_TREE
-    ref = (0.25, 0.5, 0.25)  # ref angles in pi radians
-    for i, b in enumerate(mtr.i_local_bifurcation_angle(T)):
-        nt.assert_almost_equal(b / math.pi, ref[i])
-
-
-def test_i_remote_bifurcation_angles():
-    T = BRANCHING_TREE
-
-    # (fork point, end point, end point) tuples calculated by hand
-    # from BRANCHING_TREE
-    refs = (((0, 4, 0), (0, 5, 0), (15, 15, 0)),
-            ((0, 5, 0), (4, 5, 0), (0, 5, 3)),
-            ((0, 5, 3), (0, 6, 3), (0, 6, 4)))
-
-    ref_angles = tuple(angle_3points(p[0], p[1], p[2]) / math.pi for p in refs)
-    ref = (0.2985898, 0.5, 0.25)  # ref angles in pi radians
-    # sanity check
-    for i, b in enumerate(ref_angles):
-        nt.assert_almost_equal(b, ref[i])
-
-    for i, b in enumerate(mtr.i_remote_bifurcation_angle(T)):
-        nt.assert_almost_equal(b / math.pi, ref_angles[i])
-        nt.assert_almost_equal(b / math.pi, ref[i])
 
 
 def test_n_sections():

--- a/neurom/ezy/neuron.py
+++ b/neurom/ezy/neuron.py
@@ -209,7 +209,7 @@ class Neuron(CoreNeuron):
 
         Parameters:
             iterator_type: Type of iterator with which to perform the iteration.\
-            (e.g. isegment, isection, i_section_path_length)
+            (e.g. isegment, isection)
             mapping: mapping function to be applied to the target of iteration.\
             (e.g. segment_length). Must be compatible with the iterator_type.
             neurite_type: TreeType object. Neurites of incompatible type are\
@@ -248,7 +248,7 @@ class Neuron(CoreNeuron):
 
         Parameters:
             iterator_type: Type of iterator with which to perform the iteration.
-            (e.g. isegment, isection, i_section_path_length)
+            (e.g. isegment, isection)
             mapping: mapping function to be applied to the target of iteration.
             (e.g. segment_length). Must be compatible with the iterator_type.
             neurite_type: TreeType object. Neurites of incompatible type are

--- a/neurom/view/view.py
+++ b/neurom/view/view.py
@@ -38,9 +38,10 @@ import numpy as np
 from neurom.core.tree import isegment
 from neurom.core.tree import val_iter
 from neurom.io.readers import COLS
+from neurom.segments import radius as segment_radius
+from neurom import iter_neurites
 from neurom.analysis.morphtree import get_bounding_box
 from neurom.analysis.morphtree import get_tree_type
-from neurom.analysis.morphtree import i_segment_radius
 
 
 def get_default(variable, **kwargs):
@@ -146,7 +147,7 @@ def tree(tr, plane='xy', new_fig=True, subplot=False, **kwargs):
     if get_default('diameter', **kwargs):
         scale = get_default('diameter_scale', **kwargs)
         # TODO: This was originally a numpy array. Did it have to be one?
-        linewidth = [2 * d * scale for d in i_segment_radius(tr)]
+        linewidth = [2 * d * scale for d in iter_neurites(tr, segment_radius)]
         if len(linewidth) == 0:
             linewidth = get_default('linewidth', **kwargs)
 
@@ -433,7 +434,8 @@ def tree3d(tr, new_fig=True, new_axes=True, subplot=False, **kwargs):
     # Definition of the linewidth according to diameter, if diameter is True.
     if get_default('diameter', **kwargs):
         # TODO: This was originally a numpy array. Did it have to be one?
-        linewidth = [2 * d * get_default('diameter_scale', **kwargs) for d in i_segment_radius(tr)]
+        linewidth = [2 * d * get_default('diameter_scale', **kwargs)
+                     for d in iter_neurites(tr, segment_radius)]
         if len(linewidth) == 0:
             linewidth = get_default('linewidth', **kwargs)
 


### PR DESCRIPTION
Remove neurom.analysis.morphtree map iterator functions whose
functionality has been re-factored into generalized iterations.