### PR TITLE
Refactor neuron, population loader functions.

### DIFF
--- a/neurom/ezy/__init__.py
+++ b/neurom/ezy/__init__.py
@@ -57,7 +57,7 @@ Examples:
 
 '''
 import os
-from functools import partial
+from functools import partial, update_wrapper
 from .neuron import Neuron
 from .population import Population
 from .neuron import NeuriteType
@@ -79,5 +79,9 @@ def load_neuron(filename):
 
 
 load_neurons = partial(_io.load_neurons, neuron_loader=load_neuron)
+update_wrapper(load_neurons, _io.load_neurons)
+
+
 load_population = partial(_io.load_population, neuron_loader=load_neurons,
                           population_class=Population)
+update_wrapper(load_population, _io.load_population)

--- a/neurom/ezy/__init__.py
+++ b/neurom/ezy/__init__.py
@@ -57,6 +57,7 @@ Examples:
 
 '''
 import os
+from functools import partial
 from .neuron import Neuron
 from .population import Population
 from .neuron import NeuriteType
@@ -65,7 +66,7 @@ from ..view.view import neuron as view
 from ..view.view import neuron3d as view3d
 from ..io.utils import get_morph_files
 from ..features import get
-from ..io.utils import load_neuron as _load
+from ..io import utils as _io
 from ..analysis.morphtree import set_tree_type as _set_tt
 
 
@@ -74,44 +75,9 @@ TreeType = NeuriteType  # For backwards compatibility
 
 def load_neuron(filename):
     '''Load a Neuron from a file'''
-    return Neuron(_load(filename, _set_tt))
+    return Neuron(_io.load_neuron(filename, _set_tt))
 
 
-def load_neurons(neurons):
-    '''Create a list of Neuron objects from each morphology file in directory\
-        or from a list or tuple of file names
-
-    Parameters:
-        neurons: directory path or list of neuron file paths
-
-    Returns:
-        list of Neuron objects
-    '''
-    if isinstance(neurons, list) or isinstance(neurons, tuple):
-        return [load_neuron(f) for f in neurons]
-    elif isinstance(neurons, str):
-        return [load_neuron(f) for f in get_morph_files(neurons)]
-
-
-def load_population(neurons, name=None):
-    '''Create a population object from all morphologies in a directory\
-        of from morphologies in a list of file names
-
-    Parameters:
-        neurons: directory path or list of neuron file paths
-        name (str): optional name of population. By default 'Population' or\
-            filepath basename depending on whether neurons is list or\
-            directory path respectively.
-
-    Returns:
-        neuron Population object
-
-    '''
-    pop = Population(load_neurons(neurons))
-    if isinstance(neurons, list) or isinstance(neurons, tuple):
-        name = name if name is not None else 'Population'
-    elif isinstance(neurons, str):
-        name = name if name is not None else os.path.basename(neurons)
-
-    pop.name = name
-    return pop
+load_neurons = partial(_io.load_neurons, neuron_loader=load_neuron)
+load_population = partial(_io.load_population, neuron_loader=load_neurons,
+                          population_class=Population)

--- a/neurom/fst/_io.py
+++ b/neurom/fst/_io.py
@@ -30,7 +30,7 @@
 
 import os
 from collections import namedtuple, defaultdict
-from functools import partial
+from functools import partial, update_wrapper
 from neurom.io.hdf5 import H5
 from neurom.io.swc import SWC
 from neurom.core.types import NeuriteType
@@ -113,8 +113,12 @@ def load_neuron(filename):
 
 
 load_neurons = partial(_iout.load_neurons, neuron_loader=load_neuron)
+update_wrapper(load_neurons, _iout.load_neurons)
+
+
 load_population = partial(_iout.load_population, neuron_loader=load_neurons,
                           population_class=Population)
+update_wrapper(load_population, _iout.load_population)
 
 
 def extract_sections(data_block):

--- a/neurom/fst/_io.py
+++ b/neurom/fst/_io.py
@@ -30,6 +30,7 @@
 
 import os
 from collections import namedtuple, defaultdict
+from functools import partial
 from neurom.io.hdf5 import H5
 from neurom.io.swc import SWC
 from neurom.core.types import NeuriteType
@@ -37,6 +38,8 @@ from neurom.core.tree import Tree
 from neurom.core.dataformat import POINT_TYPE
 from neurom.core.dataformat import COLS
 from neurom.core.neuron import make_soma
+from neurom.core.population import Population
+from neurom.io import utils as _iout
 
 
 Neuron = namedtuple('Neuron', 'soma, neurites, data_block')
@@ -107,6 +110,11 @@ def load_neuron(filename):
     trees = make_trees(rdw, _NEURITE_ACTION[ext.lower()])
     soma = make_soma(rdw.soma_points())
     return Neuron(soma, trees, rdw)
+
+
+load_neurons = partial(_iout.load_neurons, neuron_loader=load_neuron)
+load_population = partial(_iout.load_population, neuron_loader=load_neurons,
+                          population_class=Population)
 
 
 def extract_sections(data_block):

--- a/neurom/fst/tests/test_io.py
+++ b/neurom/fst/tests/test_io.py
@@ -26,45 +26,53 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-''' NeuroM, lightweight and fast '''
+'''Test neurom.fst._io module loaders'''
 
-import numpy as _np
-from ._io import load_neuron, load_neurons, load_population
-from . import _mm
-from ..core.types import NeuriteType
+from nose import tools as nt
+import os
+from neurom.fst import _io
 
-
-NEURITEFEATURES = {
-    'total_length': lambda *args, **kwargs: [sum(_mm.section_lengths(*args, **kwargs))],
-    'section_lengths': _mm.section_lengths,
-    'section_path_distances': _mm.section_path_lengths,
-    'number_of_sections': lambda *args, **kwargs: [_mm.n_sections(*args, **kwargs)],
-    'number_of_sections_per_neurite': _mm.n_sections_per_neurite,
-    'number_of_neurites': lambda *args, **kwargs: [_mm.n_neurites(*args, **kwargs)],
-    'section_branch_orders': _mm.section_branch_orders,
-    'section_radial_distances': _mm.section_radial_distances,
-    'local_bifurcation_angles': _mm.local_bifurcation_angles,
-    'remote_bifurcation_angles': _mm.remote_bifurcation_angles,
-    'partition': _mm.bifurcation_partitions,
-    'number_of_segments': lambda *args, **kwargs: [_mm.n_segments(*args, **kwargs)],
-    'trunk_origin_radii': _mm.trunk_origin_radii,
-    'trunk_section_lengths': _mm.trunk_section_lengths,
-    'segment_lengths': _mm.segment_lengths,
-    'segment_radial_distances': _mm.segment_radial_distances,
-    'principal_direction_extents': _mm.principal_direction_extents
-}
-
-NEURONFEATURES = {
-    'soma_radii': _mm.soma_radii,
-    'soma_surface_areas': _mm.soma_surface_areas,
-}
+_path = os.path.dirname(os.path.abspath(__file__))
+DATA_PATH = os.path.join(_path, '../../../test_data/valid_set')
+FILENAMES = [os.path.join(DATA_PATH, f)
+             for f in ['Neuron.swc', 'Neuron_h5v1.h5', 'Neuron_h5v2.h5']]
 
 
-def get(feature, *args, **kwargs):
-    '''Neuron feature getter helper
+def test_load_neuron():
 
-    Returns features as a 1D numpy array.
-    '''
-    feature = (NEURITEFEATURES[feature] if feature in NEURITEFEATURES
-               else NEURONFEATURES[feature])
-    return _np.array(feature(*args, **kwargs))
+    nrn = _io.load_neuron(FILENAMES[0])
+    nt.assert_true(isinstance(nrn, _io.Neuron))
+
+
+def test_load_neurons_directory():
+
+    nrns = _io.load_neurons(DATA_PATH)
+    nt.assert_equal(len(nrns), 5)
+    for nrn in nrns:
+        nt.assert_true(isinstance(nrn, _io.Neuron))
+
+
+def test_load_neurons_filenames():
+
+    nrns = _io.load_neurons(FILENAMES)
+    nt.assert_equal(len(nrns), 3)
+    for nrn in nrns:
+        nt.assert_true(isinstance(nrn, _io.Neuron))
+
+
+def test_load_population_directory():
+
+    pop = _io.load_population(DATA_PATH)
+    nt.assert_equal(len(pop.neurons), 5)
+    nt.assert_equal(pop.name, 'valid_set')
+
+    pop = _io.load_population(DATA_PATH, 'test123')
+    nt.assert_equal(len(pop.neurons), 5)
+    nt.assert_equal(pop.name, 'test123')
+
+
+def test_load_population_filenames():
+
+    pop = _io.load_population(FILENAMES, 'test123')
+    nt.assert_equal(len(pop.neurons), 3)
+    nt.assert_equal(pop.name, 'test123')

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -33,6 +33,7 @@ from neurom.core.dataformat import POINT_TYPE
 from neurom.core.dataformat import ROOT_ID
 from neurom.core.tree import Tree
 from neurom.core.neuron import Neuron, make_soma
+from neurom.core.population import Population
 from neurom.exceptions import IDSequenceError, MultipleTrees, MissingParentError
 from . import load_data
 from . import check
@@ -157,3 +158,45 @@ def get_morph_files(directory):
     return [m for m in lsdir
             if os.path.isfile(m) and
             os.path.splitext(m)[1].lower() in ('.swc', '.h5', '.asc')]
+
+
+def load_neurons(neurons, neuron_loader=load_neuron):
+    '''Create a list of Neuron objects from each morphology file in directory\
+        or from a list or tuple of file names
+
+    Parameters:
+        neurons: directory path or list of neuron file paths
+
+    Returns:
+        list of Neuron objects
+    '''
+    if isinstance(neurons, list) or isinstance(neurons, tuple):
+        return [neuron_loader(f) for f in neurons]
+    elif isinstance(neurons, str):
+        return [neuron_loader(f) for f in get_morph_files(neurons)]
+
+
+def load_population(neurons, name=None, neuron_loader=load_neurons,
+                    population_class=Population):
+    '''Create a population object from all morphologies in a directory\
+        of from morphologies in a list of file names
+
+    Parameters:
+        neurons: directory path or list of neuron file paths
+        population_class: class representing populations
+        name (str): optional name of population. By default 'Population' or\
+            filepath basename depending on whether neurons is list or\
+            directory path respectively.
+
+    Returns:
+        neuron population object
+
+    '''
+    pop = population_class(neuron_loader(neurons))
+    if isinstance(neurons, list) or isinstance(neurons, tuple):
+        name = name if name is not None else 'Population'
+    elif isinstance(neurons, str):
+        name = name if name is not None else os.path.basename(neurons)
+
+    pop.name = name
+    return pop


### PR DESCRIPTION
Backwards compatible changes: load_neurons and load_populations
moved from neurom.ezy to neurom.io.utils and made more generic.
Specializations with same names added to neurom.ezy and neurom.fst
modules.