### PR TITLE
used deque instead of list in ipreorder

### DIFF
--- a/neurom/core/tree.py
+++ b/neurom/core/tree.py
@@ -28,6 +28,7 @@
 
 '''Generic tree class and iteration functions'''
 from itertools import chain, imap, ifilter, repeat
+from collections import deque
 from copy import copy
 
 
@@ -77,7 +78,7 @@ def is_root(tree):
 
 def ipreorder(tree):
     '''Depth-first pre-order iteration of tree nodes'''
-    children = [tree, ]
+    children = deque((tree, ))
     while children:
         cur_node = children.pop()
         children.extend(reversed(cur_node.children))


### PR DESCRIPTION
I used the deque data structure in the ```ipreorder``` function. Deques are faster than lists in pop and extend operations, which is reflected in the 3x speedup when the former are used.

```python
from neurom.ezy import load_neuron
from neurom.core.tree import ipreorder
n = load_neuron('test_data/valid_set/Neuron.swc').neurites[0]
%timeit tuple(ipreorder(n))
```
Normally, this operation would need:
```
1000 loops, best of 3: 334 µs per loop
```
If ```chlidren=[tree, ]``` is substituted by ```children=deque((tree,))``` then we can achieve the aforementioned speedup:

```
10000 loops, best of 3: 125 µs per loop
```

And for a bigger cell ([C030796A-P3.h5.zip](https://github.com/BlueBrain/NeuroM/files/129909/C030796A-P3.h5.zip))

Before:
```
100 loops, best of 3: 3.25 ms per loop
```
After:
```
1000 loops, best of 3: 1.26 ms per loop
```