### PR TITLE
Change definition of some neurom.fst.get features.

### DIFF
--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -35,18 +35,20 @@ from ..core.types import NeuriteType
 
 
 NEURITEFEATURES = {
-    'total_length': lambda *args, **kwargs: [sum(_mm.section_lengths(*args, **kwargs))],
+    'total_length': lambda nrn, **kwargs: _as_neurons(lambda n, **kw:
+                                                      sum(_mm.section_lengths(n, **kw)),
+                                                      nrn, **kwargs),
     'section_lengths': _mm.section_lengths,
     'section_path_distances': _mm.section_path_lengths,
-    'number_of_sections': lambda *args, **kwargs: [_mm.n_sections(*args, **kwargs)],
+    'number_of_sections': lambda nrn, **kwargs: _as_neurons(_mm.n_sections, nrn, **kwargs),
     'number_of_sections_per_neurite': _mm.n_sections_per_neurite,
-    'number_of_neurites': lambda *args, **kwargs: [_mm.n_neurites(*args, **kwargs)],
+    'number_of_neurites': lambda nrn, **kwargs: _as_neurons(_mm.n_neurites, nrn, **kwargs),
     'section_branch_orders': _mm.section_branch_orders,
     'section_radial_distances': _mm.section_radial_distances,
     'local_bifurcation_angles': _mm.local_bifurcation_angles,
     'remote_bifurcation_angles': _mm.remote_bifurcation_angles,
     'partition': _mm.bifurcation_partitions,
-    'number_of_segments': lambda *args, **kwargs: [_mm.n_segments(*args, **kwargs)],
+    'number_of_segments': lambda nrn, **kwargs: _as_neurons(_mm.n_segments, nrn, **kwargs),
     'trunk_origin_radii': _mm.trunk_origin_radii,
     'trunk_section_lengths': _mm.trunk_section_lengths,
     'segment_lengths': _mm.segment_lengths,
@@ -58,6 +60,12 @@ NEURONFEATURES = {
     'soma_radii': _mm.soma_radii,
     'soma_surface_areas': _mm.soma_surface_areas,
 }
+
+
+def _as_neurons(fun, nrns, **kwargs):
+    '''Get features per neuron'''
+    nrns = nrns.neurons if hasattr(nrns, 'neurons') else (nrns,)
+    return [fun(n, **kwargs) for n in nrns]
 
 
 def get(feature, *args, **kwargs):

--- a/neurom/fst/tests/test_get_feature_compat.py
+++ b/neurom/fst/tests/test_get_feature_compat.py
@@ -92,15 +92,18 @@ class TestSectionTree(object):
         nt.assert_equal(neurite_types, self.ref_types)
         nt.assert_equal(neurite_types, [n1.type for n1 in self.ref_pop.neurites])
 
+    @nt.nottest
     def test_get_n_sections(self):
         self._check_neurite_feature('number_of_sections')
 
     def test_get_n_sections_per_neurite(self):
         self._check_neurite_feature('number_of_sections_per_neurite')
 
+    @nt.nottest
     def test_get_n_segments(self):
         self._check_neurite_feature('number_of_segments')
 
+    @nt.nottest
     def test_get_number_of_neurites(self):
         self._check_neurite_feature('number_of_neurites')
 
@@ -137,6 +140,7 @@ class TestSectionTree(object):
     def test_get_partition(self):
         self._check_neurite_feature('partition')
 
+    @nt.nottest
     def test_get_total_length(self):
         self._check_neurite_feature('total_length')
 

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test neurom.fst.get features'''
+
+import os
+import numpy as np
+from nose import tools as nt
+from neurom.core.types import NeuriteType
+from neurom.core.population import Population
+from neurom import fst
+
+
+_PWD = os.path.dirname(os.path.abspath(__file__))
+NRN_FILES = [os.path.join(_PWD, '../../../test_data/h5/v1', f)
+             for f in ('Neuron.h5', 'Neuron_2_branch.h5', 'bio_neuron-001.h5')]
+
+NRNS = fst.load_neurons(NRN_FILES)
+NRN = NRNS[0]
+POP = Population(NRNS)
+
+NEURITES = (NeuriteType.axon,
+            NeuriteType.apical_dendrite,
+            NeuriteType.basal_dendrite,
+            NeuriteType.all)
+
+
+def test_number_of_sections_pop():
+
+    feat = 'number_of_sections'
+
+    nt.assert_items_equal(fst.get(feat, POP), [84, 42, 202])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+                          [84, 42, 202])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+                          [21, 21, 179])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+                          [21, 0, 0])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+                          [42, 21, 23])
+
+
+def test_number_of_sections_nrn():
+
+    feat = 'number_of_sections'
+
+    nt.assert_items_equal(fst.get(feat, NRN), [84])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+                          [84])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+                          [21])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+                          [21])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+                          [42])
+
+
+def test_number_of_segments_pop():
+
+    feat = 'number_of_segments'
+
+    nt.assert_items_equal(fst.get(feat, POP), [840, 419, 5179])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+                          [840, 419, 5179])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+                          [210, 209, 4508])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+                          [210, 0, 0])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+                          [420, 210, 671])
+
+
+def test_number_of_segments_nrn():
+
+    feat = 'number_of_segments'
+
+    nt.assert_items_equal(fst.get(feat, NRN), [840])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+                          [840])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+                          [210])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+                          [210])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+                          [420])
+
+
+def test_number_of_neurites_pop():
+
+    feat = 'number_of_neurites'
+
+    nt.assert_items_equal(fst.get(feat, POP), [4, 2, 4])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+                          [4, 2, 4])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+                          [1, 1, 1])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+                          [1, 0, 0])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+                          [2, 1, 3])
+
+
+def test_number_of_neurites_nrn():
+
+    feat = 'number_of_neurites'
+
+    nt.assert_items_equal(fst.get(feat, NRN), [4])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+                          [4])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+                          [1])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+                          [1])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+                          [2])
+
+
+def test_total_length_pop():
+
+    feat = 'total_length'
+
+    nt.ok_(np.allclose(fst.get(feat, POP),
+                       [840.47744821, 418.83424432, 13250.82577394]))
+
+    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.all),
+                       [840.47744821, 418.83424432, 13250.82577394]))
+
+    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+                       [207.81090481, 207.81088342, 11767.15611522]))
+
+    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+                       [214.34043344, 0, 0]))
+
+    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+                       [418.32610997, 211.0233609, 1483.66965872]))
+
+
+def test_total_length_nrn():
+
+    feat = 'total_length'
+
+    nt.ok_(np.allclose(fst.get(feat, NRN),
+                       [840.47744821]))
+
+    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+                       [840.47744821]))
+
+    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+                       [207.81090481]))
+
+    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+                       [214.34043344]))
+
+    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+                       [418.32610997]))


### PR DESCRIPTION
For some scalar quantities, return list of values per neuron instead
of aggregation over all neurons in a population. Features affected:

* total_length
* number_of_sections
* number_of_segments
* number_of_neurites

Implements part of #364.