### PR TITLE
Fix unclosed figures in viewer.draw tests

### DIFF
--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -32,7 +32,7 @@ from neurom.fst import load_neuron as load_fst_neuron
 from neurom import viewer
 from neurom.analysis.morphtree import set_tree_type
 import os
-from matplotlib import pylab as plt
+from matplotlib import pyplot as plt
 
 
 class Dummy(object):

--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -32,7 +32,7 @@ from neurom.fst import load_neuron as load_fst_neuron
 from neurom import viewer
 from neurom.analysis.morphtree import set_tree_type
 import os
-import pylab as plt
+from matplotlib import pylab as plt
 
 
 class Dummy(object):

--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -32,6 +32,7 @@ from neurom.fst import load_neuron as load_fst_neuron
 from neurom import viewer
 from neurom.analysis.morphtree import set_tree_type
 import os
+import pylab as plt
 
 
 class Dummy(object):
@@ -49,26 +50,31 @@ nrn = load_neuron(MORPH_FILENAME, set_tree_type)
 def test_draw_neuron():
     viewer.draw(nrn)
     viewer.draw(fst_nrn)
+    plt.close('all')
 
 
 def test_draw_neuron3d():
     viewer.draw(nrn, mode='3d')
     viewer.draw(fst_nrn, mode='3d')
+    plt.close('all')
 
 
 def test_draw_tree():
     viewer.draw(nrn.neurites[0])
     viewer.draw(fst_nrn.neurites[0])
+    plt.close('all')
 
 
 def test_draw_tree3d():
     viewer.draw(nrn.neurites[0], mode='3d')
     viewer.draw(fst_nrn.neurites[0], mode='3d')
+    plt.close('all')
 
 
 def test_draw_soma():
     viewer.draw(nrn.soma)
     viewer.draw(fst_nrn.soma)
+    plt.close('all')
 
 
 def test_draw_soma3d():
@@ -78,6 +84,7 @@ def test_draw_soma3d():
 
 def test_draw_dendrogram():
     viewer.draw(nrn, mode='dendrogram')
+    plt.close('all')
 
 
 @nt.raises(viewer.InvalidDrawModeError)

--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -80,6 +80,7 @@ def test_draw_soma():
 def test_draw_soma3d():
     viewer.draw(nrn.soma, mode='3d')
     viewer.draw(fst_nrn.soma, mode='3d')
+    plt.close('all')
 
 
 def test_draw_dendrogram():


### PR DESCRIPTION
The tests of viewer.draw were generating too many figures, because they were not closed during the testing process. I made a quick fix for this to avoid the warnings of "too many opened figures" during the tests. 