### PR TITLE
Cleanups and minor improvements.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,17 +143,17 @@ Examples
 
 .. code-block:: python
 
-    >>> from neurom import ezy
-    >>> nrn = ezy.load_neuron('some/data/path/morph_file.swc')
-    >>> apical_seg_lengths = nrn.get_segment_lengths(ezy.TreeType.apical_dendrite)
-    >>> axon_sec_lengths = nrn.get_section_lengths(ezy.TreeType.axon)
+    >>> from neurom.ezy import load_neuron, get_feature, NeuriteType
+    >>> nrn = load_neuron('some/data/path/morph_file.swc')
+    >>> apical_seg_lengths = get_feature('segment_lengths', nrn, NeuriteType.apical_dendrite)
+    >>> axon_sec_lengths = get_feature('section_lengths', nrn, NeuriteType.axon)
 
 
 - Visualize a neuronal morphology:
 
 .. code-block:: python
 
-    >>> # Initialize nrn as above
+    >>> from neurom import ezy
     >>> fig, ax = ezy.view(nrn)
     >>> fig.show()
 

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -58,10 +58,10 @@ Basic ``eyz.Neuron`` usage
 
 .. code-block:: python
 
-    >>> from neurom import ezy
-    >>> nrn = ezy.load_neuron('some/data/path/morph_file.swc')
-    >>> apical_seg_lengths = nrn.get_segment_lengths(ezy.TreeType.apical_dendrite)
-    >>> axon_sec_lengths = nrn.get_section_lengths(ezy.TreeType.axon)
+    >>> from neurom.ezy import load_neuron, get_feature, NeuriteType
+    >>> nrn = load_neuron('some/data/path/morph_file.swc')
+    >>> apical_seg_lengths = get_feature('segment_lengths', nrn, NeuriteType.apical_dendrite)
+    >>> axon_sec_lengths = get_feature('section_lengths', nrn, NeuriteType.axon)
 
 
 - Visualize a neuronal morphology:

--- a/examples/dendrogram.py
+++ b/examples/dendrogram.py
@@ -31,7 +31,7 @@
 
 import numpy as np
 from neurom.core.tree import val_iter, Tree
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.view import common
 from neurom.analysis.morphmath import segment_length
 from neurom.analysis.morphtree import n_segments, n_bifurcations, n_terminations
@@ -195,9 +195,9 @@ def _generate_segment_collection(tree, show_diameters):
 
     for val in colors:
 
-        color_string = common.TREE_COLOR[tuple(TreeType)[int(val)]]
+        color_string = common.TREE_COLOR[tuple(NeuriteType)[int(val)]]
 
-        type_string = str(tuple(TreeType)[int(val)]).split('.')[-1]
+        type_string = str(tuple(NeuriteType)[int(val)]).split('.')[-1]
 
         linked_colors.append((color_string, type_string))
 

--- a/examples/density_plot.py
+++ b/examples/density_plot.py
@@ -33,10 +33,10 @@ import pylab as plt
 from neurom.view import common
 from neurom.view import view
 import numpy as np
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 
 
-def extract_density(population, plane='xy', bins=100, neurite_type=TreeType.basal_dendrite):
+def extract_density(population, plane='xy', bins=100, neurite_type=NeuriteType.basal_dendrite):
     '''Extracts the 2d histogram of the center
        coordinates of segments in the selected plane.
     '''
@@ -53,7 +53,7 @@ def plot_density(population, # pylint: disable=too-many-arguments, too-many-loca
                  bins=100, new_fig=True, subplot=111, levels=None, plane='xy',
                  colorlabel='Nodes per unit area', labelfontsize=16,
                  color_map='Reds', no_colorbar=False, threshold=0.01,
-                 neurite_type=TreeType.basal_dendrite, **kwargs):
+                 neurite_type=NeuriteType.basal_dendrite, **kwargs):
     '''Plots the 2d histogram of the center
        coordinates of segments in the selected plane.
     '''
@@ -87,7 +87,7 @@ def plot_neuron_on_density(population, # pylint: disable=too-many-arguments
                            bins=100, new_fig=True, subplot=111, levels=None, plane='xy',
                            colorlabel='Nodes per unit area', labelfontsize=16,
                            color_map='Reds', no_colorbar=False, threshold=0.01,
-                           neurite_type=TreeType.basal_dendrite, **kwargs):
+                           neurite_type=NeuriteType.basal_dendrite, **kwargs):
     '''Plots the 2d histogram of the center
        coordinates of segments in the selected plane
        and superimposes the view of the first neurite of the collection.

--- a/examples/end_to_end_distance.py
+++ b/examples/end_to_end_distance.py
@@ -74,11 +74,12 @@ if __name__ == '__main__':
 
     # print mean end-to-end distance per neurite type
     print('Mean end-to-end distance for axons: ',
-          mean_end_to_end_dist(n for n in nrn.neurites if n.type == ezy.TreeType.axon))
+          mean_end_to_end_dist(n for n in nrn.neurites if n.type == ezy.NeuriteType.axon))
     print('Mean end-to-end distance for basal dendrites: ',
-          mean_end_to_end_dist(n for n in nrn.neurites if n.type == ezy.TreeType.basal_dendrite))
+          mean_end_to_end_dist(n for n in nrn.neurites if n.type == ezy.NeuriteType.basal_dendrite))
     print('Mean end-to-end distance for apical dendrites: ',
-          mean_end_to_end_dist(n for n in nrn.neurites if n.type == ezy.TreeType.apical_dendrite))
+          mean_end_to_end_dist(n for n in nrn.neurites
+                               if n.type == ezy.NeuriteType.apical_dendrite))
 
     print 'End-to-end distance per neurite (nb segments, end-to-end distance, neurite type):'
     for nrte in nrn.neurites:

--- a/examples/ezy.py
+++ b/examples/ezy.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 
     # Get information about neurites
     # Most neurite data can be queried for a particular type of neurite.
-    # The allowed types are members of the TreeType enumeration.
+    # The allowed types are members of the NeuriteType enumeration.
     # NEURITE_TYPES is a list of valid neurite types.
 
     # We start by calling methods for different neurite types separately
@@ -82,29 +82,29 @@ if __name__ == '__main__':
 
     # number of neurites
     print('Number of neurites (all):', nrn.get_n_neurites())
-    print('Number of neurites (axons):', nrn.get_n_neurites(ezy.TreeType.axon))
+    print('Number of neurites (axons):', nrn.get_n_neurites(ezy.NeuriteType.axon))
     print('Number of neurites (apical dendrites):',
-          nrn.get_n_neurites(ezy.TreeType.apical_dendrite))
+          nrn.get_n_neurites(ezy.NeuriteType.apical_dendrite))
     print('Number of neurites (basal dendrites):',
-          nrn.get_n_neurites(ezy.TreeType.basal_dendrite))
+          nrn.get_n_neurites(ezy.NeuriteType.basal_dendrite))
 
     # number of sections
     print('Number of sections:', nrn.get_n_sections())
-    print('Number of sections (axons):', nrn.get_n_sections(ezy.TreeType.axon))
+    print('Number of sections (axons):', nrn.get_n_sections(ezy.NeuriteType.axon))
     print('Number of sections (apical dendrites):',
-          nrn.get_n_sections(ezy.TreeType.apical_dendrite))
+          nrn.get_n_sections(ezy.NeuriteType.apical_dendrite))
     print('Number of sections (basal dendrites):',
-          nrn.get_n_sections(ezy.TreeType.basal_dendrite))
+          nrn.get_n_sections(ezy.NeuriteType.basal_dendrite))
 
     # number of sections per neurite
     print('Number of sections per neurite:',
           nrn.get_n_sections_per_neurite())
     print('Number of sections per neurite (axons):',
-          nrn.get_n_sections_per_neurite(ezy.TreeType.axon))
+          nrn.get_n_sections_per_neurite(ezy.NeuriteType.axon))
     print('Number of sections per neurite (apical dendrites):',
-          nrn.get_n_sections_per_neurite(ezy.TreeType.apical_dendrite))
+          nrn.get_n_sections_per_neurite(ezy.NeuriteType.apical_dendrite))
     print('Number of sections per neurite (basal dendrites):',
-          nrn.get_n_sections_per_neurite(ezy.TreeType.basal_dendrite))
+          nrn.get_n_sections_per_neurite(ezy.NeuriteType.basal_dendrite))
 
     # OK, this is getting repetitive, so lets loop over valid neurite types.
     # The following methods return arrays of measurements. We will gather some

--- a/examples/ezy_advanced.py
+++ b/examples/ezy_advanced.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
     # Number of bifurcation points for apical dendrites
     print('Number of bifurcation points (apical dendrites):',
           sum(1 for _ in iter_neurites(nrn, bif.identity,
-                                       tree_type_checker(ezy.TreeType.apical_dendrite))))
+                                       tree_type_checker(ezy.NeuriteType.apical_dendrite))))
 
     # Maximum branch order
     # We create a custom branch_order section_function

--- a/examples/plot_features.py
+++ b/examples/plot_features.py
@@ -96,9 +96,9 @@ def calc_limits(data, dist=None, padding=0.25):
 
 
 # Neurite types of interest
-NEURITES_ = (ezy.TreeType.axon,
-             ezy.TreeType.apical_dendrite,
-             ezy.TreeType.basal_dendrite,)
+NEURITES_ = (ezy.NeuriteType.axon,
+             ezy.NeuriteType.apical_dendrite,
+             ezy.NeuriteType.basal_dendrite,)
 
 # map feature names to functors that get us arrays of that
 # feature, for a given tree type

--- a/examples/radius_of_gyration.py
+++ b/examples/radius_of_gyration.py
@@ -93,8 +93,9 @@ if __name__ == '__main__':
 
     # print mean radius of gyration per neurite type
     print('Mean radius of gyration for axons: ',
-          mean_rad_of_gyration(n for n in nrn.neurites if n.type == ezy.TreeType.axon))
+          mean_rad_of_gyration(n for n in nrn.neurites if n.type == ezy.NeuriteType.axon))
     print('Mean radius of gyration for basal dendrites: ',
-          mean_rad_of_gyration(n for n in nrn.neurites if n.type == ezy.TreeType.basal_dendrite))
+          mean_rad_of_gyration(n for n in nrn.neurites if n.type == ezy.NeuriteType.basal_dendrite))
     print('Mean radius of gyration for apical dendrites: ',
-          mean_rad_of_gyration(n for n in nrn.neurites if n.type == ezy.TreeType.apical_dendrite))
+          mean_rad_of_gyration(n for n in nrn.neurites
+                               if n.type == ezy.NeuriteType.apical_dendrite))

--- a/examples/refactoring.py
+++ b/examples/refactoring.py
@@ -31,7 +31,7 @@
 from neurom.core.tree import isegment, isection
 import neurom.analysis.morphtree as mtr
 
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 
 from neurom.core.types import tree_type_checker
 
@@ -86,14 +86,14 @@ class Neuron(object):
         self.neurites = neurites
         self.name = name
 
-    def segments(self, neurite_type=TreeType.all):
+    def segments(self, neurite_type=NeuriteType.all):
         '''Returns segments
         '''
         return i_neurites(self.neurites,
                           lambda n: n.segments(),
                           neu_filter=tree_type_checker(neurite_type))
 
-    def sections(self, neurite_type=TreeType.all):
+    def sections(self, neurite_type=NeuriteType.all):
         '''Returns sections
         '''
         return i_neurites(self.neurites,
@@ -120,14 +120,14 @@ class Population(object):
         '''
         return (neu.soma for neu in self.neurons)
 
-    def segments(self, neurite_type=TreeType.all):
+    def segments(self, neurite_type=NeuriteType.all):
         '''Returns segments
         '''
         return i_neurites(self.neurites,
                           lambda n: n.segments(),
                           neu_filter=tree_type_checker(neurite_type))
 
-    def sections(self, neurite_type=TreeType.all):
+    def sections(self, neurite_type=NeuriteType.all):
         '''Returns sections
         '''
         return i_neurites(self.neurites,

--- a/examples/synthesis_json.py
+++ b/examples/synthesis_json.py
@@ -68,9 +68,9 @@ FEATURE_MAP = {
 
 # Map component name to filtering parameters where applicable
 PARAM_MAP = {
-    'basal_dendrite': {'neurite_type': ezy.TreeType.basal_dendrite},
-    'apical_dendrite': {'neurite_type': ezy.TreeType.apical_dendrite},
-    'axon': {'neurite_type': ezy.TreeType.axon},
+    'basal_dendrite': {'neurite_type': ezy.NeuriteType.basal_dendrite},
+    'apical_dendrite': {'neurite_type': ezy.NeuriteType.apical_dendrite},
+    'axon': {'neurite_type': ezy.NeuriteType.axon},
     'soma': None
 }
 

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -33,7 +33,7 @@ different iteration modes.
 '''
 from itertools import izip, product
 from neurom.core import tree as tr
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.core.tree import ipreorder
 import neurom.analysis.morphmath as mm
 from neurom.analysis.morphmath import pca
@@ -115,7 +115,7 @@ def find_tree_type(tree):
         The type of the tree
     """
 
-    tree_types = tuple(TreeType)
+    tree_types = tuple(NeuriteType)
 
     types = [node[COLS.TYPE] for node in tr.val_iter(tr.ipreorder(tree))]
     types = [node[COLS.TYPE] for node in tr.val_iter(tr.ipreorder(tree))]

--- a/neurom/analysis/tests/test_dendrogram.py
+++ b/neurom/analysis/tests/test_dendrogram.py
@@ -3,7 +3,7 @@ import numpy as np
 from nose import tools as nt
 from neurom.core.tree import Tree
 from neurom.core.neuron import Neuron, make_soma
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.analysis.morphtree import set_tree_type
 import neurom.analysis.dendrogram as dm
 
@@ -15,7 +15,7 @@ TREE.children[0].add_child(Tree(np.array([-10., -10., -10., 7., 4., 0., 0.])))
 
 set_tree_type(TREE)
 
-SOMA = make_soma(np.array([[0., 0., 0., 1., 1., 1., -1.]]))   
+SOMA = make_soma(np.array([[0., 0., 0., 1., 1., 1., -1.]]))
 NEURON = Neuron(SOMA, [TREE, TREE, TREE])
 
 OLD_OFFS = [1.2, -1.2]
@@ -83,7 +83,7 @@ def test_update_offsets():
     length = 44.
 
     offs = dm._update_offsets(start_x, SPACING, 2, OLD_OFFS, length)
-    
+
     nt.assert_almost_equal(offs[0], 30.)
     nt.assert_almost_equal(offs[1], 42.8)
 
@@ -139,13 +139,13 @@ class TestDendrogram(object):
 
         for ctype in self.dtr.types:
             print ctype
-            nt.assert_true(ctype == TreeType.apical_dendrite)
+            nt.assert_true(ctype == NeuriteType.apical_dendrite)
 
     def test_types_neuron(self):
 
         for ctype in self.dnrn.types:
             print ctype
-            nt.assert_true(ctype == TreeType.apical_dendrite)
+            nt.assert_true(ctype == NeuriteType.apical_dendrite)
 
 
     def test_generate_dendro(self):pass

--- a/neurom/analysis/tests/test_morphtree.py
+++ b/neurom/analysis/tests/test_morphtree.py
@@ -32,15 +32,11 @@ from copy import deepcopy
 from neurom.core.tree import Tree
 import neurom.core.tree as tr
 import neurom.analysis.morphtree as mtr
-from neurom.analysis.morphmath import angle_3points
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.io.utils import make_neuron
 from neurom.core.neuron import make_soma
 from neurom import io
-
-import math
 import numpy as np
-from itertools import izip
 
 DATA_PATH = './test_data'
 SWC_PATH = os.path.join(DATA_PATH, 'swc/')
@@ -48,10 +44,10 @@ SWC_PATH = os.path.join(DATA_PATH, 'swc/')
 data    = io.load_data(SWC_PATH + 'Neuron.swc')
 neuron0 = make_neuron(data)
 tree0   = neuron0.neurites[0]
-tree_types = [TreeType.axon,
-              TreeType.basal_dendrite,
-              TreeType.basal_dendrite,
-              TreeType.apical_dendrite]
+tree_types = [NeuriteType.axon,
+              NeuriteType.basal_dendrite,
+              NeuriteType.basal_dendrite,
+              NeuriteType.apical_dendrite]
 
 
 # Mock tree holding integers, not points

--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -30,7 +30,7 @@
 Python module of NeuroM to check neurons.
 '''
 
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.core.tree import ipreorder
 from neurom.core.tree import isegment
 from neurom.core.tree import isection
@@ -51,7 +51,7 @@ def has_axon(neuron, treefun=find_tree_type):
         treefun: Optional function to calculate the tree type of
         neuron's neurites
     '''
-    return TreeType.axon in [treefun(n) for n in neuron.neurites]
+    return NeuriteType.axon in [treefun(n) for n in neuron.neurites]
 
 
 def has_apical_dendrite(neuron, min_number=1, treefun=find_tree_type):
@@ -64,7 +64,7 @@ def has_apical_dendrite(neuron, min_number=1, treefun=find_tree_type):
         neurites
     '''
     types = [treefun(n) for n in neuron.neurites]
-    return types.count(TreeType.apical_dendrite) >= min_number
+    return types.count(NeuriteType.apical_dendrite) >= min_number
 
 
 def has_basal_dendrite(neuron, min_number=1, treefun=find_tree_type):
@@ -77,7 +77,7 @@ def has_basal_dendrite(neuron, min_number=1, treefun=find_tree_type):
         neurites
     '''
     types = [treefun(n) for n in neuron.neurites]
-    return types.count(TreeType.basal_dendrite) >= min_number
+    return types.count(NeuriteType.basal_dendrite) >= min_number
 
 
 def get_flat_neurites(neuron, tol=0.1, method='ratio'):

--- a/neurom/core/tests/test_types.py
+++ b/neurom/core/tests/test_types.py
@@ -30,26 +30,26 @@
 from nose import tools as nt
 from mock import Mock
 
-from neurom.core.types import TreeType, tree_type_checker, NEURITES
+from neurom.core.types import NeuriteType, tree_type_checker, NEURITES
 
 
 def test_tree_type_checker():
-    #check that when TreeType.all, we accept all trees, w/o checking type
-    tree_filter = tree_type_checker(TreeType.all)
+    #check that when NeuriteType.all, we accept all trees, w/o checking type
+    tree_filter = tree_type_checker(NeuriteType.all)
     nt.ok_(tree_filter('fake_tree'))
 
     mock_tree = Mock()
-    mock_tree.type = TreeType.axon
+    mock_tree.type = NeuriteType.axon
 
     #single arg
-    tree_filter = tree_type_checker(TreeType.axon)
+    tree_filter = tree_type_checker(NeuriteType.axon)
     nt.ok_(tree_filter(mock_tree))
 
-    mock_tree.type = TreeType.basal_dendrite
+    mock_tree.type = NeuriteType.basal_dendrite
     nt.ok_(not tree_filter(mock_tree))
 
     #multiple args
-    tree_filter = tree_type_checker(TreeType.axon, TreeType.basal_dendrite)
+    tree_filter = tree_type_checker(NeuriteType.axon, NeuriteType.basal_dendrite)
     nt.ok_(tree_filter(mock_tree))
 
     tree_filter = tree_type_checker(*NEURITES)

--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -32,7 +32,7 @@ from enum import Enum, unique
 
 
 @unique
-class TreeType(Enum):
+class NeuriteType(Enum):
     '''Enum representing valid tree types'''
     undefined = 1
     soma = 2
@@ -47,15 +47,15 @@ def tree_type_checker(*ref):
 
     Returns:
         Functor that takes a tree, and returns true if that tree matches any of
-        TreeTypes in ref
+        NeuriteTypes in ref
 
     Ex:
-        >>> from neurom.core.types import TreeType, tree_type_checker
-        >>> tree_filter = tree_type_checker(TreeType.axon, TreeType.basal_dendrite)
+        >>> from neurom.core.types import NeuriteType, tree_type_checker
+        >>> tree_filter = tree_type_checker(NeuriteType.axon, NeuriteType.basal_dendrite)
         >>> nrn.i_neurites(tree.isegment, tree_filter=tree_filter)
     '''
     ref = tuple(ref)
-    if TreeType.all in ref:
+    if NeuriteType.all in ref:
         def check_tree_type(_):
             '''Always returns true'''
             return True
@@ -64,17 +64,17 @@ def tree_type_checker(*ref):
             '''Check whether tree has the same type as ref
 
             Returns:
-                True if ref in the same type as tree.type or ref is TreeType.all
+                True if ref in the same type as tree.type or ref is NeuriteType.all
             '''
             return tree.type in ref
 
     return check_tree_type
 
 
-NEURITES = (TreeType.all,
-            TreeType.axon,
-            TreeType.basal_dendrite,
-            TreeType.apical_dendrite)
+NEURITES = (NeuriteType.all,
+            NeuriteType.axon,
+            NeuriteType.basal_dendrite,
+            NeuriteType.apical_dendrite)
 
 
 ROOT_ID = -1

--- a/neurom/ezy/__init__.py
+++ b/neurom/ezy/__init__.py
@@ -37,8 +37,8 @@ Examples:
 
     Obtain some morphometrics
 
-    >>> apical_seg_lengths = nrn.get_segment_lengths(ezy.TreeType.apical_dendrite)
-    >>> axon_sec_lengths = nrn.get_section_lengths(ezy.TreeType.axon)
+    >>> apical_seg_lengths = nrn.get_segment_lengths(ezy.NeuriteType.apical_dendrite)
+    >>> axon_sec_lengths = nrn.get_section_lengths(ezy.NeuriteType.axon)
 
     View it in 2D and 3D
 
@@ -59,13 +59,17 @@ Examples:
 import os
 from .neuron import Neuron
 from .population import Population
-from .neuron import TreeType
+from .neuron import NeuriteType
 from ..core.types import NEURITES as NEURITE_TYPES
 from ..view.view import neuron as view
 from ..view.view import neuron3d as view3d
 from ..io.utils import get_morph_files
+from ..features import get_feature
 from ..io.utils import load_neuron as _load
 from ..analysis.morphtree import set_tree_type as _set_tt
+
+
+TreeType = NeuriteType  # For backwards compatibility
 
 
 def load_neuron(filename):

--- a/neurom/ezy/neuron.py
+++ b/neurom/ezy/neuron.py
@@ -31,7 +31,7 @@
 
 
 from itertools import product
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.core.types import tree_type_checker
 from neurom import segments as _seg
 from neurom import sections as _sec
@@ -65,7 +65,7 @@ class Neuron(CoreNeuron):
 
     >>> from neurom import ezy
     >>> nrn = ezy.load_neuron('test_data/swc/Neuron.swc')
-    >>> nrn.get_segment_lengths(ezy.TreeType.apical_dendrite)
+    >>> nrn.get_segment_lengths(ezy.NeuriteType.apical_dendrite)
 
     Example:
         use lists instead of numpy arrays and get section \
@@ -73,7 +73,7 @@ class Neuron(CoreNeuron):
 
     >>> from neurom import ezy
     >>> nrn = ezy.load_neuron('test_data/h5/v1/Neuron.h5', iterable_type=list)
-    >>> nrn.get_section_lengths(ezy.TreeType.axon)
+    >>> nrn.get_section_lengths(ezy.NeuriteType.axon)
 
     Example:
         plot the neuron and save to a file
@@ -91,14 +91,14 @@ class Neuron(CoreNeuron):
     def __eq__(self, other):
         return False if not isinstance(self, type(other)) else \
                all(self._compare_neurites(other, ttype) for ttype in
-                   [TreeType.axon, TreeType.basal_dendrite,
-                    TreeType.apical_dendrite, TreeType.undefined])
+                   [NeuriteType.axon, NeuriteType.basal_dendrite,
+                    NeuriteType.apical_dendrite, NeuriteType.undefined])
 
-    def get_section_lengths(self, neurite_type=TreeType.all):
+    def get_section_lengths(self, neurite_type=NeuriteType.all):
         '''Get an iterable containing the lengths of all sections of a given type'''
         return self._pkg(_sec.length, neurite_type)
 
-    def get_segment_lengths(self, neurite_type=TreeType.all):
+    def get_segment_lengths(self, neurite_type=NeuriteType.all):
         '''Get an iterable containing the lengths of all segments of a given type'''
         return self._pkg(_seg.length, neurite_type)
 
@@ -114,7 +114,7 @@ class Neuron(CoreNeuron):
         '''
         return 4 * math.pi * self.get_soma_radius() ** 2
 
-    def get_local_bifurcation_angles(self, neurite_type=TreeType.all):
+    def get_local_bifurcation_angles(self, neurite_type=NeuriteType.all):
         '''Get local bifircation angles of all segments of a given type
 
         The local bifurcation angle is defined as the angle between
@@ -125,7 +125,7 @@ class Neuron(CoreNeuron):
         '''
         return self._pkg(_bifs.local_angle, neurite_type)
 
-    def get_remote_bifurcation_angles(self, neurite_type=TreeType.all):
+    def get_remote_bifurcation_angles(self, neurite_type=NeuriteType.all):
         '''Get remote bifircation angles of all segments of a given type
 
         The remote bifurcation angle is defined as the angle between
@@ -138,7 +138,7 @@ class Neuron(CoreNeuron):
         return self._pkg(_bifs.remote_angle, neurite_type)
 
     def get_section_radial_distances(self, origin=None, use_start_point=False,
-                                     neurite_type=TreeType.all):
+                                     neurite_type=NeuriteType.all):
         '''Get an iterable containing section radial distances to origin of\
            all neurites of a given type
 
@@ -154,7 +154,7 @@ class Neuron(CoreNeuron):
                                   neurite_type=neurite_type)
 
     def get_section_path_distances(self, use_start_point=False,
-                                   neurite_type=TreeType.all):
+                                   neurite_type=NeuriteType.all):
         '''
         Get section path distances of all neurites of a given type
         The section path distance is measured to the neurite's root.
@@ -163,7 +163,7 @@ class Neuron(CoreNeuron):
             use_start_point: boolean\
             if true, use the section's first point,\
             otherwise use the end-point (default False)
-            neurite_type: TreeType\
+            neurite_type: NeuriteType\
             Type of neurites to be considered (default all)
 
         Returns:
@@ -173,38 +173,38 @@ class Neuron(CoreNeuron):
                       else _sec.end_point_path_length)
         return self._pkg(magic_iter, neurite_type)
 
-    def get_n_sections(self, neurite_type=TreeType.all):
+    def get_n_sections(self, neurite_type=NeuriteType.all):
         '''Get the number of sections of a given type'''
         tree_filter = tree_type_checker(neurite_type)
         return _sec.count(self, tree_filter)
 
-    def get_n_sections_per_neurite(self, neurite_type=TreeType.all):
+    def get_n_sections_per_neurite(self, neurite_type=NeuriteType.all):
         '''Get an iterable with the number of sections for a given neurite type'''
         tree_filter = tree_type_checker(neurite_type)
         return self._iterable_type(
             [_sec.count(n) for n in self.neurites if tree_filter(n)]
         )
 
-    def get_n_neurites(self, neurite_type=TreeType.all):
+    def get_n_neurites(self, neurite_type=NeuriteType.all):
         '''Get the number of neurites of a given type in a neuron'''
         tree_filter = tree_type_checker(neurite_type)
         return sum(1 for n in self.neurites if tree_filter(n))
 
-    def get_trunk_origin_radii(self, neurite_type=TreeType.all):
+    def get_trunk_origin_radii(self, neurite_type=NeuriteType.all):
         '''Get the trunk origin radii of a given type in a neuron'''
         tree_filter = tree_type_checker(neurite_type)
         return self._iterable_type(
             [_pts.radius(t) for t in self.neurites if tree_filter(t)]
         )
 
-    def get_trunk_section_lengths(self, neurite_type=TreeType.all):
+    def get_trunk_section_lengths(self, neurite_type=NeuriteType.all):
         '''Get the trunk section lengths of a given type in a neuron'''
         tree_filter = tree_type_checker(neurite_type)
         return self._iterable_type(
             [trunk_section_length(t) for t in self.neurites if tree_filter(t)]
         )
 
-    def _iter_neurites(self, iterator_type, mapping=None, neurite_type=TreeType.all):
+    def _iter_neurites(self, iterator_type, mapping=None, neurite_type=NeuriteType.all):
         '''Iterate over collection of neurites applying iterator_type
 
         Parameters:
@@ -212,7 +212,7 @@ class Neuron(CoreNeuron):
             (e.g. isegment, isection)
             mapping: mapping function to be applied to the target of iteration.\
             (e.g. segment_length). Must be compatible with the iterator_type.
-            neurite_type: TreeType object. Neurites of incompatible type are\
+            neurite_type: NeuriteType object. Neurites of incompatible type are\
             filtered out.
 
         Returns:
@@ -234,7 +234,7 @@ class Neuron(CoreNeuron):
                                mapping,
                                tree_filter=tree_type_checker(neurite_type))
 
-    def _pkg(self, magic_iter, neurite_type=TreeType.all):
+    def _pkg(self, magic_iter, neurite_type=NeuriteType.all):
         '''Return an iterable built from magic_iter'''
         stuff = list(
             iter_neurites(self,
@@ -243,7 +243,7 @@ class Neuron(CoreNeuron):
         )
         return self._iterable_type(stuff)
 
-    def _neurite_loop(self, iterator_type, mapping=None, neurite_type=TreeType.all):
+    def _neurite_loop(self, iterator_type, mapping=None, neurite_type=NeuriteType.all):
         '''Iterate over collection of neurites applying iterator_type
 
         Parameters:
@@ -251,7 +251,7 @@ class Neuron(CoreNeuron):
             (e.g. isegment, isection)
             mapping: mapping function to be applied to the target of iteration.
             (e.g. segment_length). Must be compatible with the iterator_type.
-            neurite_type: TreeType object. Neurites of incompatible type are
+            neurite_type: NeuriteType object. Neurites of incompatible type are
             filtered out.
 
         Returns:

--- a/neurom/ezy/population.py
+++ b/neurom/ezy/population.py
@@ -29,7 +29,7 @@
 
 '''Population Class with basic analysis and plotting capabilities'''
 
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.core.population import Population as CorePopulation
 
 
@@ -52,7 +52,7 @@ class Population(CorePopulation):
         '''
         return iter(self.somata)
 
-    def get_n_neurites(self, neurite_type=TreeType.all):
+    def get_n_neurites(self, neurite_type=NeuriteType.all):
         '''Get the number of neurites of a given type in a population'''
         return sum(nrn.get_n_neurites(neurite_type=neurite_type) for nrn in self.iter_neurons())
 

--- a/neurom/ezy/tests/test_neuron.py
+++ b/neurom/ezy/tests/test_neuron.py
@@ -34,7 +34,7 @@ import numpy as np
 from copy import deepcopy
 from neurom import ezy
 from collections import namedtuple
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.exceptions import SomaError, IDSequenceError
 from nose import tools as nt
 from neurom import sections as sec
@@ -88,27 +88,27 @@ class TestEzyNeuron(object):
         nt.assert_equal(len(seclen), 84)
         nt.assert_true(np.all(seclen == ref_seclen))
 
-        seclen = self.neuron.get_section_lengths(TreeType.all)
+        seclen = self.neuron.get_section_lengths(NeuriteType.all)
         nt.assert_equal(len(seclen), 84)
         nt.assert_true(np.all(seclen == ref_seclen))
 
     def test_get_section_lengths_axon(self):
-        s = self.neuron.get_section_lengths(TreeType.axon)
+        s = self.neuron.get_section_lengths(NeuriteType.axon)
         nt.assert_equal(len(s), 21)
 
     def test_get_section_lengths_basal(self):
-        s = self.neuron.get_section_lengths(TreeType.basal_dendrite)
+        s = self.neuron.get_section_lengths(NeuriteType.basal_dendrite)
         nt.assert_equal(len(s), 42)
 
     def test_get_section_lengths_apical(self):
-        s = self.neuron.get_section_lengths(TreeType.apical_dendrite)
+        s = self.neuron.get_section_lengths(NeuriteType.apical_dendrite)
         nt.assert_equal(len(s), 21)
 
     def test_get_section_lengths_invalid(self):
-        s = self.neuron.get_section_lengths(TreeType.soma)
+        s = self.neuron.get_section_lengths(NeuriteType.soma)
         nt.assert_equal(len(s), 0)
-        s = self.neuron.get_section_lengths(TreeType.undefined)
-        s = self.neuron.get_section_lengths(TreeType.soma)
+        s = self.neuron.get_section_lengths(NeuriteType.undefined)
+        s = self.neuron.get_section_lengths(NeuriteType.soma)
 
     def test_get_segment_lengths(self):
         ref_seglen = list(iter_neurites(self.neuron, seg.length))
@@ -116,7 +116,7 @@ class TestEzyNeuron(object):
         nt.assert_equal(len(seglen), 840)
         nt.assert_true(np.all(seglen == ref_seglen))
 
-        seglen = self.neuron.get_segment_lengths(TreeType.all)
+        seglen = self.neuron.get_segment_lengths(NeuriteType.all)
         nt.assert_equal(len(seglen), 840)
         nt.assert_true(np.all(seglen == ref_seglen))
 
@@ -128,21 +128,21 @@ class TestEzyNeuron(object):
         nt.assert_almost_equal(self.neuron.get_soma_surface_area(), area)
 
     def test_get_segment_lengths_axon(self):
-        s = self.neuron.get_segment_lengths(TreeType.axon)
+        s = self.neuron.get_segment_lengths(NeuriteType.axon)
         nt.assert_equal(len(s), 210)
 
     def test_get_segment_lengths_basal(self):
-        s = self.neuron.get_segment_lengths(TreeType.basal_dendrite)
+        s = self.neuron.get_segment_lengths(NeuriteType.basal_dendrite)
         nt.assert_equal(len(s), 420)
 
     def test_get_segment_lengths_apical(self):
-        s = self.neuron.get_segment_lengths(TreeType.apical_dendrite)
+        s = self.neuron.get_segment_lengths(NeuriteType.apical_dendrite)
         nt.assert_equal(len(s), 210)
 
     def test_get_segment_lengths_invalid(self):
-        s = self.neuron.get_segment_lengths(TreeType.soma)
+        s = self.neuron.get_segment_lengths(NeuriteType.soma)
         nt.assert_equal(len(s), 0)
-        s = self.neuron.get_segment_lengths(TreeType.undefined)
+        s = self.neuron.get_segment_lengths(NeuriteType.undefined)
         nt.assert_equal(len(s), 0)
 
     def test_get_local_bifurcation_angles(self):
@@ -152,26 +152,26 @@ class TestEzyNeuron(object):
         local_bifangles = self.neuron.get_local_bifurcation_angles()
         nt.assert_equal(len(local_bifangles), 40)
         nt.assert_true(np.all(local_bifangles == ref_local_bifangles))
-        local_bifangles = self.neuron.get_local_bifurcation_angles(TreeType.all)
+        local_bifangles = self.neuron.get_local_bifurcation_angles(NeuriteType.all)
         nt.assert_equal(len(local_bifangles), 40)
         nt.assert_true(np.all(local_bifangles == ref_local_bifangles))
 
     def test_get_local_bifurcation_angles_axon(self):
-        s = self.neuron.get_local_bifurcation_angles(TreeType.axon)
+        s = self.neuron.get_local_bifurcation_angles(NeuriteType.axon)
         nt.assert_equal(len(s), 10)
 
     def test_get_local_bifurcation_angles_basal(self):
-        s = self.neuron.get_local_bifurcation_angles(TreeType.basal_dendrite)
+        s = self.neuron.get_local_bifurcation_angles(NeuriteType.basal_dendrite)
         nt.assert_equal(len(s), 20)
 
     def test_get_local_bifurcation_angles_apical(self):
-        s = self.neuron.get_local_bifurcation_angles(TreeType.apical_dendrite)
+        s = self.neuron.get_local_bifurcation_angles(NeuriteType.apical_dendrite)
         nt.assert_equal(len(s), 10)
 
     def test_get_local_bifurcation_angles_invalid(self):
-        s = self.neuron.get_local_bifurcation_angles(TreeType.soma)
+        s = self.neuron.get_local_bifurcation_angles(NeuriteType.soma)
         nt.assert_equal(len(s), 0)
-        s = self.neuron.get_local_bifurcation_angles(TreeType.undefined)
+        s = self.neuron.get_local_bifurcation_angles(NeuriteType.undefined)
         nt.assert_equal(len(s), 0)
 
     def test_get_remote_bifurcation_angles(self):
@@ -179,26 +179,26 @@ class TestEzyNeuron(object):
         remote_bifangles = self.neuron.get_remote_bifurcation_angles()
         nt.assert_equal(len(remote_bifangles), 40)
         nt.assert_true(np.all(remote_bifangles == ref_remote_bifangles))
-        remote_bifangles = self.neuron.get_remote_bifurcation_angles(TreeType.all)
+        remote_bifangles = self.neuron.get_remote_bifurcation_angles(NeuriteType.all)
         nt.assert_equal(len(remote_bifangles), 40)
         nt.assert_true(np.all(remote_bifangles == ref_remote_bifangles))
 
     def test_get_remote_bifurcation_angles_axon(self):
-        s = self.neuron.get_remote_bifurcation_angles(TreeType.axon)
+        s = self.neuron.get_remote_bifurcation_angles(NeuriteType.axon)
         nt.assert_equal(len(s), 10)
 
     def test_get_remote_bifurcation_angles_basal(self):
-        s = self.neuron.get_remote_bifurcation_angles(TreeType.basal_dendrite)
+        s = self.neuron.get_remote_bifurcation_angles(NeuriteType.basal_dendrite)
         nt.assert_equal(len(s), 20)
 
     def test_get_remote_bifurcation_angles_apical(self):
-        s = self.neuron.get_remote_bifurcation_angles(TreeType.apical_dendrite)
+        s = self.neuron.get_remote_bifurcation_angles(NeuriteType.apical_dendrite)
         nt.assert_equal(len(s), 10)
 
     def test_get_remote_bifurcation_angles_invalid(self):
-        s = self.neuron.get_remote_bifurcation_angles(TreeType.soma)
+        s = self.neuron.get_remote_bifurcation_angles(NeuriteType.soma)
         nt.assert_equal(len(s), 0)
-        s = self.neuron.get_remote_bifurcation_angles(TreeType.undefined)
+        s = self.neuron.get_remote_bifurcation_angles(NeuriteType.undefined)
         nt.assert_equal(len(s), 0)
 
 
@@ -228,7 +228,7 @@ class TestEzyNeuron(object):
         nt.assert_true(np.all(rad_dists == ref_sec_rad_dist_start))
 
     def test_get_section_radial_axon(self):
-        rad_dists = self.neuron.get_section_radial_distances(neurite_type=TreeType.axon)
+        rad_dists = self.neuron.get_section_radial_distances(neurite_type=NeuriteType.axon)
         nt.assert_equal(len(rad_dists), 21)
 
     def test_get_section_path_distances_endpoint(self):
@@ -248,26 +248,26 @@ class TestEzyNeuron(object):
         nt.assert_true(np.all(path_lengths == ref_sec_path_len_start))
 
     def test_get_section_path_distances_axon(self):
-        path_lengths = self.neuron.get_section_path_distances(neurite_type=TreeType.axon)
+        path_lengths = self.neuron.get_section_path_distances(neurite_type=NeuriteType.axon)
         nt.assert_equal(len(path_lengths), 21)
 
 
     def test_get_n_sections(self):
         nt.assert_equal(self.neuron.get_n_sections(), 84)
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.all), 84)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.all), 84)
 
     def test_get_n_sections_axon(self):
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.axon), 21)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.axon), 21)
 
     def test_get_n_sections_basal(self):
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.basal_dendrite), 42)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.basal_dendrite), 42)
 
     def test_get_n_sections_apical(self):
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.apical_dendrite), 21)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.apical_dendrite), 21)
 
     def test_get_n_sections_invalid(self):
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.soma), 0)
-        nt.assert_equal(self.neuron.get_n_sections(TreeType.undefined), 0)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.soma), 0)
+        nt.assert_equal(self.neuron.get_n_sections(NeuriteType.undefined), 0)
 
     def test_get_n_sections_per_neurite(self):
         nsecs = self.neuron.get_n_sections_per_neurite()
@@ -275,28 +275,28 @@ class TestEzyNeuron(object):
         nt.assert_true(np.all(nsecs == [21, 21, 21, 21]))
 
     def test_get_n_sections_per_neurite_axon(self):
-        nsecs = self.neuron.get_n_sections_per_neurite(TreeType.axon)
+        nsecs = self.neuron.get_n_sections_per_neurite(NeuriteType.axon)
         nt.assert_equal(len(nsecs), 1)
         nt.assert_equal(nsecs, [21])
 
     def test_get_n_sections_per_neurite_basal(self):
-        nsecs = self.neuron.get_n_sections_per_neurite(TreeType.basal_dendrite)
+        nsecs = self.neuron.get_n_sections_per_neurite(NeuriteType.basal_dendrite)
         nt.assert_equal(len(nsecs), 2)
         nt.assert_true(np.all(nsecs == [21, 21]))
 
     def test_get_n_sections_per_neurite_apical(self):
-        nsecs = self.neuron.get_n_sections_per_neurite(TreeType.apical_dendrite)
+        nsecs = self.neuron.get_n_sections_per_neurite(NeuriteType.apical_dendrite)
         nt.assert_equal(len(nsecs), 1)
         nt.assert_true(np.all(nsecs == [21]))
 
     def test_get_n_neurites(self):
         nt.assert_equal(self.neuron.get_n_neurites(), 4)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.all), 4)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.axon), 1)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.basal_dendrite), 2)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.apical_dendrite), 1)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.soma), 0)
-        nt.assert_equal(self.neuron.get_n_neurites(TreeType.undefined), 0)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.all), 4)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.axon), 1)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.basal_dendrite), 2)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.apical_dendrite), 1)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.soma), 0)
+        nt.assert_equal(self.neuron.get_n_neurites(NeuriteType.undefined), 0)
 
     def test_get_trunk_origin_radii(self):
         nt.assert_items_equal(self.neuron.get_trunk_origin_radii(),
@@ -305,23 +305,23 @@ class TestEzyNeuron(object):
                                0.66943255462899998,
                                0.14656092843999999])
 
-        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(TreeType.apical_dendrite),
+        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(NeuriteType.apical_dendrite),
                               [0.14656092843999999])
-        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(TreeType.basal_dendrite),
+        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(NeuriteType.basal_dendrite),
                               [0.18391483031299999,
                                0.66943255462899998])
-        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(TreeType.axon),
+        nt.assert_items_equal(self.neuron.get_trunk_origin_radii(NeuriteType.axon),
                               [0.85351288499400002])
 
     def test_get_trunk_section_lengths(self):
         nt.assert_items_equal(self.neuron.get_trunk_section_lengths(), [9.579117366740002,
-                                                                       7.972322416776259,
-                                                                       8.2245287740603779,
-                                                                       9.212707985134525])
-        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(TreeType.apical_dendrite), [9.212707985134525])
-        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(TreeType.basal_dendrite),
+                                                                        7.972322416776259,
+                                                                        8.2245287740603779,
+                                                                        9.212707985134525])
+        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(NeuriteType.apical_dendrite), [9.212707985134525])
+        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(NeuriteType.basal_dendrite),
                               [7.972322416776259, 8.2245287740603779])
-        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(TreeType.axon), [9.579117366740002])
+        nt.assert_items_equal(self.neuron.get_trunk_section_lengths(NeuriteType.axon), [9.579117366740002])
 
     def test_view(self):
         # Neuron.plot simply forwards arguments to neurom.view.view
@@ -338,7 +338,7 @@ class TestEzyNeuron(object):
 
         fake_neuron = namedtuple('Neuron', 'neurites')
         fake_neuron.neurites = []
-        nt.assert_false(self.neuron._compare_neurites(fake_neuron, TreeType.axon))
+        nt.assert_false(self.neuron._compare_neurites(fake_neuron, NeuriteType.axon))
         nt.assert_true(fake_neuron, fake_neuron)
 
         neuron2 = deepcopy(self.neuron)

--- a/neurom/ezy/tests/test_population.py
+++ b/neurom/ezy/tests/test_population.py
@@ -33,7 +33,7 @@ from nose import tools as nt
 from itertools import izip
 from neurom.ezy import load_population
 from neurom.ezy.population import Population
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 
 _path = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_path, '../../../test_data')
@@ -60,8 +60,8 @@ class TestEzyPopulation(object):
         nrts_all = sum(len(neuron.neurites) for neuron in self.pop.neurons)
         nt.assert_equal(nrts_all, self.pop.get_n_neurites())
 
-        nrts_axons = sum(nrn.get_n_neurites(neurite_type=TreeType.axon) for nrn in self.pop.neurons)
-        nt.assert_equal(nrts_axons, self.pop.get_n_neurites(neurite_type=TreeType.axon))
+        nrts_axons = sum(nrn.get_n_neurites(neurite_type=NeuriteType.axon) for nrn in self.pop.neurons)
+        nt.assert_equal(nrts_axons, self.pop.get_n_neurites(neurite_type=NeuriteType.axon))
 
 
     def test_iter_neurites(self):

--- a/neurom/features/_impl.py
+++ b/neurom/features/_impl.py
@@ -30,7 +30,7 @@
 
 from functools import wraps
 from functools import partial
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from neurom.core.neuron import Neuron
 from neurom.analysis import morphtree as _mt
 from neurom.core.types import tree_type_checker as _ttc
@@ -47,10 +47,11 @@ from neurom.analysis.morphtree import trunk_origin_elevation, trunk_origin_azimu
 def feature_getter(mapfun):
     ''' Wrapper around already existing feature functions
     '''
-    def wrapped(neurites, neurite_type=TreeType.all):
+    def wrapped(neurites, neurite_type=NeuriteType.all):
         '''Extracts feature from an object with neurites, i.e. either neurite, neuron, or population
         '''
         return iter_neurites(neurites, mapfun, _ttc(neurite_type))
+
     return wrapped
 
 
@@ -58,9 +59,10 @@ def count(f):
     ''' Counts the output of the wrapper wrapper.
     '''
     @wraps(f)
-    def wrapped(neurites, neurite_type=TreeType.all):
+    def wrapped(neurites, neurite_type=NeuriteType.all):
         ''' placeholderg'''
         yield sum(1 for _ in f(neurites, neurite_type))
+
     return wrapped
 
 
@@ -68,9 +70,10 @@ def sum_feature(f):
     ''' Counts the output of the wrapper wrapper.
     '''
     @wraps(f)
-    def wrapped(neurites, neurite_type=TreeType.all):
+    def wrapped(neurites, neurite_type=NeuriteType.all):
         ''' yields the sum of the function'''
         yield sum(f(neurites, neurite_type))
+
     return wrapped
 
 
@@ -95,7 +98,7 @@ bifurcation_number = count(feature_getter(_bifs.identity))
 partition = feature_getter(_bifs.partition)
 
 
-def total_length_per_neurite(neurons, neurite_type=TreeType.all):
+def total_length_per_neurite(neurons, neurite_type=NeuriteType.all):
     '''Get an iterable with the total length of a neurite for a given neurite type'''
     return (sum(_sec.length(ss) for ss in isection(n))
             for n in iter_neurites(neurons, filt=_ttc(neurite_type)))
@@ -103,31 +106,32 @@ def total_length_per_neurite(neurons, neurite_type=TreeType.all):
 total_length = sum_feature(total_length_per_neurite)
 
 
-def neurite_number(neurons, neurite_type=TreeType.all):
+def neurite_number(neurons, neurite_type=NeuriteType.all):
     '''Get an iterable with the number of neurites for a given neurite type
     '''
     yield sum(1 for n in iter_neurites(neurons, filt=_ttc(neurite_type)))
 
 
-def number_of_sections_per_neurite(neurons, neurite_type=TreeType.all):
+def number_of_sections_per_neurite(neurons, neurite_type=NeuriteType.all):
     '''Get an iterable with the number of sections for a given neurite type'''
     return (_sec.count(n) for n in iter_neurites(neurons, filt=_ttc(neurite_type)))
 
 
-def section_path_distances(neurites, use_start_point=False, neurite_type=TreeType.all):
+def section_path_distances(neurites, use_start_point=False, neurite_type=NeuriteType.all):
     '''
     Get section path distances of all neurites of a given type
     The section path distance is measured to the neurite's root.
 
     Parameters:
         use_start_point: boolean\
-        if true, use the section's first point,\
-        otherwise use the end-point (default False)
-        neurite_type: TreeType\
-        Type of neurites to be considered (default all)
+            if true, use the section's first point,\
+            otherwise use the end-point (default False)
+        neurite_type: NeuriteType\
+            Type of neurites to be considered (default all)
 
     Returns:
         Iterable containing the section path distances.
+
     '''
     magic_iter = (_sec.start_point_path_length if use_start_point
                   else _sec.end_point_path_length)
@@ -135,16 +139,17 @@ def section_path_distances(neurites, use_start_point=False, neurite_type=TreeTyp
 
 
 def section_radial_distances(neurites, origin=None, use_start_point=False,
-                             neurite_type=TreeType.all):
+                             neurite_type=NeuriteType.all):
     '''Get an iterable containing section radial distances to origin of\
-       all neurites of a given type
+        all neurites of a given type
 
     Parameters:
         origin: Point wrt which radial dirtance is calulated\
-                (default tree root)
+            (default tree root)
         use_start_point: if true, use the section's first point,\
-                         otherwise use the end-point (default False)
+            otherwise use the end-point (default False)
         neurite_type: Type of neurites to be considered (default all)
+
     '''
     def f(n):
         '''neurite identity function'''
@@ -154,29 +159,30 @@ def section_radial_distances(neurites, origin=None, use_start_point=False,
     return iter_neurites(neurites, f, _ttc(neurite_type))
 
 
-def trunk_section_lengths(neurons, neurite_type=TreeType.all):
+def trunk_section_lengths(neurons, neurite_type=NeuriteType.all):
     '''Get the trunk section lengths of a given type in a neuron'''
     return (_mt.trunk_section_length(t)
             for t in iter_neurites(neurons, filt=_ttc(neurite_type)))
 
 
-def trunk_origin_radii(neurons, neurite_type=TreeType.all):
+def trunk_origin_radii(neurons, neurite_type=NeuriteType.all):
     '''Get the trunk origin radii of a given type in a neuron'''
     return (_pts.radius(t) for t in iter_neurites(neurons, filt=_ttc(neurite_type)))
 
 
-def principal_directions_extents(neurons, neurite_type=TreeType.all, direction='first'):
+def principal_directions_extents(neurons, neurite_type=NeuriteType.all, direction='first'):
     ''' Get principal direction extent of either a neurite or the total neurites
     from a neuron or a population.
 
     Parameters:
         direction: string \
-        it can be either 'first', 'second' or 'third' \
-        corresponding to the respective principal direction \
-        of the extent
+            it can be either 'first', 'second' or 'third' \
+            corresponding to the respective principal direction \
+            of the extent
 
     Returns:
         Iterator containing the extents of the input neurites
+
     '''
     n = 0 if direction == 'first' else (1 if direction == 'second' else 2)
     return (_mt.principal_direction_extent(t)[n]
@@ -215,7 +221,7 @@ def soma_surface_areas(neurons):
 
 
 @as_neuron_list
-def trunk_origin_azimuths(neurons, neurite_type=TreeType.all):
+def trunk_origin_azimuths(neurons, neurite_type=NeuriteType.all):
     '''Applies the trunk_origin_azimuth function on the soma and the neurites of each
     neuron.
     '''
@@ -226,7 +232,7 @@ def trunk_origin_azimuths(neurons, neurite_type=TreeType.all):
 
 
 @as_neuron_list
-def trunk_origin_elevations(neurons, neurite_type=TreeType.all):
+def trunk_origin_elevations(neurons, neurite_type=NeuriteType.all):
     '''Applies the trunk_origin_elevation function on the soma and the neurites of each neuron.
     '''
     for nrn in neurons:

--- a/neurom/features/tests/test_features.py
+++ b/neurom/features/tests/test_features.py
@@ -4,7 +4,7 @@ from nose import tools as nt
 import numpy as np
 from neurom.core.tree import Tree
 from neurom.core.neuron import make_soma
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 import neurom.sections as sec
 import neurom.segments as seg
 import neurom.bifurcations as bifs
@@ -33,66 +33,66 @@ def test_section_lengths():
     nt.assert_equal(len(seclen), 84)
     nt.assert_true(np.all(seclen == ref_seclen))
 
-    seclen = get_feat('section_lengths', NEURON, neurite_type=TreeType.all)
+    seclen = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.all)
     nt.assert_equal(len(seclen), 84)
     nt.assert_true(np.all(seclen == ref_seclen))
 
 
 def test_section_lengths_axon():
-    s = get_feat('section_lengths', NEURON, neurite_type=TreeType.axon)
+    s = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(s), 21)
 
 
 def test_total_lengths_basal():
-    s = get_feat('section_lengths', NEURON, neurite_type=TreeType.basal_dendrite)
+    s = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(s), 42)
 
 
 def test_section_lengths_apical():
-    s = get_feat('section_lengths', NEURON, neurite_type=TreeType.apical_dendrite)
+    s = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(s), 21)
 
 
 def test_total_length_per_neurite_axon():
-    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=TreeType.axon)
+    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(tl), 1)
     nt.assert_true(np.allclose(tl, (207.87975221)))
 
 
 def test_total_length_per_neurite_basal():
-    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=TreeType.basal_dendrite)
+    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(tl), 2)
     nt.assert_true(np.allclose(tl, (211.11737442, 207.31504202)))
 
 
 def test_total_length_per_neurite_apical():
-    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=TreeType.apical_dendrite)
+    tl = get_feat('total_length_per_neurite', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(tl), 1)
     nt.assert_true(np.allclose(tl, (214.37304578)))
 
 
 def test_total_length_axon():
-    tl = get_feat('total_length', NEURON, neurite_type=TreeType.axon)
+    tl = get_feat('total_length', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(tl), 1)
     nt.assert_true(np.allclose(tl, (207.87975221)))
 
 
 def test_total_length_basal():
-    tl = get_feat('total_length', NEURON, neurite_type=TreeType.basal_dendrite)
+    tl = get_feat('total_length', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(tl), 1)
     nt.assert_true(np.allclose(tl, (418.43241644)))
 
 
 def test_total_length_apical():
-    tl = get_feat('total_length', NEURON, neurite_type=TreeType.apical_dendrite)
+    tl = get_feat('total_length', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(tl), 1)
     nt.assert_true(np.allclose(tl, (214.37304578)))
 
 
 def test_section_lengths_invalid():
-    s = get_feat('section_lengths', NEURON, neurite_type=TreeType.soma)
+    s = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.soma)
     nt.assert_equal(len(s), 0)
-    s = get_feat('section_lengths', NEURON, neurite_type=TreeType.undefined)
+    s = get_feat('section_lengths', NEURON, neurite_type=NeuriteType.undefined)
     nt.assert_equal(len(s), 0)
 
 
@@ -115,7 +115,7 @@ def test_section_path_distances_start_point():
 
 
 def test_section_path_distances_axon():
-    path_lengths = get_feat('section_path_distances', NEURON, neurite_type=TreeType.axon)
+    path_lengths = get_feat('section_path_distances', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(path_lengths), 21)
 
 
@@ -125,7 +125,7 @@ def test_segment_lengths():
     nt.assert_equal(len(seglen), 840)
     nt.assert_true(np.all(seglen == ref_seglen))
 
-    seglen = get_feat('segment_lengths', NEURON, neurite_type=TreeType.all)
+    seglen = get_feat('segment_lengths', NEURON, neurite_type=NeuriteType.all)
     nt.assert_equal(len(seglen), 840)
     nt.assert_true(np.all(seglen == ref_seglen))
 
@@ -137,28 +137,28 @@ def test_local_bifurcation_angles():
     local_bifangles = get_feat('local_bifurcation_angles', NEURON)
     nt.assert_equal(len(local_bifangles), 40)
     nt.assert_true(np.all(local_bifangles == ref_local_bifangles))
-    local_bifangles = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.all)
+    local_bifangles = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.all)
     nt.assert_equal(len(local_bifangles), 40)
     nt.assert_true(np.all(local_bifangles == ref_local_bifangles))
 
 def test_local_bifurcation_angles_axon():
-    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.axon)
+    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(s), 10)
 
 def test_local_bifurcation_angles_basal():
-    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.basal_dendrite)
+    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(s), 20)
 
 
 def test_local_bifurcation_angles_apical():
-    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.apical_dendrite)
+    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(s), 10)
 
 
 def test_local_bifurcation_angles_invalid():
-    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.soma)
+    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.soma)
     nt.assert_equal(len(s), 0)
-    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=TreeType.undefined)
+    s = get_feat('local_bifurcation_angles', NEURON, neurite_type=NeuriteType.undefined)
     nt.assert_equal(len(s), 0)
 
 
@@ -167,30 +167,30 @@ def test_remote_bifurcation_angles():
     remote_bifangles = get_feat('remote_bifurcation_angles', NEURON)
     nt.assert_equal(len(remote_bifangles), 40)
     nt.assert_true(np.all(remote_bifangles == ref_remote_bifangles))
-    remote_bifangles = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.all)
+    remote_bifangles = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.all)
     nt.assert_equal(len(remote_bifangles), 40)
     nt.assert_true(np.all(remote_bifangles == ref_remote_bifangles))
 
 
 def test_remote_bifurcation_angles_axon():
-    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.axon)
+    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(s), 10)
 
 
 def test_remote_bifurcation_angles_basal():
-    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.basal_dendrite)
+    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(s), 20)
 
 
 def test_remote_bifurcation_angles_apical():
-    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.apical_dendrite)
+    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(s), 10)
 
 
 def test_remote_bifurcation_angles_invalid():
-    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.soma)
+    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.soma)
     nt.assert_equal(len(s), 0)
-    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=TreeType.undefined)
+    s = get_feat('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.undefined)
     nt.assert_equal(len(s), 0)
 
 
@@ -222,30 +222,30 @@ def test_section_radial_distances_start_point():
 
 
 def test_section_radial_axon():
-    rad_dists = get_feat('section_radial_distances', NEURON, neurite_type=TreeType.axon)
+    rad_dists = get_feat('section_radial_distances', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(rad_dists), 21)
 
 
 def test_number_of_sections_all():
     nt.assert_equal(get_feat('number_of_sections', NEURON)[0], 84)
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.all)[0], 84)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.all)[0], 84)
 
 
 def test_number_of_sections_axon():
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.axon)[0], 21)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.axon)[0], 21)
 
 
 def test_number_of_sections_basal():
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.basal_dendrite)[0], 42)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.basal_dendrite)[0], 42)
 
 
 def test_n_sections_apical():
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.apical_dendrite)[0], 21)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.apical_dendrite)[0], 21)
 
 
 def test_seciton_number_invalid():
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.soma)[0], 0)
-    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=TreeType.undefined)[0], 0)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.soma)[0], 0)
+    nt.assert_equal(get_feat('number_of_sections', NEURON, neurite_type=NeuriteType.undefined)[0], 0)
 
 
 def test_per_neurite_number_of_sections():
@@ -255,31 +255,31 @@ def test_per_neurite_number_of_sections():
 
 
 def test_per_neurite_number_of_sections_axon():
-    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=TreeType.axon)
+    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=NeuriteType.axon)
     nt.assert_equal(len(nsecs), 1)
     nt.assert_equal(nsecs, [21])
 
 
 def test_n_sections_per_neurite_basal():
-    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=TreeType.basal_dendrite)
+    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=NeuriteType.basal_dendrite)
     nt.assert_equal(len(nsecs), 2)
     nt.assert_true(np.all(nsecs == [21, 21]))
 
 
 def test_n_sections_per_neurite_apical():
-    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=TreeType.apical_dendrite)
+    nsecs = get_feat('number_of_sections_per_neurite', NEURON, neurite_type=NeuriteType.apical_dendrite)
     nt.assert_equal(len(nsecs), 1)
     nt.assert_true(np.all(nsecs == [21]))
 
 
 def test_neurite_number():
     nt.assert_equal(get_feat('number_of_neurites', NEURON)[0], 4)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.all)[0], 4)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.axon)[0], 1)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.basal_dendrite)[0], 2)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.apical_dendrite)[0], 1)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.soma)[0], 0)
-    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=TreeType.undefined)[0], 0)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.all)[0], 4)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.axon)[0], 1)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.basal_dendrite)[0], 2)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.apical_dendrite)[0], 1)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.soma)[0], 0)
+    nt.assert_equal(get_feat('number_of_neurites', NEURON, neurite_type=NeuriteType.undefined)[0], 0)
 
 
 def test_trunk_origin_radii():
@@ -289,32 +289,32 @@ def test_trunk_origin_radii():
                            0.66943255462899998,
                            0.14656092843999999])
 
-    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, TreeType.apical_dendrite),
+    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, NeuriteType.apical_dendrite),
                           [0.14656092843999999])
-    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, TreeType.basal_dendrite),
+    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, NeuriteType.basal_dendrite),
                           [0.18391483031299999,
                            0.66943255462899998])
-    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, TreeType.axon),
+    nt.assert_items_equal(get_feat('trunk_origin_radii', NEURON, NeuriteType.axon),
                           [0.85351288499400002])
 
 
 def test_get_trunk_section_lengths():
     nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON), [9.579117366740002,
-                                                                7.972322416776259,
-                                                                8.2245287740603779,
-                                                                9.212707985134525])
-    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, TreeType.apical_dendrite),
+                                                                      7.972322416776259,
+                                                                      8.2245287740603779,
+                                                                      9.212707985134525])
+    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, NeuriteType.apical_dendrite),
                           [9.212707985134525])
-    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, TreeType.basal_dendrite),
+    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, NeuriteType.basal_dendrite),
                           [7.972322416776259, 8.2245287740603779])
-    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, TreeType.axon), [9.579117366740002])
+    nt.assert_items_equal(get_feat('trunk_section_lengths', NEURON, NeuriteType.axon), [9.579117366740002])
 
 
 def test_principal_directions_extents():
     points = np.array([[-10., 0., 0.],
-                    [-9., 0., 0.],
-                    [9., 0., 0.],
-                    [10., 0., 0.]])
+                       [-9., 0., 0.],
+                       [9., 0., 0.],
+                       [10., 0., 0.]])
 
     tree = Tree(np.array([points[0][0], points[0][1], points[0][2], 1., 0., 0.]))
     tree.add_child(Tree(np.array([points[1][0], points[1][1], points[1][2], 1., 0., 0.])))
@@ -344,21 +344,21 @@ def test_trunk_origin_elevations():
 
     s = make_soma([[0, 0, 0, 4]])
     t0 = Tree((1, 0, 0, 2))
-    t0.type = TreeType.basal_dendrite
+    t0.type = NeuriteType.basal_dendrite
     t1 = Tree((0, 1, 0, 2))
-    t1.type = TreeType.basal_dendrite
+    t1.type = NeuriteType.basal_dendrite
     n0.neurites = [t0, t1]
     n0.soma = s
 
     t2 = Tree((0, -1, 0, 2))
-    t2.type = TreeType.basal_dendrite
+    t2.type = NeuriteType.basal_dendrite
     n1.neurites = [t2]
     n1.soma = s
 
     pop = [n0, n1]
     nt.assert_true(np.all(get_feat('trunk_origin_elevations', pop) ==
                           [0.0, np.pi/2., -np.pi/2.]))
-    nt.eq_(len(get_feat('trunk_origin_elevations', pop, neurite_type=TreeType.axon)), 0)
+    nt.eq_(len(get_feat('trunk_origin_elevations', pop, neurite_type=NeuriteType.axon)), 0)
 
 def test_trunk_origin_azimuths():
     n0 = MockNeuron()
@@ -369,7 +369,7 @@ def test_trunk_origin_azimuths():
     n5 = MockNeuron()
 
     t = Tree((0, 0, 0, 2))
-    t.type = TreeType.basal_dendrite
+    t.type = NeuriteType.basal_dendrite
     n0.neurites = [t]
     n1.neurites = [t]
     n2.neurites = [t]
@@ -392,4 +392,4 @@ def test_trunk_origin_azimuths():
     pop[5].soma = s5
     nt.assert_true(np.all(get_feat('trunk_origin_azimuths', pop) ==
                           [-np.pi/2., np.pi/2., 0.0, np.pi/4., 0.0, np.pi]))
-    nt.eq_(len(get_feat('trunk_origin_azimuths', pop, neurite_type=TreeType.axon)), 0)
+    nt.eq_(len(get_feat('trunk_origin_azimuths', pop, neurite_type=NeuriteType.axon)), 0)

--- a/neurom/geom/transform.py
+++ b/neurom/geom/transform.py
@@ -90,7 +90,7 @@ def translate(obj, t):
     Input :
 
         obj : object with one of the following types:
-             'TreeType', 'Neuron', 'ezyNeuron'
+             'NeuriteType', 'Neuron', 'ezyNeuron'
 
     Returns: copy of the object with the applied translation
     '''

--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -30,7 +30,7 @@
 Module containing the common functionality
 to be used by view-plot modules.
 """
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 import os
 import matplotlib
 
@@ -45,11 +45,11 @@ from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=unused-import
 
 
 # Map tree type to color
-TREE_COLOR = {TreeType.basal_dendrite: 'red',
-              TreeType.apical_dendrite: 'purple',
-              TreeType.axon: 'blue',
-              TreeType.soma: 'black',
-              TreeType.undefined: 'green'}
+TREE_COLOR = {NeuriteType.basal_dendrite: 'red',
+              NeuriteType.apical_dendrite: 'purple',
+              NeuriteType.axon: 'blue',
+              NeuriteType.soma: 'black',
+              NeuriteType.undefined: 'green'}
 
 
 def figure_naming(pretitle=None, posttitle=None, prefile=None, postfile=None):

--- a/neurom/view/tests/test_common.py
+++ b/neurom/view/tests/test_common.py
@@ -39,7 +39,7 @@ from neurom.view.common import plot_limits
 from neurom.view.common import plot_ticks
 from neurom.view.common import plot_sphere
 from neurom.view.common import get_color
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 
 import os
 import numpy as np
@@ -191,14 +191,14 @@ def test_plot_style():
     os.rmdir(fig_dir)
 
 def test_get_color():
-    nt.ok_(get_color(None, TreeType.basal_dendrite) == "red")
-    nt.ok_(get_color(None, TreeType.axon) == "blue")
-    nt.ok_(get_color(None, TreeType.apical_dendrite) == "purple")
-    nt.ok_(get_color(None, TreeType.soma) == "black")
-    nt.ok_(get_color(None, TreeType.undefined) == "green")
+    nt.ok_(get_color(None, NeuriteType.basal_dendrite) == "red")
+    nt.ok_(get_color(None, NeuriteType.axon) == "blue")
+    nt.ok_(get_color(None, NeuriteType.apical_dendrite) == "purple")
+    nt.ok_(get_color(None, NeuriteType.soma) == "black")
+    nt.ok_(get_color(None, NeuriteType.undefined) == "green")
     nt.ok_(get_color(None, 'wrong') == "green")
     nt.ok_(get_color('blue', 'wrong') == "blue")
-    nt.ok_(get_color('yellow', TreeType.axon) == "yellow")
+    nt.ok_(get_color('yellow', NeuriteType.axon) == "yellow")
 
 def test_plot_sphere():
     fig0, ax0 = get_figure(params={'projection':'3d'})

--- a/neurom/view/view.py
+++ b/neurom/view/view.py
@@ -32,7 +32,7 @@ Python module of NeuroM to visualize morphologies
 
 from itertools import izip
 from neurom.view import common
-from neurom.core.types import TreeType
+from neurom.core.types import NeuriteType
 from matplotlib.collections import LineCollection
 import numpy as np
 from neurom.core.tree import isegment
@@ -225,7 +225,7 @@ def soma(sm, plane='xy', new_fig=True, subplot=False, **kwargs):
     fig, ax = common.get_figure(new_fig=new_fig, subplot=subplot)
 
     # Definition of the tree color depending on the tree type.
-    treecolor = common.get_color(treecolor, tree_type=TreeType.soma)
+    treecolor = common.get_color(treecolor, tree_type=NeuriteType.soma)
 
     # Plot the outline of the soma as a circle, is outline is selected.
     if not outline:
@@ -500,7 +500,7 @@ def soma3d(sm, new_fig=True, new_axes=True, subplot=False, **kwargs):
                                 subplot=subplot, params={'projection': '3d'})
 
     # Definition of the tree color depending on the tree type.
-    treecolor = common.get_color(treecolor, tree_type=TreeType.soma)
+    treecolor = common.get_color(treecolor, tree_type=NeuriteType.soma)
 
     xs = sm.center[0]
     ys = sm.center[1]
@@ -613,7 +613,7 @@ def neuron3d(nrn, new_fig=True, new_axes=True, subplot=False, **kwargs):
 def _format_str(string):
     ''' String formatting
     '''
-    return string.replace('TreeType.', '').replace('_', ' ').capitalize()
+    return string.replace('NeuriteType.', '').replace('_', ' ').capitalize()
 
 
 def _generate_collection(group, ax, ctype, colors):
@@ -663,7 +663,7 @@ def _render_dendrogram(dnd, ax, displacement):
 
     if soma_square is not None:
 
-        _generate_collection((soma_square + (displacement / 2., 0.),), ax, TreeType.soma, colors)
+        _generate_collection((soma_square + (displacement / 2., 0.),), ax, NeuriteType.soma, colors)
         ax.plot((displacement / 2., displacement), (0., 0.), color='k')
         ax.plot((0., displacement / 2.), (0., 0.), color='k')
 


### PR DESCRIPTION
* TreeType renamed to NeuriteType. Alias ezy.TreeType kept for
  backwards compatibility.
* neurom.geatures.get_feature added to neurom.ezy module.
* Documentation examples updated.
* Examples updated.