### PR TITLE
Functions iter_sections and iter_segments in neurom.fst._mm 

### DIFF
--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -64,14 +64,13 @@ from ..analysis.morphmath import segment_taper_rate as seg_taper
 from ..analysis.morphmath import section_length as sec_len
 
 
-def _iseg(nrn, neurite_type=None):
+def _iseg(nrn, neurite_type=NeuriteType.all):
     '''Build a tree type filter from a neurite type and forward to functon
 
     TODO:
         This should be a decorator
     '''
-    tree_filter = None if neurite_type is None else _is_type(neurite_type)
-    return _mm.iter_segments(nrn, tree_filter=tree_filter)
+    return _mm.iter_segments(nrn, tree_filter=_is_type(neurite_type))
 
 
 load_population = deprecated('Use load_neurons instead.',

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -58,9 +58,21 @@ from . import _mm
 from ..utils import deprecated
 from ..core.types import NeuriteType
 from ..core.types import NEURITES as NEURITE_TYPES
+from ..core.types import tree_type_checker as _is_type
 from ..analysis.morphmath import segment_radius as seg_rad
 from ..analysis.morphmath import segment_taper_rate as seg_taper
 from ..analysis.morphmath import section_length as sec_len
+
+
+def _iseg(nrn, neurite_type=None):
+    '''Build a tree type filter from a neurite type and forward to functon
+
+    TODO:
+        This should be a decorator
+    '''
+    tree_filter = None if neurite_type is None else _is_type(neurite_type)
+    return _mm.iter_segments(nrn, tree_filter=tree_filter)
+
 
 load_population = deprecated('Use load_neurons instead.',
                              fun_name='load_population')(load_neurons)
@@ -95,10 +107,10 @@ NEURITEFEATURES = {
     'trunk_origin_elevations': _mm.trunk_origin_elevations,
     'trunk_section_lengths': _mm.trunk_section_lengths,
     'segment_lengths': _mm.segment_lengths,
-    'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _mm.iter_segments(nrn, **kwargs)],
+    'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _iseg(nrn, **kwargs)],
     'segment_midpoints': _mm.segment_midpoints,
     'segment_taper_rates': lambda nrn, **kwargs: [seg_taper(s)
-                                                  for s in _mm.iter_segments(nrn, **kwargs)],
+                                                  for s in _iseg(nrn, **kwargs)],
     'segment_radial_distances': _mm.segment_radial_distances,
     'principal_direction_extents': _mm.principal_direction_extents
 }

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -95,8 +95,6 @@ def test_section_tortuosity_pop():
 
     feat = 'section_tortuosity'
 
-    print 'XXX', _stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite))
-
     nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
                        (1.0,
                         4.6571118550276704,

--- a/neurom/fst/tests/test_mm.py
+++ b/neurom/fst/tests/test_mm.py
@@ -102,7 +102,7 @@ def test_section_tortuosity():
     nt.eq_(_mm.section_tortuosity(sec_a), 1.0)
     nt.eq_(_mm.section_tortuosity(sec_b), 4.0 / 2.0)
 
-    for s in _mm.i_chain2(NRN.neurites):
+    for s in _mm.iter_sections(NRN):
         s = s.value
         nt.eq_(_mm.section_tortuosity(s),
                mmth.section_length(s) / mmth.point_dist(s[0], s[-1]))

--- a/neurom/fst/tests/test_mm.py
+++ b/neurom/fst/tests/test_mm.py
@@ -103,7 +103,6 @@ def test_section_tortuosity():
     nt.eq_(_mm.section_tortuosity(sec_b), 4.0 / 2.0)
 
     for s in _mm.iter_sections(NRN):
-        s = s.value
         nt.eq_(_mm.section_tortuosity(s),
                mmth.section_length(s) / mmth.point_dist(s[0], s[-1]))
 


### PR DESCRIPTION
Return iterables to sections and segments respectively. Both take a tree filter object as parameter as opposed to a neurite type. This allows for more general filtering over neurite tree characteristics.