### PR TITLE
Migrate some features to neurom.fst module

### DIFF
--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -47,6 +47,7 @@ NEURITEFEATURES = {
     'local_bifurcation_angles': _impl.local_bifurcation_angles,
     'remote_bifurcation_angles': _impl.remote_bifurcation_angles,
     'bifurcation_number': _impl.bifurcation_number,
+    'number_of_bifurcations': _impl.bifurcation_number,
     'segment_lengths': _impl.segment_lengths,
     'number_of_segments': _impl.number_of_segments,
     'segment_taper_rates': _impl.segment_taper_rates,

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -92,6 +92,8 @@ NEURITEFEATURES = {
     'partition': _mm.bifurcation_partitions,
     'number_of_segments': partial(_as_neurons, _mm.n_segments),
     'trunk_origin_radii': _mm.trunk_origin_radii,
+    'trunk_origin_azimuths': _mm.trunk_origin_azimuths,
+    'trunk_origin_elevations': _mm.trunk_origin_elevations,
     'trunk_section_lengths': _mm.trunk_section_lengths,
     'segment_lengths': _mm.segment_lengths,
     'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _mm.iter_segments(nrn, **kwargs)],

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -54,37 +54,50 @@ Examples:
 '''
 
 import numpy as _np
+from functools import partial
 from ._io import load_neuron, load_neurons, Neuron
 from . import _mm
 from ..utils import deprecated
 from ..core.types import NeuriteType
 from ..core.types import NEURITES as NEURITE_TYPES
 from ..analysis.morphmath import segment_radius as seg_rad
-
+from ..analysis.morphmath import segment_taper_rate as seg_taper
+from ..analysis.morphmath import section_length as sec_len
 
 load_population = deprecated('Use load_neurons instead.',
                              fun_name='load_population')(load_neurons)
 
 
+def _as_neurons(fun, nrns, **kwargs):
+    '''Get features per neuron'''
+    nrns = nrns.neurons if hasattr(nrns, 'neurons') else (nrns,)
+    return list(fun(n, **kwargs) for n in nrns)
+
+
 NEURITEFEATURES = {
-    'total_length': lambda nrn, **kwargs: _as_neurons(lambda n, **kw:
-                                                      sum(_mm.section_lengths(n, **kw)),
-                                                      nrn, **kwargs),
-    'section_lengths': _mm.section_lengths,
+    'total_length': partial(_as_neurons, lambda n, **kw: sum(_mm.section_lengths(n, **kw))),
+    'total_length_per_neurite': _mm.total_length_per_neurite,
+    'section_lengths': partial(_mm.map_sections, sec_len),
+    'section_volumes': partial(_mm.map_sections, _mm.section_volume),
+    'section_areas': partial(_mm.map_sections, _mm.section_area),
     'section_path_distances': _mm.section_path_lengths,
-    'number_of_sections': lambda nrn, **kwargs: _as_neurons(_mm.n_sections, nrn, **kwargs),
+    'number_of_sections': partial(_as_neurons, _mm.n_sections),
     'number_of_sections_per_neurite': _mm.n_sections_per_neurite,
-    'number_of_neurites': lambda nrn, **kwargs: _as_neurons(_mm.n_neurites, nrn, **kwargs),
+    'number_of_neurites': partial(_as_neurons, _mm.n_neurites),
+    'number_of_bifurcations': partial(_as_neurons, _mm.n_bifurcation_points),
     'section_branch_orders': _mm.section_branch_orders,
     'section_radial_distances': _mm.section_radial_distances,
     'local_bifurcation_angles': _mm.local_bifurcation_angles,
     'remote_bifurcation_angles': _mm.remote_bifurcation_angles,
     'partition': _mm.bifurcation_partitions,
-    'number_of_segments': lambda nrn, **kwargs: _as_neurons(_mm.n_segments, nrn, **kwargs),
+    'number_of_segments': partial(_as_neurons, _mm.n_segments),
     'trunk_origin_radii': _mm.trunk_origin_radii,
     'trunk_section_lengths': _mm.trunk_section_lengths,
     'segment_lengths': _mm.segment_lengths,
     'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _mm.iter_segments(nrn, **kwargs)],
+    'segment_midpoints': _mm.segment_midpoints,
+    'segment_taper_rates': lambda nrn, **kwargs: [seg_taper(s)
+                                                  for s in _mm.iter_segments(nrn, **kwargs)],
     'segment_radial_distances': _mm.segment_radial_distances,
     'principal_direction_extents': _mm.principal_direction_extents
 }
@@ -93,12 +106,6 @@ NEURONFEATURES = {
     'soma_radii': _mm.soma_radii,
     'soma_surface_areas': _mm.soma_surface_areas,
 }
-
-
-def _as_neurons(fun, nrns, **kwargs):
-    '''Get features per neuron'''
-    nrns = nrns.neurons if hasattr(nrns, 'neurons') else (nrns,)
-    return [fun(n, **kwargs) for n in nrns]
 
 
 def get(feature, *args, **kwargs):

--- a/neurom/fst/_mm.py
+++ b/neurom/fst/_mm.py
@@ -225,6 +225,7 @@ def trunk_origin_azimuths(nrn, neurite_type=NeuriteType.all):
 
     The azimuth is defined as Angle between x-axis and the vector
     defined by (initial tree point - soma center) on the x-z plane.
+
     The range of the azimuth angle [-pi, pi] radians
     '''
     tree_filter = is_type(neurite_type)
@@ -242,9 +243,11 @@ def trunk_origin_azimuths(nrn, neurite_type=NeuriteType.all):
 def trunk_origin_elevations(nrn, neurite_type=NeuriteType.all):
     '''Get a list of all the trunk origin elevations of a neuron or population
 
-    The elevation is defined as Angle between x-axis and the vector
-    defined by (initial tree point - soma center) on the x-z plane.
-    The range of the elevation angle [-pi, pi] radians
+    The elevation is defined as the angle between x-axis and the
+    vector defined by (initial tree point - soma center)
+    on the x-y half-plane.
+
+    The range of the elevation angle [-pi/2, pi/2] radians
     '''
     tree_filter = is_type(neurite_type)
     nrns = nrn.neurons if hasattr(nrn, 'neurons') else [nrn]

--- a/neurom/fst/_mm.py
+++ b/neurom/fst/_mm.py
@@ -220,6 +220,49 @@ def trunk_origin_radii(nrn, neurite_type=NeuriteType.all):
     return [s.value[0][COLS.R] for s in nrn.neurites if tree_filter(s)]
 
 
+def trunk_origin_azimuths(nrn, neurite_type=NeuriteType.all):
+    '''Get a list of all the trunk origin azimuths of a neuron or population
+
+    The azimuth is defined as Angle between x-axis and the vector
+    defined by (initial tree point - soma center) on the x-z plane.
+    The range of the azimuth angle [-pi, pi] radians
+    '''
+    tree_filter = is_type(neurite_type)
+    nrns = nrn.neurons if hasattr(nrn, 'neurons') else [nrn]
+
+    def _azimuth(section, soma):
+        '''Azimuth of a section'''
+        vector = mm.vector(section[0], soma.center)
+        return np.arctan2(vector[COLS.Z], vector[COLS.X])
+
+    return [_azimuth(s.value, n.soma)
+            for n in nrns for s in n.neurites if tree_filter(s)]
+
+
+def trunk_origin_elevations(nrn, neurite_type=NeuriteType.all):
+    '''Get a list of all the trunk origin elevations of a neuron or population
+
+    The elevation is defined as Angle between x-axis and the vector
+    defined by (initial tree point - soma center) on the x-z plane.
+    The range of the elevation angle [-pi, pi] radians
+    '''
+    tree_filter = is_type(neurite_type)
+    nrns = nrn.neurons if hasattr(nrn, 'neurons') else [nrn]
+
+    def _elevation(section, soma):
+        '''Elevation of a section'''
+        vector = mm.vector(section[0], soma.center)
+        norm_vector = np.linalg.norm(vector)
+
+        if norm_vector >= np.finfo(type(norm_vector)).eps:
+            return np.arcsin(vector[COLS.Y] / norm_vector)
+        else:
+            raise ValueError("Norm of vector between soma center and section is almost zero.")
+
+    return [_elevation(s.value, n.soma)
+            for n in nrns for s in n.neurites if tree_filter(s)]
+
+
 def n_sections_per_neurite(nrn, neurite_type=NeuriteType.all):
     '''Get the number of sections per neurite in a neuron'''
     tree_filter = is_type(neurite_type)

--- a/neurom/fst/tests/test_get_feature_compat.py
+++ b/neurom/fst/tests/test_get_feature_compat.py
@@ -34,8 +34,8 @@ from nose import tools as nt
 from neurom.core.types import NeuriteType
 from neurom.core.population import Population
 from neurom import fst
-from neurom.core.tree import i_chain2, ibifurcation_point
 from neurom.io.utils import load_neuron
+from neurom.core.dataformat import COLS
 from neurom.features import get
 from neurom.analysis import morphtree as mt
 
@@ -45,7 +45,7 @@ DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/Neuron.h5')
 NRN_PATHS = [DATA_PATH] * 10
 
 
-def _close(a, b, debug, rtol, atol):
+def _close(a, b, debug=False, rtol=1e-05, atol=1e-08):
     if debug:
         print '\na.shape: %s\nb.shape: %s\n' % (a.shape, b.shape)
         print '\na: %s\nb:%s\n' % (a, b)
@@ -107,6 +107,10 @@ class TestSectionTree(object):
     def test_get_number_of_neurites(self):
         self._check_neurite_feature('number_of_neurites')
 
+    @nt.nottest
+    def test_get_number_of_bifurcations(self):
+        self._check_neurite_feature('number_of_bifurcations')
+
     def test_get_section_lengths(self):
         self._check_neurite_feature('section_lengths')
 
@@ -119,6 +123,23 @@ class TestSectionTree(object):
     def test_get_segment_radii(self):
         self._check_neurite_feature('segment_radii', debug=False)
 
+    def test_get_segment_radial_distances(self):
+        self._check_neurite_feature('segment_radial_distances', debug=False)
+
+    def test_get_segment_taper_rates(self):
+        self._check_neurite_feature('segment_taper_rates', debug=False)
+
+    def test_get_segment_midpoint(self):
+
+        for ntyp in fst.NEURITE_TYPES:
+            pts = fst.get('segment_midpoints', self.fst_pop, neurite_type=ntyp)
+            ref_xyz = (get('segment_x_coordinates', self.ref_pop, neurite_type=ntyp),
+                       get('segment_y_coordinates', self.ref_pop, neurite_type=ntyp),
+                       get('segment_z_coordinates', self.ref_pop, neurite_type=ntyp))
+
+            for i in xrange(3):
+                _equal(pts[:, i], ref_xyz[i])
+
     def test_get_local_bifurcation_angles(self):
         self._check_neurite_feature('local_bifurcation_angles')
 
@@ -127,9 +148,6 @@ class TestSectionTree(object):
 
     def test_get_section_radial_distances(self):
         self._check_neurite_feature('section_radial_distances')
-
-    def test_get_segment_radial_distances(self):
-        self._check_neurite_feature('segment_radial_distances', debug=False)
 
     def test_get_trunk_origin_radii(self):
         self._check_neurite_feature('trunk_origin_radii')
@@ -143,9 +161,18 @@ class TestSectionTree(object):
     def test_get_partition(self):
         self._check_neurite_feature('partition')
 
+    def test_get_section_areas(self):
+        self._check_neurite_feature('section_areas')
+
+    def test_get_section_volumes(self):
+        self._check_neurite_feature('section_volumes')
+
     @nt.nottest
     def test_get_total_length(self):
         self._check_neurite_feature('total_length')
+
+    def test_get_total_length_per_neurite(self):
+        self._check_neurite_feature('total_length_per_neurite')
 
     def test_get_principal_direction_extents(self):
         self._check_neurite_feature('principal_direction_extents', debug=False)

--- a/neurom/fst/tests/test_get_feature_compat.py
+++ b/neurom/fst/tests/test_get_feature_compat.py
@@ -155,6 +155,13 @@ class TestSectionTree(object):
     def test_get_trunk_section_lengths(self):
         self._check_neurite_feature('trunk_section_lengths')
 
+    def test_trunk_origin_azimuths(self):
+        self._check_neurite_feature('trunk_origin_azimuths')
+
+    @nt.nottest
+    def test_trunk_origin_elevations(self):
+        self._check_neurite_feature('trunk_origin_elevations')
+
     def test_get_section_branch_orders(self):
         self._check_neurite_feature('section_branch_orders')
 

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -167,6 +167,44 @@ def test_number_of_neurites_nrn():
                           [2])
 
 
+def test_number_of_bifurcations_nrn():
+
+    feat = 'number_of_bifurcations'
+
+    nt.assert_items_equal(fst.get(feat, NRN), [40])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+                          [40])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+                          [10])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+                          [10])
+
+    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+                          [20])
+
+
+def test_number_of_bifurcations_pop():
+
+    feat = 'number_of_bifurcations'
+
+    nt.assert_items_equal(fst.get(feat, POP), [40, 20, 97])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+                          [40, 20, 97])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+                          [10, 10, 87])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+                          [10, 0, 0])
+
+    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+                          [20, 10, 10])
+
+
 def test_total_length_pop():
 
     feat = 'total_length'

--- a/neurom/fst/tests/test_mm.py
+++ b/neurom/fst/tests/test_mm.py
@@ -35,6 +35,8 @@ from neurom import fst
 from neurom.fst import _mm
 from neurom.io import utils as io_utils
 from neurom.core import tree as tr
+from neurom.core.neuron import make_soma
+from neurom.core.population import Population
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
@@ -96,3 +98,49 @@ def test_principal_direction_extents():
 
     p = _mm.principal_direction_extents(nrn)
     _close(np.array(p), np.array(p_ref))
+
+
+def test_trunk_origin_elevations():
+    class Mock(object):
+        pass
+
+    n0 = Mock()
+    n1 = Mock()
+
+    s = make_soma([[0, 0, 0, 4]])
+    t0 = tr.Tree(((1, 0, 0, 2), (2, 1, 1, 2)))
+    t0.type = fst.NeuriteType.basal_dendrite
+    t1 = tr.Tree(((0, 1, 0, 2), (1, 2, 1, 2)))
+    t1.type = fst.NeuriteType.basal_dendrite
+    n0.neurites = [t0, t1]
+    n0.soma = s
+
+    t2 = tr.Tree(((0, -1, 0, 2), (-1, -2, -1, 2)))
+    t2.type = fst.NeuriteType.basal_dendrite
+    n1.neurites = [t2]
+    n1.soma = s
+
+    pop = Population([n0, n1])
+    nt.assert_items_equal(_mm.trunk_origin_elevations(pop),
+                          [0.0, np.pi/2., -np.pi/2.])
+
+    nt.assert_items_equal(
+        _mm.trunk_origin_elevations(pop, neurite_type=fst.NeuriteType.basal_dendrite),
+        [0.0, np.pi/2., -np.pi/2.]
+    )
+
+    nt.eq_(
+        len(_mm.trunk_origin_elevations(pop,
+                                        neurite_type=fst.NeuriteType.axon)),
+        0
+    )
+
+    nt.eq_(
+        len(_mm.trunk_origin_elevations(pop,
+                                        neurite_type=fst.NeuriteType.apical_dendrite)),
+        0
+    )
+
+@nt.raises(Exception)
+def test_trunk_elevation_zero_norm_vector_raises():
+    _mm.trunk_origin_elevations(NRN)


### PR DESCRIPTION
Implemented features:

* section_areas
* section_volumes
* segment_taper_rates
* number_of_bifurcations: 
  * analogous to "bifurcation_number", but for populations it is estimated per neuon, and not as a total over all neurons.
* total_length_per_neurite
* segment_midpoints
  * returns an array of (x, y, z) positions representing the segment midpoints and replaces segment_x_coordinates,  segment_y_coordinates, and segment_z_coordinates.
* trunk_origin_azimuths
* trunk_origin_elevations

Replace some lambda expressions for functools.partial calls.