### PR TITLE
Fix for matplotlib inline issue fixes #280

### DIFF
--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -371,6 +371,8 @@ def plot_style(fig, ax, **kwargs):
     show_plot = kwargs.get('show_plot', True)
     tight = kwargs.get('tight', False)
 
+    final = kwargs.get('final', True)
+
     # Definition of save options
     output_path = kwargs.get('output_path', None)
 
@@ -401,7 +403,8 @@ def plot_style(fig, ax, **kwargs):
         plt.close()
         return (None, None)
     else:
-        plt.show()
+        if final:
+            plt.show()
         return fig, ax
 
 

--- a/neurom/view/view.py
+++ b/neurom/view/view.py
@@ -319,6 +319,8 @@ def neuron(nrn, plane='xy', new_fig=True, subplot=False, **kwargs):
     kwargs['new_fig'] = False
     kwargs['subplot'] = subplot
 
+    kwargs['final'] = False
+
     soma(nrn.soma, plane=plane, **kwargs)
 
     kwargs['title'] = kwargs.get('title', 'Neuron view')
@@ -346,6 +348,7 @@ def neuron(nrn, plane='xy', new_fig=True, subplot=False, **kwargs):
         kwargs['ylim'] = kwargs.get('ylim', [np.min(v) - get_default('white_space', **kwargs),
                                              np.max(v) + get_default('white_space', **kwargs)])
 
+    kwargs['final'] = True
     return common.plot_style(fig=fig, ax=ax, **kwargs)
 
 
@@ -572,6 +575,8 @@ def neuron3d(nrn, new_fig=True, new_axes=True, subplot=False, **kwargs):
     kwargs['new_axes'] = False
     kwargs['title'] = kwargs.get('title', 'Neuron view')
 
+    kwargs['final'] = False
+
     soma3d(nrn.soma, **kwargs)
 
     h = []
@@ -601,6 +606,7 @@ def neuron3d(nrn, new_fig=True, new_axes=True, subplot=False, **kwargs):
         kwargs['zlim'] = kwargs.get('zlim', [np.min(d) - get_default('white_space', **kwargs),
                                              np.max(d) + get_default('white_space', **kwargs)])
 
+    kwargs['final'] = True
     return common.plot_style(fig=fig, ax=ax, **kwargs)
 
 


### PR DESCRIPTION
Found the issue:
In the past, in order to ensure that a plot is showed in a non-interactive shell, I had put a ```plt.show``` command in the ```common.plot_style``` function which is called every time a tree, neuron, soma is craeted.
In the case of a single tree this works like a charm. However, when a soma and multiple trees are created for a neuron plot, the ```plt.show()``` is called multiple times, which triggers this multple plot behavior in the non-interactive shell of the inline backend.

To fix this I introduced a ```final``` flag that restricts the command show until the end of all plots, when it is called only once. This fixes all related problems with ```inline``` and ```python shell``` displays.