### PR TITLE
Iteration and path length optimizations.

### DIFF
--- a/neurom/analysis/morphmath.py
+++ b/neurom/analysis/morphmath.py
@@ -177,7 +177,7 @@ def point_dist(p1, p2):
     Returns:
         The euclidian distance between the points.
     '''
-    return np.linalg.norm(vector(p1, p2))
+    return np.sqrt(point_dist2(p1, p2))
 
 
 def angle_3points(p0, p1, p2):
@@ -226,6 +226,14 @@ def segment_length(seg):
     Returns: Euclidian distance between centres of points in seg
     '''
     return point_dist(seg[0], seg[1])
+
+
+def segment_length2(seg):
+    '''Return the square of the length of a segment.
+
+    Returns: Square of Euclidian distance between centres of points in seg
+    '''
+    return point_dist2(seg[0], seg[1])
 
 
 def segment_radius(seg):

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -122,8 +122,7 @@ def find_tree_type(tree):
 
     tree_types = tuple(NeuriteType)
 
-    types = [node[COLS.TYPE] for node in tr.val_iter(tr.ipreorder(tree))]
-    types = [node[COLS.TYPE] for node in tr.val_iter(tr.ipreorder(tree))]
+    types = np.array([node.value[COLS.TYPE] for node in tr.ipreorder(tree)])
 
     return tree_types[int(np.median(types))]
 

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -44,8 +44,13 @@ import numpy as np
 
 def path_length(tree):
     '''Get the path length from a sub-tree to the root node'''
-    return np.sum(s for s in
-                  tr.imap_val(mm.segment_length, tr.isegment(tree, tr.iupstream)))
+    t = tree
+    l = 0
+    while t.parent is not None:
+        l += mm.segment_length((t.parent.value, t.value))
+        t = t.parent
+
+    return l
 
 
 def local_bifurcation_angle(bifurcation_point):

--- a/neurom/analysis/morphtree.py
+++ b/neurom/analysis/morphtree.py
@@ -45,12 +45,12 @@ import numpy as np
 def path_length(tree):
     '''Get the path length from a sub-tree to the root node'''
     t = tree
-    l = 0
+    l2 = []
     while t.parent is not None:
-        l += mm.segment_length((t.parent.value, t.value))
+        l2.append(mm.segment_length2((t.parent.value, t.value)))
         t = t.parent
 
-    return l
+    return np.sum(np.sqrt(l2))
 
 
 def local_bifurcation_angle(bifurcation_point):

--- a/neurom/analysis/tests/test_morphmath.py
+++ b/neurom/analysis/tests/test_morphmath.py
@@ -97,7 +97,7 @@ def test_path_fraction_three_symmetric_points():
               np.array((0., 0., 1.))]
 
     res = mm.path_fraction_point(points, 0.0)
-    nt.assert_true(np.allclose(res, (1., 0., 0.)))          
+    nt.assert_true(np.allclose(res, (1., 0., 0.)))
 
     res = mm.path_fraction_point(points, 0.25)
     nt.assert_true(np.allclose(res, (0.5, 0., 0.)))
@@ -115,7 +115,7 @@ def test_path_fraction_many_points():
     x = lambda theta: np.cos(theta)
     y = lambda theta: np.sin(theta)
     points = [np.array((x(theta), y(theta), 2.)) for theta in (0., np.pi/4., np.pi/2., 3.*np.pi/4., np.pi)]
-    
+
     res = mm.path_fraction_point(points, 0.)
     nt.assert_true(np.allclose(res, (x(0.), y(0.), 2.)))
 

--- a/neurom/bifurcations.py
+++ b/neurom/bifurcations.py
@@ -52,7 +52,7 @@ def bifurcation_point_function(as_tree=False):
         def _wrapper(bifurcation_point):
             '''Simply pass arguments to wrapped function'''
             if not as_tree:
-                bifurcation_point = tr.as_elements(bifurcation_point)
+                bifurcation_point = bifurcation_point.value
             return fun(bifurcation_point)
 
         _wrapper.iter_type = tr.ibifurcation_point

--- a/neurom/io/hdf5.py
+++ b/neurom/io/hdf5.py
@@ -183,9 +183,10 @@ class H5(object):
 
         '''
 
-        def _find_last_point(group_id, groups):
+        group_initial_ids = groups[:, 0]
+
+        def _find_last_point(group_id):
             ''' Identifies and returns the id of the last point of a group'''
-            group_initial_ids = np.sort(np.transpose(groups)[0])
 
             if group_id != len(group_initial_ids) - 1:
                 return group_initial_ids[np.where(group_initial_ids ==
@@ -196,7 +197,7 @@ class H5(object):
 
         for ig, g in enumerate(groups):
             if g[2] != -1 and np.allclose(points[g[0]],
-                                          points[_find_last_point(g[2], groups)]):
+                                          points[_find_last_point(g[2])]):
                 # Remove duplicate from list of points
                 to_be_removed.append(g[0])
                 # Reduce the id of the following sections

--- a/neurom/io/hdf5.py
+++ b/neurom/io/hdf5.py
@@ -201,7 +201,7 @@ class H5(object):
                 to_be_removed.append(g[0])
                 # Reduce the id of the following sections
                 # in groups structure by one
-                for igg in range(ig + 1, len(groups)):
+                for igg in xrange(ig + 1, len(groups)):
                     to_be_reduced[igg] = to_be_reduced[igg] + 1
 
         groups = np.array([np.subtract(i, [j, 0, 0])

--- a/neurom/points.py
+++ b/neurom/points.py
@@ -51,7 +51,7 @@ def point_function(as_tree=False):
         def _wrapper(point):
             '''Simply pass arguments to wrapped function'''
             if not as_tree:
-                point = tr.as_elements(point)
+                point = point.value
             return fun(point)
 
         _wrapper.iter_type = tr.ipreorder

--- a/neurom/sections.py
+++ b/neurom/sections.py
@@ -53,7 +53,7 @@ def section_function(as_tree=False):
         def _wrapper(section):
             '''Simply pass arguments to wrapped function'''
             if not as_tree:
-                section = tr.as_elements(section)
+                section = tuple(t.value for t in section)
             return fun(section)
 
         _wrapper.iter_type = tr.isection

--- a/neurom/segments.py
+++ b/neurom/segments.py
@@ -52,7 +52,7 @@ def segment_function(as_tree=False):
         def _wrapper(segment):
             '''Simply pass arguments to wrapped function'''
             if not as_tree:
-                segment = tr.as_elements(segment)
+                segment = (segment[0].value, segment[-1].value)
             return fun(segment)
 
         _wrapper.iter_type = tr.isegment
@@ -62,6 +62,7 @@ def segment_function(as_tree=False):
 
 
 length = segment_function(as_tree=False)(mm.segment_length)
+length2 = segment_function(as_tree=False)(mm.segment_length2)
 radius = segment_function(as_tree=False)(mm.segment_radius)
 volume = segment_function(as_tree=False)(mm.segment_volume)
 area = segment_function(as_tree=False)(mm.segment_area)

--- a/neurom/tests/test_segments.py
+++ b/neurom/tests/test_segments.py
@@ -120,6 +120,13 @@ def _check_segment_lengths(obj):
     nt.eq_(lg, [1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 2.0, 1.0, 1.0])
 
 
+def _check_segment_lengths2(obj):
+
+    lg = [l for l in iter_neurites(obj, seg.length2)]
+
+    nt.eq_(lg, [1.0, 1.0, 4.0, 1.0, 4.0, 1.0, 1.0, 4.0, 1.0, 1.0])
+
+
 def _check_segment_volumes(obj):
 
     sv = (l/math.pi for l in iter_neurites(obj, seg.volume))
@@ -203,6 +210,11 @@ def test_segment_volumes():
 def test_segment_lengths():
     _check_segment_lengths(NEURON)
     _check_segment_lengths(NEURON_TREE)
+
+
+def test_segment_lengths2():
+    _check_segment_lengths2(NEURON)
+    _check_segment_lengths2(NEURON_TREE)
 
 
 def test_segment_areas():

--- a/neurom/triplets.py
+++ b/neurom/triplets.py
@@ -51,7 +51,7 @@ def triplet_function(as_tree=False):
         def _wrapper(triplet):
             '''Simply pass arguments to wrapped function'''
             if not as_tree:
-                triplet = tr.as_elements(triplet)
+                triplet = (triplet[0].value, triplet[1].value, triplet[2].value)
             return fun(triplet)
 
         _wrapper.iter_type = tr.itriplet


### PR DESCRIPTION
* Convert points, segments, sections, bifurcations and triplets
  to value representation manually instead of calling as_elements.
* Use numpy.sqrt instead of numpy.linalg.norm to calculate distance
  between points.
* Add segment length squared function.
* Re-implement morphtree.path_length with a loop instead of using
  sum over complex iterator expression.