### PR TITLE
Simplify h5 duplicate removal.

### DIFF
--- a/neurom/io/hdf5.py
+++ b/neurom/io/hdf5.py
@@ -185,19 +185,18 @@ class H5(object):
         group_initial_ids = groups[:, 0]
         group_len = len(group_initial_ids)
 
-        def _find_last_point(group_id):
-            ''' Identifies and returns the id of the last point of a group'''
-            return group_initial_ids[group_id + 1] - 1
-
         to_be_reduced = np.zeros(group_len)
         to_be_removed = []
 
         # This is the slow part
+        # groups: (GPFIRST, GTYPE, GPID) -> [FIRST_POINT_ID, TYPE, PARENT_GROUP_ID]
         for ig, g in enumerate(groups):
-            if g[2] != -1 and np.allclose(points[g[0]],
-                                          points[_find_last_point(g[2])]):
+            iid, typ, pid = g[_H5STRUCT.GPFIRST], g[_H5STRUCT.GTYPE], g[_H5STRUCT.GPID]
+            # Remove first point from sections that are
+            # not the root section, a soma, or a child of a soma
+            if pid != -1 and typ != 1 and groups[pid][_H5STRUCT.GTYPE] != 1:
                 # Remove duplicate from list of points
-                to_be_removed.append(g[0])
+                to_be_removed.append(iid)
                 # Reduce the id of the following sections
                 # in groups structure by one
                 to_be_reduced[ig + 1:] += 1

--- a/neurom/io/hdf5.py
+++ b/neurom/io/hdf5.py
@@ -42,7 +42,7 @@ There is one such row per measured point.
 '''
 import h5py
 import numpy as np
-from itertools import izip, izip_longest
+from itertools import izip_longest
 from ..core.dataformat import COLS
 
 
@@ -182,14 +182,11 @@ class H5(object):
 
         '''
 
-        group_initial_ids = groups[:, 0]
-        group_len = len(group_initial_ids)
+        group_initial_ids = groups[:, _H5STRUCT.GPFIRST]
 
-        to_be_reduced = np.zeros(group_len)
+        to_be_reduced = np.zeros(len(group_initial_ids))
         to_be_removed = []
 
-        # This is the slow part
-        # groups: (GPFIRST, GTYPE, GPID) -> [FIRST_POINT_ID, TYPE, PARENT_GROUP_ID]
         for ig, g in enumerate(groups):
             iid, typ, pid = g[_H5STRUCT.GPFIRST], g[_H5STRUCT.GTYPE], g[_H5STRUCT.GPID]
             # Remove first point from sections that are
@@ -201,10 +198,9 @@ class H5(object):
                 # in groups structure by one
                 to_be_reduced[ig + 1:] += 1
 
-        groups = np.array([np.subtract(i, [j, 0, 0])
-                           for i, j in izip(groups, to_be_reduced)])
-
+        groups[:, _H5STRUCT.GPFIRST] = groups[:, _H5STRUCT.GPFIRST] - to_be_reduced
         points = np.delete(points, to_be_removed, axis=0)
+
         return points, groups
 
 

--- a/neurom/io/readers.py
+++ b/neurom/io/readers.py
@@ -124,8 +124,12 @@ class RawDataWrapper(object):
         self.data_block, self.fmt = raw_data
         self.adj_list = defaultdict(list)
         self._id_map = {}
+        # this loop takes all the time in the world
         for i, row in enumerate(self.data_block):
+            # and building this adjacency list takes most of that.
             self.adj_list[int(row[COLS.P])].append(int(row[COLS.ID]))
+            # TODO: This is only needed for SWC. Re-factor so
+            # that is isn't run when using H5
             self._id_map[int(row[COLS.ID])] = i
         self._ids = np.array(self.data_block[:, COLS.ID],
                              dtype=np.int32).tolist()


### PR DESCRIPTION
* Following tightening in HDF5 format specification, duplicate removal can be simplified to always remove first point of non-root, non soma sections.
* Small improvement in duplicate removal implementation by using vectorization.