### PR TITLE
updated tree_type_checker to allow multiple types

### DIFF
--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -56,7 +56,9 @@ def tree_type_checker(*ref):
     '''
     ref = tuple(ref)
     if TreeType.all in ref:
-        check_tree_type = lambda _: True
+        def check_tree_type(_):
+            '''Always returns true'''
+            return True
     else:
         def check_tree_type(tree):
             '''Check whether tree has the same type as ref


### PR DESCRIPTION
* can now do 'tree_type_checker(TreeType.axon, TreeType.basal_dendrite)'
* sped up the TreeType.all path in the functor
* added tests