### PR TITLE
Re-factor and extend section unpacking code.

### DIFF
--- a/examples/section_tree_swc.py
+++ b/examples/section_tree_swc.py
@@ -1,26 +1,6 @@
 '''Example showing how to extract section information from SWC block'''
 from neurom import ezy
-from neurom.io import swc
 from neurom.core import section_neuron as sn
-from neurom.core.dataformat import COLS
-from neurom.core.dataformat import POINT_TYPE
-
-
-def remove_soma_initial_point(tree, post_action=sn.set_neurite_type):
-    '''Remove tree's initial point if soma and apply post_action'''
-    if tree.value[0][COLS.TYPE] == POINT_TYPE.SOMA:
-        tree.value = tree.value[1:]
-
-    if post_action is not None:
-        post_action(tree)
-
-
-def load_neuron(filename, tree_action=remove_soma_initial_point):
-    '''Build section trees from an swc file'''
-    rdw = swc.SWC.read(filename, sn.SecDataWrapper)
-    trees = sn.make_trees(rdw, tree_action)
-    soma = sn.make_soma(rdw.soma_points())
-    return sn.Neuron(soma, trees, rdw)
 
 
 def do_new_stuff(filename):
@@ -65,6 +45,7 @@ def do_old_stuff(filename):
     print '\nneurite types:'
     for n in _n.neurites:
         print n.type
+
 
 if __name__ == '__main__':
 

--- a/examples/section_tree_swc.py
+++ b/examples/section_tree_swc.py
@@ -1,116 +1,31 @@
 '''Example showing how to extract section information from SWC block'''
-import numpy as np
 from neurom import ezy
 from neurom.io import swc
-from neurom.core.tree import Tree
 from neurom.core import section_neuron as sn
 from neurom.core.dataformat import COLS
 from neurom.core.dataformat import POINT_TYPE
 
 
-class Section(object):
-    '''sections (id, (ids), type, parent_id)'''
-    def __init__(self, idx, ids=None, ntype=0, pid=-1):
-        self.id = idx
-        self.ids = [] if ids is None else ids
-        self.ntype = ntype
-        self.pid = pid
+def remove_soma_initial_point(tree, post_action=sn.set_neurite_type):
+    '''Remove tree's initial point if soma and apply post_action'''
+    if tree.value[0][COLS.TYPE] == POINT_TYPE.SOMA:
+        tree.value = tree.value[1:]
 
-    def __str__(self):
-        return 'Section(id=%s, ids=%s, ntype=%s, pid=%s)' % (self.id, self.ids,
-                                                             self.ntype, self.pid)
+    if post_action is not None:
+        post_action(tree)
 
 
-def neurite_trunks(data_wrapper):
-    '''Get the section IDs of the intitial neurite sections'''
-    sec = data_wrapper.sections
-    return [ss.id for ss in sec
-            if ss.pid is not None and (sec[ss.pid].ntype == POINT_TYPE.SOMA and
-                                       ss.ntype != POINT_TYPE.SOMA)]
-
-
-def soma_points(data_wrapper):
-    '''Get the soma points'''
-    db = data_wrapper.data_block
-    return db[db[:, COLS.TYPE] == POINT_TYPE.SOMA]
-
-
-def add_sections(data_wrapper):
-    '''Make a list of sections from an SWC data wrapper'''
-
-    # get SWC ID to array position map
-    id_map = {-1: -1}
-    for i, r in enumerate(data_wrapper.data_block):
-        id_map[int(r[COLS.ID])] = i
-
-    fork_points = set(id_map[p] for p in data_wrapper.get_fork_points())
-    end_points = set(id_map[p] for p in data_wrapper.get_end_points())
-    section_end_points = fork_points | end_points
-
-    _sections = [Section(0)]
-    curr_section = _sections[-1]
-    parent_section = {-1: None}
-
-    for row in data_wrapper.data_block:
-        row_id = id_map[int(row[COLS.ID])]
-        if len(curr_section.ids) == 0:
-            curr_section.ids.append(id_map[int(row[COLS.P])])
-            curr_section.ntype = int(row[COLS.TYPE])
-        curr_section.ids.append(row_id)
-        if row_id in section_end_points:
-            parent_section[curr_section.ids[-1]] = curr_section.id
-            _sections.append(Section(len(_sections)))
-            curr_section = _sections[-1]
-
-    # get the section parent ID from the id of the first point.
-    for sec in _sections:
-        if sec.ids:
-            sec.pid = parent_section[sec.ids[0]]
-
-    data_wrapper.sections = [s for s in _sections if s.ids]
-    return data_wrapper
-
-
-def make_trees(data_wrapper, post_action=None):
-    '''Build a section tree'''
-    trunks = neurite_trunks(data_wrapper)
-    start_node = min(trunks)
-    # One pass over sections to build nodes
-    nodes = [Tree(np.array(data_wrapper.data_block[sec.ids]))
-             for sec in data_wrapper.sections[start_node:]]
-
-    # One pass over nodes to connect children to parents
-    for i in xrange(len(nodes)):
-        parent_id = data_wrapper.sections[i + start_node].pid - start_node
-        if parent_id >= 0:
-            nodes[parent_id].add_child(nodes[i])
-
-    head_nodes = [nodes[i - start_node] for i in trunks]
-
-    for t in head_nodes:
-        # if any neurite trunk starting points are soma,
-        # remove them
-        if t.value[0][COLS.TYPE] == POINT_TYPE.SOMA:
-            t.value = t.value[1:]
-
-        if post_action is not None:
-            post_action(t)
-
-    return head_nodes
-
-
-def load_neuron(filename, tree_action=sn.set_neurite_type):
-    '''Build section trees from an h5 file'''
-    data_wrapper = swc.SWC.read(filename)
-    add_sections(data_wrapper)
-    trees = make_trees(data_wrapper, tree_action)
-    soma = sn.make_soma(soma_points(data_wrapper))
-    return sn.Neuron(soma, trees, data_wrapper)
+def load_neuron(filename, tree_action=remove_soma_initial_point):
+    '''Build section trees from an swc file'''
+    rdw = swc.SWC.read(filename, sn.SecDataWrapper)
+    trees = sn.make_trees(rdw, tree_action)
+    soma = sn.make_soma(rdw.soma_points())
+    return sn.Neuron(soma, trees, rdw)
 
 
 def do_new_stuff(filename):
     '''Use the section trees to get some basic stats'''
-    _n = load_neuron(filename)
+    _n = sn.load_neuron(filename)
 
     for nt in (sn.NeuriteType.axon,
                sn.NeuriteType.basal_dendrite,
@@ -155,4 +70,4 @@ if __name__ == '__main__':
 
     fname = 'test_data/swc/Neuron.swc'
 
-    nrn = load_neuron(fname)
+    nrn = sn.load_neuron(fname)

--- a/neurom/core/section_neuron.py
+++ b/neurom/core/section_neuron.py
@@ -29,9 +29,11 @@
 '''Section tree module'''
 
 import math
-from collections import namedtuple
+import os
+from collections import namedtuple, defaultdict
 import numpy as np
 from neurom.io.hdf5 import H5
+from neurom.io.swc import SWC
 from neurom.core.types import NeuriteType
 from neurom.core.tree import Tree, ipreorder, ibifurcation_point
 from neurom.core.types import tree_type_checker as is_type
@@ -42,29 +44,24 @@ from neurom.core.neuron import make_soma
 from neurom.analysis import morphmath as mm
 
 
-class SEC(object):
-    '''Enum class with section content indices'''
-    (START, END, TYPE, ID, PID) = xrange(5)
-
-
 Neuron = namedtuple('Neuron', 'soma, neurites, data_block')
 
 
 class SecDataWrapper(object):
     '''Class holding a raw data block and section information'''
 
-    def __init__(self, data_block, fmt, sections):
+    def __init__(self, data_block, fmt, sections=None):
         '''Section Data Wrapper'''
         self.data_block = data_block
         self.fmt = fmt
-        self.sections = sections
+        self.sections = sections if sections is not None else extract_sections(data_block)
 
     def neurite_trunks(self):
         '''Get the section IDs of the intitial neurite sections'''
         sec = self.sections
-        return [ss[SEC.ID] for ss in sec
-                if sec[ss[SEC.PID]][SEC.TYPE] == POINT_TYPE.SOMA and
-                ss[SEC.TYPE] != POINT_TYPE.SOMA]
+        return [i for i, ss in enumerate(sec)
+                if ss.pid > -1 and (sec[ss.pid].ntype == POINT_TYPE.SOMA and
+                                    ss.ntype != POINT_TYPE.SOMA)]
 
     def soma_points(self):
         '''Get the soma points'''
@@ -84,12 +81,11 @@ def make_trees(rdw, post_action=None):
     trunks = rdw.neurite_trunks()
     start_node = min(trunks)
     # One pass over sections to build nodes
-    nodes = [Tree(rdw.data_block[sec[SEC.START]: sec[SEC.END]])
-             for sec in rdw.sections[start_node:]]
+    nodes = [Tree(rdw.data_block[sec.ids]) for sec in rdw.sections[start_node:]]
 
     # One pass over nodes to connect children to parents
     for i in xrange(len(nodes)):
-        parent_id = rdw.sections[i + start_node][SEC.PID] - start_node
+        parent_id = rdw.sections[i + start_node].pid - start_node
         if parent_id >= 0:
             nodes[parent_id].add_child(nodes[i])
 
@@ -103,9 +99,18 @@ def make_trees(rdw, post_action=None):
 
 
 def load_neuron(filename, tree_action=set_neurite_type):
-    '''Build section trees from an h5 file'''
-    rdw = H5.read(filename, remove_duplicates=False, wrapper=SecDataWrapper)
-    trees = make_trees(rdw, tree_action)
+    '''Build section trees from an h5 or swc file'''
+    _READERS = {
+        'swc': lambda f: SWC.read(f, wrapper=SecDataWrapper),
+        'h5': lambda f: H5.read(f, remove_duplicates=False, wrapper=SecDataWrapper)
+    }
+    _NEURITE_ACTION = {
+        'swc': lambda t: remove_soma_initial_point(t, tree_action),
+        'h5': tree_action
+    }
+    ext = os.path.splitext(filename)[1][1:]
+    rdw = _READERS[ext.lower()](filename)
+    trees = make_trees(rdw, _NEURITE_ACTION[ext.lower()])
     soma = make_soma(rdw.soma_points())
     return Neuron(soma, trees, rdw)
 
@@ -262,3 +267,65 @@ def remote_bifurcation_angle(bif_point):
     return mm.angle_3points(bif_point.value[-1],
                             bif_point.children[0].value[-1],
                             bif_point.children[1].value[-1])
+
+
+def extract_sections(data_block):
+    '''Make a list of sections from an SWC-style data wrapper block'''
+
+    class Section(object):
+        '''sections ((ids), type, parent_id)'''
+        def __init__(self, ids=None, ntype=0, pid=-1):
+            self.ids = [] if ids is None else ids
+            self.ntype = ntype
+            self.pid = pid
+
+    # get SWC ID to array position map
+    id_map = {-1: -1}
+    for i, r in enumerate(data_block):
+        id_map[int(r[COLS.ID])] = i
+
+    # parent-children adjacency list
+    adj_list = defaultdict(list)
+    for row in data_block:
+        adj_list[int(row[COLS.P])].append(int(row[COLS.ID]))
+
+    def _section_end_points():
+        '''Get IDs of the end points of all sections'''
+        end_points = [int(i) for i in
+                      set(data_block[:, COLS.ID]) - set(adj_list.keys())]
+        end_points = set(id_map[p] for p in end_points)
+        fork_points = [i for i, l in adj_list.iteritems() if len(l) > 1]
+        fork_points = set(id_map[p] for p in fork_points)
+
+        return fork_points | end_points
+
+    _sections = [Section()]
+    curr_section = _sections[-1]
+    parent_section = {-1: -1}
+
+    for row in data_block:
+        row_id = id_map[int(row[COLS.ID])]
+        if len(curr_section.ids) == 0:
+            curr_section.ids.append(id_map[int(row[COLS.P])])
+            curr_section.ntype = int(row[COLS.TYPE])
+        curr_section.ids.append(row_id)
+        if row_id in _section_end_points():
+            parent_section[curr_section.ids[-1]] = len(_sections) - 1
+            _sections.append(Section())
+            curr_section = _sections[-1]
+
+    # get the section parent ID from the id of the first point.
+    for sec in _sections:
+        if sec.ids:
+            sec.pid = parent_section[sec.ids[0]]
+
+    return [s for s in _sections if s.ids]
+
+
+def remove_soma_initial_point(tree, post_action=None):
+    '''Remove tree's initial point if soma and apply post_action'''
+    if tree.value[0][COLS.TYPE] == POINT_TYPE.SOMA:
+        tree.value = tree.value[1:]
+
+    if post_action is not None:
+        post_action(tree)

--- a/neurom/core/tests/test_section_neuron.py
+++ b/neurom/core/tests/test_section_neuron.py
@@ -41,9 +41,11 @@ from neurom.analysis import morphtree as mt
 
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
+SWC_DATA_PATH = os.path.join(_PWD, '../../../test_data/swc')
 H5V1_DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v1')
 H5V2_DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v2')
 MORPH_FILENAME = 'Neuron.h5'
+SWC_MORPH_FILENAME = 'Neuron.swc'
 
 # Arbitrarily use h5 v1 as reference always
 REF_NRN = load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME),
@@ -71,11 +73,14 @@ class SectionTreeBase(object):
 
     def setUp(self):
         self.ref_nrn = REF_NRN
+        self.ref_types = REF_NEURITE_TYPES
+
+
 
     def test_neurite_type(self):
 
         neurite_types = [n0.type for n0 in self.sec_nrn.neurites]
-        nt.assert_equal(neurite_types, REF_NEURITE_TYPES)
+        nt.assert_equal(neurite_types, self.ref_types)
         nt.assert_equal(neurite_types, [n1.type for n1 in self.ref_nrn.neurites])
 
     def test_get_n_sections(self):
@@ -191,3 +196,12 @@ class TestH5V2(SectionTreeBase):
     def setUp(self):
         super(TestH5V2, self).setUp()
         self.sec_nrn = sn.load_neuron(os.path.join(H5V2_DATA_PATH, MORPH_FILENAME))
+
+
+class TestSWC(SectionTreeBase):
+
+    def setUp(self):
+        self.ref_nrn = load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME),
+                                   mt.set_tree_type)
+        self.sec_nrn = sn.load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME))
+        self.ref_types = [n.type for n in self.ref_nrn.neurites]

--- a/neurom/io/swc.py
+++ b/neurom/io/swc.py
@@ -44,24 +44,6 @@ from ..core.dataformat import ROOT_ID
 from .datawrapper import RawDataWrapper
 
 
-class SWC(object):
-    '''Read SWC files and unpack into internal raw data block
-
-    Input row format: [ID, TYPE, X, Y, Z, R, PARENT_ID]
-    Internal row format: [X, Y, Z, R, TYPE, ID, PARENT_ID]
-    '''
-    (ID, TYPE, X, Y, Z, R, P) = xrange(7)
-
-    @staticmethod
-    def read(filename):
-        '''Read an SWC file and return a tuple of data, format.'''
-        data = np.loadtxt(filename)
-        if len(np.shape(data)) == 1:
-            data = np.reshape(data, (1, -1))
-        data = data[:, [SWC.X, SWC.Y, SWC.Z, SWC.R, SWC.TYPE, SWC.ID, SWC.P]]
-        return SWCRawDataWrapper(data, 'SWC')
-
-
 class SWCRawDataWrapper(RawDataWrapper):
     '''Specialization of RawDataWrapper for SWC data
 
@@ -71,7 +53,7 @@ class SWCRawDataWrapper(RawDataWrapper):
     Index validity is checked and mappings performed before
     delegating to base class methods.
     '''
-    def __init__(self, raw_data, fmt):
+    def __init__(self, raw_data, fmt, _=None):
         super(SWCRawDataWrapper, self).__init__(raw_data, fmt)
 
         self._id_map = {}
@@ -110,3 +92,21 @@ class SWCRawDataWrapper(RawDataWrapper):
         '''Get row from idx'''
         idx = self._get_idx(idx)
         return super(SWCRawDataWrapper, self).get_row(idx)
+
+
+class SWC(object):
+    '''Read SWC files and unpack into internal raw data block
+
+    Input row format: [ID, TYPE, X, Y, Z, R, PARENT_ID]
+    Internal row format: [X, Y, Z, R, TYPE, ID, PARENT_ID]
+    '''
+    (ID, TYPE, X, Y, Z, R, P) = xrange(7)
+
+    @staticmethod
+    def read(filename, wrapper=SWCRawDataWrapper):
+        '''Read an SWC file and return a tuple of data, format.'''
+        data = np.loadtxt(filename)
+        if len(np.shape(data)) == 1:
+            data = np.reshape(data, (1, -1))
+        data = data[:, [SWC.X, SWC.Y, SWC.Z, SWC.R, SWC.TYPE, SWC.ID, SWC.P]]
+        return wrapper(data, 'SWC', None)


### PR DESCRIPTION
* Enable section tree neurons from SWC data. This is
  easily extensible to NeuroLucida ASCII.
* Remove redundant section ID field.
* Use slice objects to represent section point ID ranges in h5 data.
* Use id lists to represent section point ID ranges in non-h5 data.