### PR TITLE
Enable experimental NeuroLucida .asc reader in neuro.fst module.

### DIFF
--- a/examples/nl_compat.py
+++ b/examples/nl_compat.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Compatibility between NL and H5 files'''
+import numpy as np
+from neurom import ezy
+
+nrn_h5 = ezy.load_neuron('C050600B1.h5')
+nrn_asc = ezy.load_neuron('C050600B1.asc')
+
+print 'h5 number of sections: %s' % ezy.get('number_of_sections', nrn_h5)[0]
+print 'nl number of sections: %s\n' % ezy.get('number_of_sections', nrn_asc)[0]
+print 'h5 number of segments: %s' % ezy.get('number_of_segments', nrn_h5)[0]
+print 'nl number of segments: %s\n' % ezy.get('number_of_segments', nrn_asc)[0]
+print 'h5 total neurite surface area: %s' % np.sum(ezy.get('section_areas', nrn_h5))
+print 'nl total neurite surface area: %s\n' % np.sum(ezy.get('section_areas', nrn_asc))
+print 'h5 total neurite volume: %s' % np.sum(ezy.get('section_volumes', nrn_h5))
+print 'nl total neurite volume: %s\n' % np.sum(ezy.get('section_volumes', nrn_asc))
+print 'h5 total neurite length: %s' % np.sum(ezy.get('section_lengths', nrn_h5))
+print 'nl total neurite length: %s\n' % np.sum(ezy.get('section_lengths', nrn_asc))

--- a/examples/nl_fst_compat.py
+++ b/examples/nl_fst_compat.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Compatibility between NL and H5 files'''
+# pylint: disable=protected-access
+
+import numpy as np
+from neurom import fst
+
+nrn_h5 = fst.load_neuron('C050600B1.h5')
+nrn_asc = fst.load_neuron('C050600B1.asc')
+
+print 'h5 number of sections: %s' % fst.get('number_of_sections', nrn_h5)[0]
+print 'nl number of sections: %s\n' % fst.get('number_of_sections', nrn_asc)[0]
+print 'h5 number of segments: %s' % fst.get('number_of_segments', nrn_h5)[0]
+print 'nl number of segments: %s\n' % fst.get('number_of_segments', nrn_asc)[0]
+print 'h5 total neurite length: %s' % np.sum(fst.get('section_lengths', nrn_h5))
+print 'nl total neurite length: %s\n' % np.sum(fst.get('section_lengths', nrn_asc))
+
+print '\nNumber of neurites:'
+for nt in fst.NeuriteType:
+    print nt, fst._mm.n_neurites(nrn_h5, neurite_type=nt),\
+          fst._mm.n_neurites(nrn_asc, neurite_type=nt)
+
+print '\nNumber of segments:'
+for nt in fst.NeuriteType:
+    print nt, fst._mm.n_segments(nrn_h5, neurite_type=nt),\
+        fst._mm.n_segments(nrn_asc, neurite_type=nt)

--- a/neurom/fst/_io.py
+++ b/neurom/fst/_io.py
@@ -33,6 +33,7 @@ from collections import namedtuple, defaultdict
 from functools import partial, update_wrapper
 from neurom.io.hdf5 import H5
 from neurom.io.swc import SWC
+from neurom.io.neurolucida import NeurolucidaASC
 from neurom.core.types import NeuriteType
 from neurom.core.tree import Tree
 from neurom.core.dataformat import POINT_TYPE
@@ -99,11 +100,13 @@ def load_neuron(filename):
     '''Build section trees from an h5 or swc file'''
     _READERS = {
         'swc': lambda f: SWC.read(f, wrapper=SecDataWrapper),
-        'h5': lambda f: H5.read(f, remove_duplicates=False, wrapper=SecDataWrapper)
+        'h5': lambda f: H5.read(f, remove_duplicates=False, wrapper=SecDataWrapper),
+        'asc': lambda f: NeurolucidaASC.read(f, remove_duplicates=True, wrapper=SecDataWrapper)
     }
     _NEURITE_ACTION = {
         'swc': remove_soma_initial_point,
-        'h5': None
+        'h5': None,
+        'asc': None
     }
     ext = os.path.splitext(filename)[1][1:]
     rdw = _READERS[ext.lower()](filename)

--- a/neurom/io/neurolucida.py
+++ b/neurom/io/neurolucida.py
@@ -182,7 +182,7 @@ def _extract_section(section, remove_duplicates=False):
     Returns a numpy array with the row format:
         [X, Y, Z, R, TYPE, ID, PARENT_ID]
 
-    Note: PARENT_ID starts at -1
+    Note: PARENT_ID starts at -1 for soma and 0 for neurites
     '''
     # try and detect type
     _type = WANTED_SECTIONS.get(section[0][0], None)
@@ -195,8 +195,9 @@ def _extract_section(section, remove_duplicates=False):
             return None
         start = 2
 
+    parent = -1 if _type == POINT_TYPE.SOMA else 0
     subsection_iter = _flatten_subsection(section[start:], _type, offset=0,
-                                          parent=-1, remove_duplicates=remove_duplicates)
+                                          parent=parent, remove_duplicates=remove_duplicates)
 
     ret = np.array([row for row in subsection_iter])
     return ret
@@ -240,7 +241,7 @@ def _sections_to_raw_data(sections, remove_duplicates=False):
 class NeurolucidaASC(object):
     '''Reader for Neurolucida ASCII files'''
     @staticmethod
-    def read(morph_file, remove_duplicates=True):
+    def read(morph_file, remove_duplicates=True, wrapper=RawDataWrapper):
         '''return a 'raw_data' np.array with the full neuron, and the format of the file
         suitable to be wrapped by RawDataWrapper
         '''
@@ -249,4 +250,4 @@ class NeurolucidaASC(object):
         with open(morph_file) as morph_fd:
             sections = _parse_sections(morph_fd)
         raw_data = _sections_to_raw_data(sections, remove_duplicates)
-        return RawDataWrapper(raw_data, 'Beta Neurolucida ASCII')
+        return wrapper(raw_data, 'Beta Neurolucida ASCII')


### PR DESCRIPTION
Note: discrepancies WRT h5 still observed. These appear to be larger
than with the standard neuron layout.