### PR TITLE
refactor: move raw data block parsing out of load_data

### DIFF
--- a/neurom/io/__init__.py
+++ b/neurom/io/__init__.py
@@ -28,5 +28,5 @@
 
 ''' IO operations module for NeuroM '''
 
-from .readers import load_data
+from .readers import load_data, unpack_raw_data
 from . import check

--- a/neurom/io/__init__.py
+++ b/neurom/io/__init__.py
@@ -28,5 +28,5 @@
 
 ''' IO operations module for NeuroM '''
 
-from .readers import load_data, unpack_raw_data
+from .readers import load_data
 from . import check

--- a/neurom/io/readers.py
+++ b/neurom/io/readers.py
@@ -51,6 +51,45 @@ from neurom.core.dataformat import ROOT_ID
 from neurom.utils import memoize
 
 
+def unpack_raw_data(filename):
+    '''Parse a morphology file into internal representation data block
+
+    Forwards filename to appropriate parser depending on extension.
+
+    Parameters:
+        filename: path to morphology file
+
+    Returns:
+        tuple of (raw data block, input file format string).
+    '''
+
+    @memoize
+    def _h5_reader():
+        '''Lazy loading of HDF5 reader'''
+        from .hdf5 import H5
+        return H5.read
+
+    @memoize
+    def _swc_reader():
+        '''Lazy loading of SWC reader'''
+        from .swc import SWC
+        return SWC.read
+
+    @memoize
+    def _neurolucida_reader():
+        '''Lazy loading of Neurolucida ASCII reader'''
+        from .neurolucida import NeurolucidaASC
+        return NeurolucidaASC.read
+
+    _READERS = {
+        'swc': _swc_reader,
+        'h5': _h5_reader,
+        'asc': _neurolucida_reader,
+    }
+    extension = os.path.splitext(filename)[1][1:]
+    return _READERS[extension.lower()]()(filename)
+
+
 def load_data(filename):
     '''Unpack filename and return a RawDataWrapper object containing the data
 
@@ -61,36 +100,8 @@ def load_data(filename):
           determine the version from the contents of the file
         * Neurolucida ASCII (case-insensitive extension ".asc")
     '''
-    def unpack_data():
-        '''Read an file and return a tuple of data, offset, format.
-        Forwards filename to appropriate reader depending on extension'''
-        @memoize
-        def _h5_reader():
-            '''Lazy loading of HDF5 reader'''
-            from .hdf5 import H5
-            return H5.read
 
-        @memoize
-        def _swc_reader():
-            '''Lazy loading of SWC reader'''
-            from .swc import SWC
-            return SWC.read
-
-        @memoize
-        def _neurolucida_reader():
-            '''Lazy loading of Neurolucida ASCII reader'''
-            from .neurolucida import NeurolucidaASC
-            return NeurolucidaASC.read
-
-        _READERS = {
-            'swc': _swc_reader,
-            'h5': _h5_reader,
-            'asc': _neurolucida_reader,
-        }
-        extension = os.path.splitext(filename)[1][1:]
-        return _READERS[extension.lower()]()(filename)
-
-    return RawDataWrapper(unpack_data())
+    return RawDataWrapper(unpack_raw_data(filename))
 
 
 class RawDataWrapper(object):

--- a/neurom/io/readers.py
+++ b/neurom/io/readers.py
@@ -51,7 +51,7 @@ from neurom.core.dataformat import ROOT_ID
 from neurom.utils import memoize
 
 
-def unpack_raw_data(filename):
+def _unpack_raw_data(filename):
     '''Parse a morphology file into internal representation data block
 
     Forwards filename to appropriate parser depending on extension.
@@ -101,7 +101,7 @@ def load_data(filename):
         * Neurolucida ASCII (case-insensitive extension ".asc")
     '''
 
-    return RawDataWrapper(unpack_raw_data(filename))
+    return RawDataWrapper(_unpack_raw_data(filename))
 
 
 class RawDataWrapper(object):


### PR DESCRIPTION
neurom.io.readers._unpack_raw_data(filename) parses input and produces a 2D
array with internal representation of neuron morphology. This
functionality is an implementation detail of
neurom.io.load_data, but it can be useful for debugging purposes.

Note: if and when the internal data structure is formalized and specified, this could be made public.