### PR TITLE
Allow single neurite trees as parameter to fst.get function

### DIFF
--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -112,7 +112,7 @@ def extract_stats(neurons):
         stat_name = old_name(ns)
         stats[stat_name] = {}
         for n in NEURITES:
-            stats[stat_name][n.name] = eval_stats(fst.get(ns, neurons, n))
+            stats[stat_name][n.name] = eval_stats(fst.get(ns, neurons, neurite_type=n))
             L.debug('Stat: %s, Neurite: %s, Type: %s', ns, n, type(stats[stat_name][n.name]))
 
     for ns in NEURON_STATS:

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -125,6 +125,7 @@ def get(feature, obj, **kwargs):
     '''Neuron feature getter helper
 
     Parameters:
+        feature (string): feature to extract.
         obj: a neuron, population or neurite tree.
         **kwargs: parameters to forward to underlying worker functions.
 

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -122,7 +122,7 @@ NEURONFEATURES = {
 
 
 def get(feature, obj, **kwargs):
-    '''Neuron feature getter helper
+    '''Obtain a feature from a set of morphology objects
 
     Parameters:
         feature (string): feature to extract.
@@ -137,3 +137,12 @@ def get(feature, obj, **kwargs):
                else NEURONFEATURES[feature])
 
     return _np.array(feature(obj, **kwargs))
+
+
+_SEP = '\n\t- '
+_get_doc = ('\nNeurite features (neurite, neuron, neuron population):%s%s'
+            '\nNeuron features (neuron, neuron population):%s%s'
+            % (_SEP, _SEP.join(sorted(NEURITEFEATURES)),
+               _SEP, _SEP.join(sorted(NEURONFEATURES))))
+
+get.__doc__ += _get_doc  # pylint: disable=no-member

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -59,6 +59,7 @@ from ..utils import deprecated
 from ..core.types import NeuriteType
 from ..core.types import NEURITES as NEURITE_TYPES
 from ..core.types import tree_type_checker as _is_type
+from ..core.tree import Tree
 from ..analysis.morphmath import segment_radius as seg_rad
 from ..analysis.morphmath import segment_taper_rate as seg_taper
 from ..analysis.morphmath import section_length as sec_len
@@ -101,10 +102,6 @@ NEURITEFEATURES = {
     'remote_bifurcation_angles': _mm.remote_bifurcation_angles,
     'partition': _mm.bifurcation_partitions,
     'number_of_segments': partial(_as_neurons, _mm.n_segments),
-    'trunk_origin_radii': _mm.trunk_origin_radii,
-    'trunk_origin_azimuths': _mm.trunk_origin_azimuths,
-    'trunk_origin_elevations': _mm.trunk_origin_elevations,
-    'trunk_section_lengths': _mm.trunk_section_lengths,
     'segment_lengths': _mm.segment_lengths,
     'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _iseg(nrn, **kwargs)],
     'segment_midpoints': _mm.segment_midpoints,
@@ -117,14 +114,25 @@ NEURITEFEATURES = {
 NEURONFEATURES = {
     'soma_radii': _mm.soma_radii,
     'soma_surface_areas': _mm.soma_surface_areas,
+    'trunk_origin_radii': _mm.trunk_origin_radii,
+    'trunk_origin_azimuths': _mm.trunk_origin_azimuths,
+    'trunk_origin_elevations': _mm.trunk_origin_elevations,
+    'trunk_section_lengths': _mm.trunk_section_lengths,
 }
 
 
-def get(feature, *args, **kwargs):
+def get(feature, obj, **kwargs):
     '''Neuron feature getter helper
 
-    Returns features as a 1D numpy array.
+    Parameters:
+        obj: a neuron, population or neurite tree.
+        **kwargs: parameters to forward to underlying worker functions.
+
+    Returns:
+        features as a 1D or 2D numpy array.
     '''
+
     feature = (NEURITEFEATURES[feature] if feature in NEURITEFEATURES
                else NEURONFEATURES[feature])
-    return _np.array(feature(*args, **kwargs))
+
+    return _np.array(feature(obj, **kwargs))

--- a/neurom/fst/tests/test_feature_compat.py
+++ b/neurom/fst/tests/test_feature_compat.py
@@ -84,12 +84,18 @@ class SectionTreeBase(object):
         nt.assert_equal(neurite_types, [n1.type for n1 in self.ref_nrn.neurites])
 
     def test_get_n_sections(self):
+        nt.assert_equal(fst._mm.n_sections(self.sec_nrn.neurites[0]),
+                        get('number_of_sections', self.ref_nrn.neurites[0])[0])
+
         nt.assert_equal(fst._mm.n_sections(self.sec_nrn), get('number_of_sections', self.ref_nrn)[0])
         for t in NeuriteType:
             nt.assert_equal(fst._mm.n_sections(self.sec_nrn, neurite_type=t),
                             get('number_of_sections', self.ref_nrn, neurite_type=t)[0])
 
     def test_get_n_sections_per_neurite(self):
+        _equal(fst._mm.n_sections_per_neurite(self.sec_nrn.neurites[0]),
+               get('number_of_sections_per_neurite', self.ref_nrn.neurites[0]))
+
         _equal(fst._mm.n_sections_per_neurite(self.sec_nrn),
                get('number_of_sections_per_neurite', self.ref_nrn))
 
@@ -98,18 +104,27 @@ class SectionTreeBase(object):
                    get('number_of_sections_per_neurite', self.ref_nrn, neurite_type=t))
 
     def test_get_n_segments(self):
+        nt.assert_equal(fst._mm.n_segments(self.sec_nrn.neurites[0]),
+                        get('number_of_segments', self.ref_nrn.neurites[0])[0])
+
         nt.assert_equal(fst._mm.n_segments(self.sec_nrn), get('number_of_segments', self.ref_nrn)[0])
         for t in NeuriteType:
             nt.assert_equal(fst._mm.n_segments(self.sec_nrn, neurite_type=t),
                             get('number_of_segments', self.ref_nrn, neurite_type=t)[0])
 
     def test_get_number_of_neurites(self):
+        nt.assert_equal(fst._mm.n_neurites(self.sec_nrn.neurites[0]),
+                        get('number_of_neurites', self.ref_nrn.neurites[0])[0])
+
         nt.assert_equal(fst._mm.n_neurites(self.sec_nrn), get('number_of_neurites', self.ref_nrn)[0])
         for t in NeuriteType:
             nt.assert_equal(fst._mm.n_neurites(self.sec_nrn, neurite_type=t),
                             get('number_of_neurites', self.ref_nrn, neurite_type=t)[0])
 
     def test_get_section_path_distances(self):
+        _close(fst._mm.section_path_lengths(self.sec_nrn.neurites[0]),
+               get('section_path_distances', self.ref_nrn.neurites[0]))
+
         _close(fst._mm.section_path_lengths(self.sec_nrn), get('section_path_distances', self.ref_nrn))
         for t in NeuriteType:
             _close(fst._mm.section_path_lengths(self.sec_nrn, neurite_type=t),
@@ -120,6 +135,9 @@ class SectionTreeBase(object):
 
     @nt.nottest
     def test_get_segment_lengths(self):
+        _equal(fst._mm.segment_lengths(self.sec_nrn.neurites[0]),
+               get('segment_lengths', self.ref_nrn.neurites[0]))
+
         _equal(fst._mm.segment_lengths(self.sec_nrn), get('segment_lengths', self.ref_nrn))
         for t in NeuriteType:
             _equal(fst._mm.segment_lengths(self.sec_nrn, neurite_type=t),
@@ -132,6 +150,9 @@ class SectionTreeBase(object):
         nt.assert_equal(fst._mm.soma_surface_area(self.sec_nrn), get('soma_surface_areas', self.ref_nrn)[0])
 
     def test_get_local_bifurcation_angles(self):
+        _close(fst._mm.local_bifurcation_angles(self.sec_nrn.neurites[0]),
+               get('local_bifurcation_angles', self.ref_nrn.neurites[0]))
+
         _close(fst._mm.local_bifurcation_angles(self.sec_nrn),
                get('local_bifurcation_angles', self.ref_nrn))
 
@@ -145,6 +166,9 @@ class SectionTreeBase(object):
         _close(ba, get('local_bifurcation_angles', self.ref_nrn))
 
     def test_get_remote_bifurcation_angles(self):
+        _close(fst._mm.remote_bifurcation_angles(self.sec_nrn.neurites[0]),
+               get('remote_bifurcation_angles', self.ref_nrn.neurites[0]))
+
         _close(fst._mm.remote_bifurcation_angles(self.sec_nrn),
                get('remote_bifurcation_angles', self.ref_nrn))
 
@@ -158,6 +182,9 @@ class SectionTreeBase(object):
         _close(ba, get('remote_bifurcation_angles', self.ref_nrn))
 
     def test_get_section_radial_distances(self):
+        _close(fst._mm.section_radial_distances(self.sec_nrn.neurites[0]),
+               get('section_radial_distances', self.ref_nrn.neurites[0]))
+
         _close(fst._mm.section_radial_distances(self.sec_nrn),
                get('section_radial_distances', self.ref_nrn))
 

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -335,3 +335,11 @@ def test_segment_radii_nrn():
                         1.0215770602226257,
                         256.71241207793355,
                         0.61122002875698467)))
+
+
+def test_neurite_features_accept_single_tree():
+
+    features = fst.NEURITEFEATURES.keys()
+
+    for f in features:
+        fst.get(f, NRN.neurites[0])


### PR DESCRIPTION
Note: trunk features have been mover to NEURONFEATURES.
Resolves #394.