### PR TITLE
Set neuron name when loading with fst module.

### DIFF
--- a/neurom/fst/_io.py
+++ b/neurom/fst/_io.py
@@ -43,7 +43,7 @@ from neurom.core.population import Population
 from neurom.io import utils as _iout
 
 
-Neuron = namedtuple('Neuron', 'soma, neurites, data_block')
+Neuron = namedtuple('Neuron', 'soma, neurites, data_block, name')
 
 
 class SecDataWrapper(object):
@@ -115,7 +115,8 @@ def load_neuron(filename):
     rdw = _READERS[ext.lower()](filename)
     trees = make_trees(rdw, _NEURITE_ACTION[ext.lower()])
     soma = make_soma(rdw.soma_points())
-    return Neuron(soma, trees, rdw)
+    name = os.path.splitext(os.path.basename(filename))[0]
+    return Neuron(soma, trees, rdw, name)
 
 
 load_neurons = partial(_iout.load_neurons, neuron_loader=load_neuron)

--- a/neurom/fst/tests/test_io.py
+++ b/neurom/fst/tests/test_io.py
@@ -38,18 +38,28 @@ DATA_PATH = os.path.join(_path, '../../../test_data/valid_set')
 FILENAMES = [os.path.join(DATA_PATH, f)
              for f in ['Neuron.swc', 'Neuron_h5v1.h5', 'Neuron_h5v2.h5']]
 
+NRN_NAMES = ('Neuron', 'Neuron_h5v1', 'Neuron_h5v2')
 
 
 def test_load_neuron():
 
     nrn = _io.load_neuron(FILENAMES[0])
     nt.assert_true(isinstance(nrn, _io.Neuron))
+    nt.assert_equal(nrn.name, 'Neuron')
+
+
+def test_neuron_name():
+
+    for fn, nn in zip(FILENAMES, NRN_NAMES):
+        nrn = _io.load_neuron(fn)
+        nt.eq_(nrn.name, nn)
 
 
 def test_load_neuron_soma_only():
 
     nrn = _io.load_neuron(os.path.join(DATA_ROOT, 'swc', 'Soma_origin.swc'))
     nt.eq_(len(nrn.neurites), 0)
+    nt.assert_equal(nrn.name, 'Soma_origin')
 
 
 def test_load_neurons_directory():
@@ -64,8 +74,9 @@ def test_load_neurons_filenames():
 
     nrns = _io.load_neurons(FILENAMES)
     nt.assert_equal(len(nrns), 3)
-    for nrn in nrns:
+    for nrn, name in zip(nrns, NRN_NAMES):
         nt.assert_true(isinstance(nrn, _io.Neuron))
+        nt.assert_equal(nrn.name, name)
 
 
 def test_load_population_directory():
@@ -84,3 +95,6 @@ def test_load_population_filenames():
     pop = _io.load_population(FILENAMES, 'test123')
     nt.assert_equal(len(pop.neurons), 3)
     nt.assert_equal(pop.name, 'test123')
+    for nrn, name in zip(pop.neurons, NRN_NAMES):
+        nt.assert_true(isinstance(nrn, _io.Neuron))
+        nt.assert_equal(nrn.name, name)


### PR DESCRIPTION
Follows same logic of neurom.io point neuron loader.
Implements #365.