### PR TITLE
A zigzagging check for morphologies

### DIFF
--- a/neurom/analysis/morphmath.py
+++ b/neurom/analysis/morphmath.py
@@ -47,6 +47,45 @@ def vector(p1, p2):
     return np.subtract(p1[0:3], p2[0:3])
 
 
+def scalar_projection(v1, v2):
+    '''compute the scalar projection of v1 upon v2
+
+    Args:
+        v1, v2: iterable
+        indices 0, 1, 2 corresponding to cartesian coordinates
+
+    Returns:
+        3-vector of the projection of point p onto the direction of v
+    '''
+    return np.dot(v1, v2) / np.linalg.norm(v2)
+
+
+def vector_projection(v1, v2):
+    '''compute the vector projection of v1 upon v2
+
+    Args:
+        v1, v2: iterable
+        indices 0, 1, 2 corresponding to cartesian coordinates
+
+    Returns:
+        3-vector of the projection of point p onto the direction of v
+    '''
+    return scalar_projection(v1, v2) * v2 / np.linalg.norm(v2)
+
+
+def dist_point_line(p, l1, l2):
+    '''compute the orthogonal distance between from the line that goes through
+    the points l1, l2 and the point p
+
+    Args:
+        p, l1, l2 : iterable
+        point
+        indices 0, 1, 2 corresponding to cartesian coordinates
+    '''
+    cross_prod = np.cross(l2 - l1, p - l1)
+    return np.linalg.norm(cross_prod) / np.linalg.norm(l2 - l1)
+
+
 def point_dist2(p1, p2):
     '''compute the square of the euclidian distance between two 3D points
 

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -47,21 +47,54 @@ def test_vector():
 
 
 def test_scalar_projection():
-
-    v1 = np.array([4., 1.])
-    v2 = np.array([2., 3.])
+    v1 = np.array([4., 1., 0.])
+    v2 = np.array([2., 3., 0.])
 
     res = mm.scalar_projection(v1, v2)
     nt.assert_true(np.isclose(res, 3.0508510792387602))
 
 
-def test_vector_projection():
+def test_scalar_projection_collinear():
+    v1 = np.array([1., 2., 0.])
+    v2 = np.array([4., 6., 0.])
 
-    v1 = np.array([4., 1.])
-    v2 = np.array([2., 3.])
+    res = mm.scalar_projection(v1, v2)
+
+    nt.assert_true(np.allclose(res, 16./np.linalg.norm(v2)))
+
+
+def test_scalar_projection_perpendicular():
+    v1 = np.array([3., 0., 0.])
+    v2 = np.array([0., 1.5, 0.])
+
+    res = mm.scalar_projection(v1, v2)
+    nt.assert_true(np.allclose(res, 0.))
+
+
+def test_vector_projection():
+    v1 = np.array([4., 1., 0.])
+    v2 = np.array([2., 3., 0.])
 
     res = mm.vector_projection(v1, v2)
-    nt.assert_true(np.allclose(res, np.array([1.6923076923076923, 2.5384615384615383])))
+    nt.assert_true(np.allclose(res, (1.6923076923076923, 2.5384615384615383, 0.)))
+
+
+def test_vector_projection_collinear():
+
+    v1 = np.array([1., 2., 3.])
+    v2 = np.array([4., 8., 6.])
+
+    res = mm.vector_projection(v1, v2)
+    nt.assert_true(np.allclose(res, (38./29., 76./29., 57./29.)))
+
+
+def test_vector_projection_perpendicular():
+
+    v1 = np.array([2., 0., 0.])
+    v2 = np.array([0., 3., 0.])
+
+    res = mm.vector_projection(v1, v2)
+    nt.assert_true(np.allclose(res, (0.,0.,0.)))
 
 
 def test_dist_point_line():

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -28,22 +28,7 @@
 
 from nose import tools as nt
 from neurom.core.point import Point
-from neurom.analysis.morphmath import point_dist
-from neurom.analysis.morphmath import point_dist2
-from neurom.analysis.morphmath import vector
-from neurom.analysis.morphmath import angle_3points
-from neurom.analysis.morphmath import polygon_diameter
-from neurom.analysis.morphmath import average_points_dist
-from neurom.analysis.morphmath import path_distance
-from neurom.analysis.morphmath import segment_length
-from neurom.analysis.morphmath import segment_radius
-from neurom.analysis.morphmath import segment_volume
-from neurom.analysis.morphmath import segment_area
-from neurom.analysis.morphmath import segment_radial_dist
-from neurom.analysis.morphmath import taper_rate
-from neurom.analysis.morphmath import segment_taper_rate
-from neurom.analysis.morphmath import pca
-from neurom.analysis.morphmath import sphere_area
+from neurom.analysis import morphmath as mm
 from math import sqrt, pi, fabs
 
 from numpy.random import uniform
@@ -57,21 +42,57 @@ np.random.seed(0)
 def test_vector():
     vec1 = (12.0, 3, 6.0)
     vec2 = (14.0, 1.0, 6.0)
-    vec = vector(vec1,vec2)
+    vec = mm.vector(vec1,vec2)
     nt.ok_(np.all(vec ==(-2.0, 2.0, 0.0)))
+
+
+def test_scalar_projection():
+
+    v1 = np.array([4., 1.])
+    v2 = np.array([2., 3.])
+
+    res = mm.scalar_projection(v1, v2)
+    nt.assert_true(np.isclose(res, 3.0508510792387602))
+
+
+def test_vector_projection():
+
+    v1 = np.array([4., 1.])
+    v2 = np.array([2., 3.])
+
+    res = mm.vector_projection(v1, v2)
+    nt.assert_true(np.allclose(res, np.array([1.6923076923076923, 2.5384615384615383])))
+
+
+def test_dist_point_line():
+
+    # an easy one:
+    res = mm.dist_point_line(np.array([0., 0., 0.]), np.array([0., 1., 0.]), np.array([1., 0., 0.]))
+    nt.assert_true(np.isclose(res, np.sqrt(2) / 2.))
+
+    # check the distance of the line 3x - 4y + 1 = 0
+    # with parametric form of (t, (4t - 1)/3)
+    # two points that satisfy this equation:
+    l1 = np.array([0., 1./4., 0.])
+    l2 = np.array([1., 1., 0.])
+
+    p = np.array([2. , 3., 0.])
+
+    res = mm.dist_point_line(p, l1, l2)
+    nt.assert_equal(res, 1.)
 
 
 def test_point_dist2():
     p1 = Point(3.0, 4.0, 5.0, 3.0, 1)
     p2 = Point(4.0, 5.0, 6.0, 3.0, 1)
-    dist = point_dist2(p1, p2)
+    dist = mm.point_dist2(p1, p2)
     nt.ok_(dist==3)
 
 
 def test_point_dist():
     p1 = Point(3.0, 4.0, 5.0, 3.0, 1)
     p2 = Point(4.0, 5.0, 6.0, 3.0, 1)
-    dist = point_dist(p1,p2)
+    dist = mm.point_dist(p1,p2)
     nt.ok_(dist==sqrt(3))
 
 
@@ -79,61 +100,61 @@ def test_angle_3points_half_pi():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (0.0, 2.0, 0.0)
-    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
+    nt.eq_(mm.angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec2 = (0.0, 0.0, 3.0)
-    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
+    nt.eq_(mm.angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec2 = (0.0, 0.0, -3.0)
-    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
+    nt.eq_(mm.angle_3points(orig, vec1, vec2), pi / 2.0)
 
     vec1 = (0.0, 4.0, 0.0)
-    nt.eq_(angle_3points(orig, vec1, vec2), pi / 2.0)
+    nt.eq_(mm.angle_3points(orig, vec1, vec2), pi / 2.0)
 
 
 def test_angle_3points_quarter_pi():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (2.0, 2.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), pi / 4.0)
 
     vec2 = (3.0, 3.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), pi / 4.0)
 
     vec2 = (3.0, -3.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), pi / 4.0)
 
     vec2 = (3.0, 0.0, 3.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), pi / 4.0)
 
     vec2 = (3.0, 0.0, -3.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), pi / 4.0)
 
 
 def test_angle_3points_three_quarter_pi():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (-2.0, 2.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
 
     vec2 = (-3.0, 3.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), 3* pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), 3* pi / 4.0)
 
     vec2 = (-3.0, -3.0, 0.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
 
     vec2 = (-3.0, 0.0, 3.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
 
     vec2 = (-3.0, 0.0, -3.0)
-    nt.assert_equal(angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
+    nt.assert_equal(mm.angle_3points(orig, vec1, vec2), 3 * pi / 4.0)
 
 
 def test_angle_3points_equal_points_returns_zero():
     orig = (0.0, 1.0, 0.0)
     vec1 = (1.0, 0.0, 0.0)
     vec2 = (0.0, 1.0, 0.0)
-    a = angle_3points(orig, vec1, vec2)
+    a = mm.angle_3points(orig, vec1, vec2)
     nt.assert_equal(a, 0.0)
 
 
@@ -141,7 +162,7 @@ def test_angle_3points_opposing_returns_pi():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 1.0, 1.0)
     vec2 = (-2.0, -2.0, -2.0)
-    angle=angle_3points(orig, vec1, vec2)
+    angle=mm.angle_3points(orig, vec1, vec2)
     nt.assert_equal(angle, pi)
 
 
@@ -149,7 +170,7 @@ def test_angle_3points_collinear_returns_zero():
     orig = (0.0, 0.0, 0.0)
     vec1 = (1.0, 1.0, 1.0)
     vec2 = (2.0, 2.0, 2.0)
-    angle=angle_3points(orig, vec1, vec2)
+    angle=mm.angle_3points(orig, vec1, vec2)
     nt.assert_equal(angle, 0.0)
 
 
@@ -168,10 +189,10 @@ def test_polygon_diameter():
     p1 = Point(3.0, 4.0, 5.0, 3.0, 1)
     p2 = Point(3.0, 5.0, 5.0, 3.0, 1)
     p3 = Point(3.0, 6.0, 5.0, 3.0, 1)
-    dia= polygon_diameter([p1,p2,p3])
+    dia= mm.polygon_diameter([p1,p2,p3])
     nt.ok_(dia==2.0)
     surfpoint= soma_points()
-    dia1 = polygon_diameter(surfpoint)
+    dia1 = mm.polygon_diameter(surfpoint)
     nt.ok_(fabs(dia1-10.0) < 0.1)
 
 
@@ -180,7 +201,7 @@ def test_average_points_dist():
     p1 = Point(0.0, 0.0, 1.0, 3.0, 1)
     p2 = Point(0.0, 1.0, 0.0, 3.0, 1)
     p3 = Point(1.0, 0.0, 0.0, 3.0, 1)
-    av_dist = average_points_dist(p0, [p1, p2, p3])
+    av_dist = mm.average_points_dist(p0, [p1, p2, p3])
     nt.ok_(av_dist == 1.0)
 
 def test_path_distance():
@@ -189,7 +210,7 @@ def test_path_distance():
     p3 = Point(3.0, 6.0, 5.0, 3.0, 1)
     p4 = Point(3.0, 7.0, 5.0, 3.0, 1)
     p5 = Point(3.0, 8.0, 5.0, 3.0, 1)
-    dist = path_distance([p1, p2, p3, p4, p5])
+    dist = mm.path_distance([p1, p2, p3, p4, p5])
     nt.ok_(dist == 4)
 
 
@@ -201,18 +222,18 @@ def test_segment_area():
     p4 = Point(1.0, 0.0, 0.0, 3.0, 1)
     p5 = Point(4.0, 0.0, 0.0, 3.0, 1)
 
-    a01 = segment_area((p0, p1))
-    a02 = segment_area((p0, p2))
-    a03 = segment_area((p0, p3))
-    a04 = segment_area((p0, p4))
-    a45 = segment_area((p4, p5))
-    a05 = segment_area((p0, p5))
+    a01 = mm.segment_area((p0, p1))
+    a02 = mm.segment_area((p0, p2))
+    a03 = mm.segment_area((p0, p3))
+    a04 = mm.segment_area((p0, p4))
+    a45 = mm.segment_area((p4, p5))
+    a05 = mm.segment_area((p0, p5))
 
     nt.assert_almost_equal(a01, 37.6991118, places=6)
     nt.assert_almost_equal(2*a01, a02)
     nt.assert_almost_equal(a03, 141.3716694, places=6)
     nt.assert_almost_equal(a45, a05 - a04)
-    nt.assert_almost_equal(segment_area((p0, p3)), segment_area((p3, p0)))
+    nt.assert_almost_equal(mm.segment_area((p0, p3)), mm.segment_area((p3, p0)))
 
 
 def test_segment_volume():
@@ -223,34 +244,34 @@ def test_segment_volume():
     p4 = Point(1.0, 0.0, 0.0, 3.0, 1)
     p5 = Point(4.0, 0.0, 0.0, 3.0, 1)
 
-    v01 = segment_volume((p0, p1))
-    v02 = segment_volume((p0, p2))
-    v03 = segment_volume((p0, p3))
-    v04 = segment_volume((p0, p4))
-    v45 = segment_volume((p4, p5))
-    v05 = segment_volume((p0, p5))
+    v01 = mm.segment_volume((p0, p1))
+    v02 = mm.segment_volume((p0, p2))
+    v03 = mm.segment_volume((p0, p3))
+    v04 = mm.segment_volume((p0, p4))
+    v45 = mm.segment_volume((p4, p5))
+    v05 = mm.segment_volume((p0, p5))
 
     nt.assert_almost_equal(v01, 56.5486677, places=6)
     nt.assert_almost_equal(2*v01, v02)
     nt.assert_almost_equal(v03, 263.8937829, places=6)
     nt.assert_almost_equal(v45, v05 - v04)
-    nt.assert_almost_equal(segment_volume((p0, p3)), segment_volume((p3, p0)))
+    nt.assert_almost_equal(mm.segment_volume((p0, p3)), mm.segment_volume((p3, p0)))
 
 
 def test_segment_length():
-    nt.ok_(segment_length(((0,0,0), (0,0,42))) == 42)
-    nt.ok_(segment_length(((0,0,0), (0,42,0))) == 42)
-    nt.ok_(segment_length(((0,0,0), (42,0,0))) == 42)
+    nt.ok_(mm.segment_length(((0,0,0), (0,0,42))) == 42)
+    nt.ok_(mm.segment_length(((0,0,0), (0,42,0))) == 42)
+    nt.ok_(mm.segment_length(((0,0,0), (42,0,0))) == 42)
 
 
 def test_segment_radius():
-    nt.ok_(segment_radius(((0,0,0,4),(0,0,0,6))) == 5)
+    nt.ok_(mm.segment_radius(((0,0,0,4),(0,0,0,6))) == 5)
 
 
 def test_segment_radial_dist():
     seg = ((11,11,11), (33, 33, 33))
-    nt.assert_almost_equal(segment_radial_dist(seg, (0,0,0)),
-                           point_dist((0,0,0), (22,22,22)))
+    nt.assert_almost_equal(mm.segment_radial_dist(seg, (0,0,0)),
+                           mm.point_dist((0,0,0), (22,22,22)))
 
 
 def test_taper_rate():
@@ -258,9 +279,9 @@ def test_taper_rate():
     p1 = (1.0, 0.0, 0.0, 4.0)
     p2 = (2.0, 0.0, 0.0, 4.0)
     p3 = (3.0, 0.0, 0.0, 4.0)
-    nt.assert_almost_equal(taper_rate(p0, p1), 6.0)
-    nt.assert_almost_equal(taper_rate(p0, p2), 3.0)
-    nt.assert_almost_equal(taper_rate(p0, p3), 2.0)
+    nt.assert_almost_equal(mm.taper_rate(p0, p1), 6.0)
+    nt.assert_almost_equal(mm.taper_rate(p0, p2), 3.0)
+    nt.assert_almost_equal(mm.taper_rate(p0, p3), 2.0)
 
 
 def test_segment_taper_rate():
@@ -268,9 +289,9 @@ def test_segment_taper_rate():
     p1 = (1.0, 0.0, 0.0, 4.0)
     p2 = (2.0, 0.0, 0.0, 4.0)
     p3 = (3.0, 0.0, 0.0, 4.0)
-    nt.assert_almost_equal(segment_taper_rate((p0, p1)), 6.0)
-    nt.assert_almost_equal(segment_taper_rate((p0, p2)), 3.0)
-    nt.assert_almost_equal(segment_taper_rate((p0, p3)), 2.0)
+    nt.assert_almost_equal(mm.segment_taper_rate((p0, p1)), 6.0)
+    nt.assert_almost_equal(mm.segment_taper_rate((p0, p2)), 3.0)
+    nt.assert_almost_equal(mm.segment_taper_rate((p0, p3)), 2.0)
 
 def test_pca():
 
@@ -289,7 +310,7 @@ def test_pca():
                         [ 0.0765238 , -0.16005947,  0.98413672]])
 
     RES_EIGS = np.array([0.0278769, 0.00439387, 0.0001592])
-    eigs, eigv = pca(p)
+    eigs, eigv = mm.pca(p)
 
     nt.assert_true(np.allclose(eigs, RES_EIGS))
     nt.assert_true(np.allclose(eigv[:,0], RES_EIGV[:,0]) or np.allclose(eigv[:, 0], -1. * RES_EIGV[:, 0]))
@@ -297,5 +318,5 @@ def test_pca():
     nt.assert_true(np.allclose(eigv[:,2], RES_EIGV[:,2]) or np.allclose(eigv[:, 2], -1. * RES_EIGV[:, 2]))
 
 def test_sphere_area():
-    area = sphere_area(0.5)
+    area = mm.sphere_area(0.5)
     nt.assert_almost_equal(area, pi)

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -56,11 +56,11 @@ def test_scalar_projection():
 
 def test_scalar_projection_collinear():
     v1 = np.array([1., 2., 0.])
-    v2 = np.array([4., 6., 0.])
+    v2 = np.array([4., 8., 0.])
 
     res = mm.scalar_projection(v1, v2)
 
-    nt.assert_true(np.allclose(res, 16./np.linalg.norm(v2)))
+    nt.assert_true(np.allclose(res, 20./np.linalg.norm(v2)))
 
 
 def test_scalar_projection_perpendicular():
@@ -82,10 +82,10 @@ def test_vector_projection():
 def test_vector_projection_collinear():
 
     v1 = np.array([1., 2., 3.])
-    v2 = np.array([4., 8., 6.])
+    v2 = np.array([4., 8., 12.])
 
     res = mm.vector_projection(v1, v2)
-    nt.assert_true(np.allclose(res, (38./29., 76./29., 57./29.)))
+    nt.assert_true(np.allclose(res, v1))
 
 
 def test_vector_projection_perpendicular():

--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -39,7 +39,7 @@ from neurom.core.dataformat import COLS
 from neurom.analysis.morphmath import section_length
 from neurom.analysis.morphmath import segment_length
 from neurom.analysis.morphtree import find_tree_type
-from neurom.check.morphtree import is_flat, is_monotonic
+from neurom.check.morphtree import is_flat, is_monotonic, is_zigzagging
 from itertools import chain
 
 
@@ -127,6 +127,12 @@ def has_all_monotonic_neurites(neuron, tol=1e-6):
         tol : the tolerance for testing monotonicity
     '''
     return len(get_nonmonotonic_neurites(neuron, tol)) == 0
+
+
+def get_zigzagging_neurites(neuron):
+    '''blah
+    '''
+    return [n for n in neuron.neurites if is_zigzagging(n)]
 
 
 def nonzero_segment_lengths(neuron, threshold=0.0):

--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -130,7 +130,10 @@ def has_all_monotonic_neurites(neuron, tol=1e-6):
 
 
 def get_zigzagging_neurites(neuron):
-    '''blah
+    '''Get neurites that have zigzags. A zigzag is the placement of
+    a point near a previous segment during the reconstruction, causing
+    a zigzag jump in the morphology which can cause issues with meshing
+    algorithms.
     '''
     return [n for n in neuron.neurites if is_zigzagging(n)]
 

--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -39,7 +39,7 @@ from neurom.core.dataformat import COLS
 from neurom.analysis.morphmath import section_length
 from neurom.analysis.morphmath import segment_length
 from neurom.analysis.morphtree import find_tree_type
-from neurom.check.morphtree import is_flat, is_monotonic, is_zigzagging
+from neurom.check.morphtree import is_flat, is_monotonic, is_back_tracking
 from itertools import chain
 
 
@@ -129,13 +129,13 @@ def has_all_monotonic_neurites(neuron, tol=1e-6):
     return len(get_nonmonotonic_neurites(neuron, tol)) == 0
 
 
-def get_zigzagging_neurites(neuron):
-    '''Get neurites that have zigzags. A zigzag is the placement of
+def get_back_tracking_neurites(neuron):
+    '''Get neurites that have back-tracks. A back-track is the placement of
     a point near a previous segment during the reconstruction, causing
     a zigzag jump in the morphology which can cause issues with meshing
     algorithms.
     '''
-    return [n for n in neuron.neurites if is_zigzagging(n)]
+    return [n for n in neuron.neurites if is_back_tracking(n)]
 
 
 def nonzero_segment_lengths(neuron, threshold=0.0):

--- a/neurom/check/morphtree.py
+++ b/neurom/check/morphtree.py
@@ -31,9 +31,11 @@ Python module of NeuroM to check neuronal trees.
 '''
 
 import numpy as np
-from neurom.core.tree import ipreorder
+from neurom.core.tree import ipreorder, isection
 from neurom.core.dataformat import COLS
+from neurom.analysis import morphmath as mm
 from neurom.analysis.morphtree import principal_direction_extent
+from neurom.core.point import COLS
 
 
 def is_monotonic(tree, tol):
@@ -87,3 +89,89 @@ def is_flat(tree, tol, method='tolerance'):
     else:
 
         return any(ext < float(tol))
+
+
+def is_zigzagging(tree):
+    ''' zigzag
+    '''
+    def paired(n):
+        ''' Pairs the input list into triplets
+        '''
+        return zip(n, n[1:], n[2:])
+
+    def coords(node):
+        ''' Returns the first three values of the tree that
+        correspond to the x, y, z coordinates
+        '''
+        return node.value[:COLS.R]
+
+    def max_radius(seg):
+        ''' Returns maximum radius from the two segment endpoints
+        '''
+        return max(seg[0].value[COLS.R], seg[1].value[COLS.R])
+
+    def is_not_zero_seg(seg):
+        ''' Returns True if segment has zero length
+        '''
+        return not np.all(coords(seg[0]) == coords(seg[1]))
+
+    def is_in_the_same_verse(seg, other):
+        ''' Checks if the vectors face the same direction. This
+        is true if their dot product is greater than zero.
+        '''
+        return np.dot(coords(other[1]) - coords(other[0]),
+                      coords(seg[1]) - coords(seg[0])) > 0.
+
+    def is_seg_within_seg_radius(dist, seg, other):
+        ''' Checks whether the orthogonal distance from the point at the end of
+        a segment to the other's segment body is smaller than the sum of their radii
+        '''
+        return dist <= max_radius(seg) + max_radius(other)
+
+    def is_seg_projection_within_other(seg, other):
+        '''projection lies within the length of the cylinder
+        '''
+        s1 = coords(other[0])
+        s2 = coords(other[1])
+
+        # center of the other segment
+        C = 0.5 * (s1 + s2)
+
+        # endpoint of the current segment
+        P = coords(seg[1])
+
+        # vector from C to P
+        CP = P - C
+
+        # projection of CP upon the other segment vector
+        prj = mm.vector_projection(CP, s2 - s1)
+
+        # check if the distance of the orthogonal complement of CP projection on S1S2
+        # is smaller than the sum of the radii. If not exit early.
+        if not is_seg_within_seg_radius(np.linalg.norm(CP - prj), seg, other):
+            return False
+
+        length = np.linalg.norm(s2 - s1)
+        # projection lies within the length of the cylinder
+        # check if the distance between the center of other segment
+        # and the projection of the end point of the current one
+        # is smaller than half of the others length plus a 5% tolerance
+        return np.linalg.norm(prj) < 0.55 * length
+
+    def is_inside_cylinder(seg, other):
+        ''' Checks if a point approximately lies within a cylindrical
+        volume
+        '''
+        return not is_in_the_same_verse(seg, other) and \
+               is_seg_projection_within_other(seg, other)
+
+    # filter out single segment sections
+    for segments in (paired(nodes) for nodes in isection(tree) if len(nodes) > 2):
+        # filter out zero length segments
+        for i, seg in enumerate(filter(is_not_zero_seg, segments[1:])):
+            # check if the end point of the segment lies within the previous
+            # ones in the current section
+            if any(is_inside_cylinder(seg, other) for other in segments[:i + 1]):
+                return True
+
+    return False

--- a/neurom/check/morphtree.py
+++ b/neurom/check/morphtree.py
@@ -91,7 +91,7 @@ def is_flat(tree, tol, method='tolerance'):
         return any(ext < float(tol))
 
 
-def is_zigzagging(tree):
+def is_back_tracking(tree):
     ''' zigzag
     '''
     def paired(n):

--- a/neurom/check/morphtree.py
+++ b/neurom/check/morphtree.py
@@ -129,7 +129,7 @@ def is_zigzagging(tree):
         return dist <= max_radius(seg) + max_radius(other)
 
     def is_seg_projection_within_other(seg, other):
-        '''projection lies within the length of the cylinder
+        '''Checks if a segment is in proximity of another one upstream
         '''
         s1 = coords(other[0])
         s2 = coords(other[1])

--- a/neurom/check/morphtree.py
+++ b/neurom/check/morphtree.py
@@ -113,7 +113,7 @@ def is_zigzagging(tree):
     def is_not_zero_seg(seg):
         ''' Returns True if segment has zero length
         '''
-        return not np.all(coords(seg[0]) == coords(seg[1]))
+        return not np.allclose(coords(seg[0]), coords(seg[1]))
 
     def is_in_the_same_verse(seg, other):
         ''' Checks if the vectors face the same direction. This

--- a/neurom/check/tests/test_morphology.py
+++ b/neurom/check/tests/test_morphology.py
@@ -185,10 +185,10 @@ def test_get_nonmonotonic_neurites():
     nt.assert_equal(len(check_morph.get_nonmonotonic_neurites(n)), 0)
 
 
-def test_get_zigzagging_neurites():
+def test_get_back_tracking_neurites():
 
     _, n = _load_neuron('Neuron.swc')
-    nt.assert_equal(len(check_morph.get_zigzagging_neurites(n)), 4)
+    nt.assert_equal(len(check_morph.get_back_tracking_neurites(n)), 4)
 
 
 def test_nonzero_neurite_radii_good_data():

--- a/neurom/check/tests/test_morphology.py
+++ b/neurom/check/tests/test_morphology.py
@@ -185,6 +185,12 @@ def test_get_nonmonotonic_neurites():
     nt.assert_equal(len(check_morph.get_nonmonotonic_neurites(n)), 0)
 
 
+def test_get_zigzagging_neurites():
+
+    _, n = _load_neuron('Neuron.swc')
+    nt.assert_equal(len(check_morph.get_zigzagging_neurites(n)), 4)
+
+
 def test_nonzero_neurite_radii_good_data():
     files = ['Neuron.swc',
              'Single_apical.swc',

--- a/neurom/check/tests/test_morphtree.py
+++ b/neurom/check/tests/test_morphtree.py
@@ -62,7 +62,7 @@ def _generate_tree(mode):
 
 	return tree
 
-def _generate_zigzag_tree(n, dev):
+def _generate_back_track_tree(n, dev):
 	t = Tree(np.array([0., 0., 0., 0.2, 1., 0., 0.]))
 	t.add_child(Tree(np.array([0., 1., 0., 0.15, 1., 0., 0.])))
 	t.children[0].add_child(Tree(np.array([0., 2., 0., 0.14, 1., 0., 0.])))
@@ -98,26 +98,26 @@ def test_is_flat():
 	nt.assert_false(mt.is_flat(neu_tree, 1e-6, method='tolerance'))
 	nt.assert_false(mt.is_flat(neu_tree, 0.1, method='ratio'))
 
-def test_is_zigzagging():
+def test_is_back_tracking():
 
-	# case 1: a zigzag falls directly on a previous node
-	t = _generate_zigzag_tree(5, (0., 0., 0.))
-	nt.assert_true(mt.is_zigzagging(t))
+	# case 1: a back-track falls directly on a previous node
+	t = _generate_back_track_tree(5, (0., 0., 0.))
+	nt.assert_true(mt.is_back_tracking(t))
 
 	# case 2: a zigzag is close to another segment
-	t = _generate_zigzag_tree(5, (0.1, -0.1, 0.02))
-	nt.assert_true(mt.is_zigzagging(t))
+	t = _generate_back_track_tree(5, (0.1, -0.1, 0.02))
+	nt.assert_true(mt.is_back_tracking(t))
 
 	# case 3: a zigzag is close to another segment 2
-	t = _generate_zigzag_tree(5, (-0.2, 0.04, 0.144))
-	nt.assert_true(mt.is_zigzagging(t))
+	t = _generate_back_track_tree(5, (-0.2, 0.04, 0.144))
+	nt.assert_true(mt.is_back_tracking(t))
 
 	# case 4: a zigzag far from civilization
-	t = _generate_zigzag_tree(5, (10., -10., 10.))
-	nt.assert_false(mt.is_zigzagging(t))
+	t = _generate_back_track_tree(5, (10., -10., 10.))
+	nt.assert_false(mt.is_back_tracking(t))
 
 	# case 5: a zigzag on another section
 	# currently zigzag is defined on the same section
 	# thus this test should not be true
-	t = _generate_zigzag_tree(3, (-0.2, 0.04, 0.144))
-	nt.assert_false(mt.is_zigzagging(t))
+	t = _generate_back_track_tree(3, (-0.2, 0.04, 0.144))
+	nt.assert_false(mt.is_back_tracking(t))

--- a/neurom/check/tests/test_morphtree.py
+++ b/neurom/check/tests/test_morphtree.py
@@ -28,10 +28,9 @@
 
 from neurom.check import morphtree
 from neurom.ezy import load_neuron
-from neurom.check.morphtree import is_monotonic
-from neurom.check.morphtree import is_flat
+from neurom.check import morphtree as mt
 from neurom.core.dataformat import COLS
-from neurom.core.tree import Tree
+from neurom.core.tree import Tree, ipreorder, val_iter
 from nose import tools as nt
 import numpy as np
 import os
@@ -63,6 +62,19 @@ def _generate_tree(mode):
 
 	return tree
 
+def _generate_zigzag_tree(n, dev):
+	t = Tree(np.array([0., 0., 0., 0.2, 1., 0., 0.]))
+	t.add_child(Tree(np.array([0., 1., 0., 0.15, 1., 0., 0.])))
+	t.children[0].add_child(Tree(np.array([0., 2., 0., 0.14, 1., 0., 0.])))
+	t.children[0].children[0].add_child(Tree(np.array([1., 3., 0., 0.15, 1., 0., 0.])))
+	t.children[0].children[0].add_child(Tree(np.array([1., -3., 0., 0.15, 1., 0., 0.])))
+	t.children[0].children[0].children[0].add_child(Tree(np.array([2., 4., 0., 0.11, 1., 0., 0.])))
+	t.children[0].children[0].children[1].add_child(Tree(np.array([2., -4., 0., 0.12, 1., 0., 0.])))
+	t.children[0].children[0].children[1].children[0].add_child(Tree(tuple(val_iter(ipreorder(t)))[n] + np.array([dev[0],dev[1],dev[2], 0.11, 1.,0.,0.])))
+	t.children[0].children[0].children[1].children[0].children[0].add_child(Tree(np.array([3., -5., 0., 0.1, 1., 0., 0.])))
+	t.children[0].children[0].children[1].children[0].children[0].children[0].add_child(Tree(np.array([4.,-6., 0., 0.1, 1., 0., 0.])))
+	return t
+
 
 def test_is_monotonic():
 
@@ -75,15 +87,37 @@ def test_is_monotonic():
 	# tree with increasing radii
 	incr_diams = _generate_tree(2)
 
-	nt.assert_true(is_monotonic(decr_diams, 1e-6))
-	nt.assert_true(is_monotonic(equl_diams, 1e-6))
-	nt.assert_false(is_monotonic(incr_diams, 1e-6))
+	nt.assert_true(mt.is_monotonic(decr_diams, 1e-6))
+	nt.assert_true(mt.is_monotonic(equl_diams, 1e-6))
+	nt.assert_false(mt.is_monotonic(incr_diams, 1e-6))
 
 def test_is_flat():
 
 	neu_tree = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc')).neurites[0]
 
-	nt.assert_false(is_flat(neu_tree, 1e-6, method='tolerance'))
-	nt.assert_false(is_flat(neu_tree, 0.1, method='ratio'))
+	nt.assert_false(mt.is_flat(neu_tree, 1e-6, method='tolerance'))
+	nt.assert_false(mt.is_flat(neu_tree, 0.1, method='ratio'))
 
+def test_is_zigzagging():
 
+	# case 1: a zigzag falls directly on a previous node
+	t = _generate_zigzag_tree(5, (0., 0., 0.))
+	nt.assert_true(mt.is_zigzagging(t))
+
+	# case 2: a zigzag is close to another segment
+	t = _generate_zigzag_tree(5, (0.1, -0.1, 0.02))
+	nt.assert_true(mt.is_zigzagging(t))
+
+	# case 3: a zigzag is close to another segment 2
+	t = _generate_zigzag_tree(5, (-0.2, 0.04, 0.144))
+	nt.assert_true(mt.is_zigzagging(t))
+
+	# case 4: a zigzag far from civilization
+	t = _generate_zigzag_tree(5, (10., -10., 10.))
+	nt.assert_false(mt.is_zigzagging(t))
+
+	# case 5: a zigzag on another section
+	# currently zigzag is defined on the same section
+	# thus this test should not be true
+	t = _generate_zigzag_tree(3, (-0.2, 0.04, 0.144))
+	nt.assert_false(mt.is_zigzagging(t))


### PR DESCRIPTION
This check is implemented for the following issue:
https://bbpteam.epfl.ch/project/issues/browse/SCIMORPH-9

The algorithm checks if the endpoint of a segment lies within or close to another segment upstream.

Firstly, it checks that the distance of the projection of the vector from the center of the other segments to the endpoint of the running one is smaller than the half length of that segment plus a 5% tolerance to take into account exact overlaps.

Secondly, the orthogonal complement of the projection must be smaller or equal than the sum of the maximum radius of each segment pair.

Zero segments are ignored.