### PR TITLE
Generic 3D transformations

### DIFF
--- a/neurom/check/morphology.py
+++ b/neurom/check/morphology.py
@@ -37,7 +37,6 @@ from neurom.analysis.morphmath import section_length
 from neurom.analysis.morphmath import segment_length
 from neurom.check.morphtree import is_flat, is_monotonic, is_back_tracking
 from neurom.exceptions import SomaError
-from neurom.io import check as io_check
 from neurom.fst import _mm as fst_mm
 
 
@@ -194,5 +193,12 @@ def nonzero_neurite_radii(neuron, threshold=0.0):
         threshold: value above which a radius is considered to be non-zero
     Return: list of IDs of zero-radius points
     '''
-    return io_check.has_all_finite_radius_neurites(neuron.data_block,
-                                                   threshold)[1]
+    bad_ids = []
+    seen_ids = set()
+    for s in fst_mm.iter_sections(neuron):
+        for p in s:
+            if p[COLS.R] <= threshold and p[COLS.ID] not in seen_ids:
+                seen_ids.add(p[COLS.ID])
+                bad_ids.append(p[COLS.ID])
+
+    return bad_ids

--- a/neurom/check/tests/test_morphology.py
+++ b/neurom/check/tests/test_morphology.py
@@ -59,8 +59,8 @@ def _make_monotonic(neuron):
 
 
 def _make_flat(neuron):
-    for neurite in neuron.neurites:
-        neurite.points[:, COLS.Z] = 0.
+    for s in neuron.sections:
+        s.value[:, COLS.Z] = 0.;
 
 
 NEURONS = dict([_load_neuron(n) for n in ['Neuron.h5',
@@ -263,7 +263,7 @@ def test_nonzero_neurite_radii_threshold():
 def test_nonzero_neurite_radii_bad_data():
     nrn = NEURONS['Neuron_zero_radius.swc']
     ids = check_morph.nonzero_neurite_radii(nrn)
-    nt.ok_(ids == [194, 210, 246, 304, 493])
+    nt.assert_equal(ids, [194, 210, 246, 304, 493])
 
 
 def test_nonzero_segment_lengths_good_data():

--- a/neurom/core/neuron.py
+++ b/neurom/core/neuron.py
@@ -30,7 +30,6 @@
 from neurom.analysis.morphmath import average_points_dist
 import neurom.core.tree as tr
 from neurom.core.dataformat import COLS
-from neurom.core.tree import make_copy
 from copy import deepcopy
 from neurom.exceptions import SomaError
 import numpy as np
@@ -208,6 +207,4 @@ class Neuron(object):
     def copy(self):
         '''Return a copy of the Neuron object.
         '''
-        return Neuron(deepcopy(self.soma),
-                      [make_copy(neu) for neu in self.neurites],
-                      self.name)
+        return deepcopy(self)

--- a/neurom/core/tests/test_neuron.py
+++ b/neurom/core/tests/test_neuron.py
@@ -27,6 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from nose import tools as nt
+from copy import deepcopy
 from neurom.core import neuron
 from neurom.core.tree import Tree, val_iter, ipreorder
 from neurom.exceptions import SomaError
@@ -182,6 +183,18 @@ def test_copy():
     soma = neuron.make_soma([[0, 0, 0, 1, 1, 1, -1]])
     nrn1 = neuron.Neuron(soma, [TREE], name="Rabbit of Caerbannog")
     nrn2 = nrn1.copy()
+    check_cloned_neuron(nrn1, nrn2)
+
+
+def test_deep_copy():
+
+    soma = neuron.make_soma([[0, 0, 0, 1, 1, 1, -1]])
+    nrn1 = neuron.Neuron(soma, [TREE], name="Rabbit of Caerbannog")
+    nrn2 = deepcopy(nrn1)
+    check_cloned_neuron(nrn1, nrn2)
+
+
+def check_cloned_neuron(nrn1, nrn2):
 
     # check if two neurons are identical
 

--- a/neurom/core/tests/test_tree.py
+++ b/neurom/core/tests/test_tree.py
@@ -46,9 +46,7 @@ from neurom.core.tree import ibifurcation_point
 from neurom.core.tree import isection
 from neurom.core.tree import val_iter
 from neurom.core.tree import i_branch_end_points
-from neurom.core.tree import make_copy
 from copy import deepcopy
-from itertools import izip
 
 REF_TREE = Tree(0)
 REF_TREE.add_child(Tree(11))
@@ -377,36 +375,3 @@ def test_branch_end_points():
 
     nt.assert_equal(_build_tuple(REF_TREE2.children[0].children[0].children[0]),
                     (11111, 11112, 11113))
-
-
-def test_make_copy():
-
-    tree_copy = make_copy(REF_TREE3)
-
-    # assert that the two trees have the same values
-
-    # first by total nodes
-    nt.assert_true(len(list(ipreorder(tree_copy))) == len(list(ipreorder(REF_TREE3))))
-
-    # then node by node
-    for val1, val2 in izip(val_iter(ipreorder(tree_copy)), val_iter(ipreorder(REF_TREE3))):
-
-        nt.assert_true(all(val1 == val2))
-
-    # assert that the tree values do not have the same identity
-    for val1, val2 in izip(val_iter(ipreorder(tree_copy)), val_iter(ipreorder(REF_TREE3))):
-
-        nt.assert_false(val1 is val2)
-
-    # create a deepcopy of the original tree for validation
-    validation_tree = deepcopy(REF_TREE3)
-
-    # modify copied tree
-    tree_copy.value[0:3] = np.array([1000.,1000.,-1000.])
-    tree_copy.children[0].add_child(Tree(np.array([0., 0., 0., 1., 1., 1., 1.])))
-
-    # check if anything changed in REF_TREE3 with respect to the validation deepcopy
-    nt.assert_true(len(list(ipreorder(validation_tree))) == len(list(ipreorder(REF_TREE3))))
-    for val1, val2 in izip(val_iter(ipreorder(REF_TREE3)), val_iter(ipreorder(validation_tree))):
-
-        nt.assert_true(all(val1 == val2))

--- a/neurom/core/tree.py
+++ b/neurom/core/tree.py
@@ -29,7 +29,6 @@
 '''Generic tree class and iteration functions'''
 from itertools import chain, imap, ifilter, repeat
 from collections import deque
-from copy import copy
 
 
 class Tree(object):
@@ -271,34 +270,3 @@ def i_chain2(trees, iterator_type=ipreorder, mapping=None, tree_filter=None):
 
     chain_it = chain.from_iterable(imap(iterator_type, nrt))
     return chain_it if mapping is None else imap(mapping, chain_it)
-
-
-def make_copy(tree):
-    '''
-    Copies a tree structure. A new tree is generated with the copied values
-    and node structure as the input one and is returned.
-
-    Input : tree object
-
-    Returns : copied tree object
-    '''
-    copy_head = Tree(copy(tree.value))
-
-    orig_children = [tree, ]
-    copy_children = [copy_head, ]
-
-    while orig_children:
-
-        orig_current_node = orig_children.pop()
-        copy_current_node = copy_children.pop()
-
-        for c in orig_current_node.children:
-
-            copy_child = Tree(copy(c.value))
-
-            copy_current_node.add_child(copy_child)
-
-            orig_children.append(c)
-            copy_children.append(copy_child)
-
-    return copy_head

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -52,8 +52,9 @@ Examples:
 '''
 
 import numpy as _np
-from functools import partial
-from ._io import load_neuron, load_neurons, Neuron, Neurite
+from functools import partial, update_wrapper
+from ._io import load_neuron, load_neurons
+from ._core import Neuron, Neurite
 from . import _mm
 from ..utils import deprecated
 from ..core.population import Population

--- a/neurom/fst/_core.py
+++ b/neurom/fst/_core.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Fast neuron IO module'''
+
+from copy import deepcopy
+import numpy as np
+from neurom.core.types import NeuriteType
+from neurom.core.tree import Tree, ipreorder
+from neurom.core.dataformat import POINT_TYPE
+from neurom.core.dataformat import COLS
+from neurom.core.neuron import make_soma
+
+
+class Neurite(object):
+    '''Class representing a neurite tree'''
+    def __init__(self, root_node):
+        self.root_node = root_node
+        self.type = root_node.type
+        self._points = None
+
+    @property
+    def points(self):
+        '''Return unordered array with all the points in this neurite'''
+        # add all points in a section except the first one, which is a
+        # duplicate
+        _pts = [v for s in ipreorder(self.root_node) for v in s.value[1:, :4]]
+        # except for the very first point, which is not a duplicate
+        _pts.insert(0, self.root_node.value[0][:4])
+        _points = np.array(_pts)
+
+        return _points
+
+    def transform(self, trans):
+        '''Return a copy of this neurite with a 3D transformation applied'''
+        clone = deepcopy(self)
+        for n in clone.iter_nodes():
+            n.value[:, 0:3] = trans(n.value[:, 0:3])
+
+        return clone
+
+    def iter_nodes(self):
+        '''unordered iteration over section nodes'''
+        return ipreorder(self.root_node)
+
+    def __deepcopy__(self, memo):
+        '''Deep copy of neurite object'''
+        return Neurite(deepcopy(self.root_node, memo))
+
+
+class Neuron(object):
+    '''Class representing a neuron'''
+    def __init__(self, data_wrapper, name='Neuron'):
+        self._data = data_wrapper
+        self.neurites, self.sections = make_neurites(self._data)
+        self.soma = make_soma(self._data.soma_points())
+        self.name = name
+
+    @property
+    def points(self):
+        '''Return unordered array with all the points in this neuron'''
+        _points = self.soma.points.tolist()
+        for n in self.neurites:
+            _points.extend(n.points.tolist())
+        return np.array(_points)
+
+    def transform(self, trans):
+        '''Return a copy of this neuron with a 3D transformation applied'''
+        _data = deepcopy(self._data)
+        _data.data_block[:, 0:3] = trans(_data.data_block[:, 0:3])
+        return Neuron(_data, self.name)
+
+    def __deepcopy__(self, memo):
+        '''Deep-copy neuron object
+
+        Note:
+            Efficient copying is performed by deep-copying the internal
+            data block and building a neuron from it
+        '''
+        return Neuron(deepcopy(self._data, memo), self.name)
+
+
+def make_neurites(rdw):
+    '''Build neurite trees from a raw data wrapper'''
+    post_action = _NEURITE_ACTION[rdw.fmt]
+    trunks = rdw.neurite_trunks()
+    if len(trunks) == 0:
+        return [], []
+
+    start_node = min(trunks)
+
+    # One pass over sections to build nodes
+    nodes = tuple(Tree(rdw.data_block[sec.ids]) for sec in rdw.sections)
+
+    # One pass over nodes to set the neurite type
+    # and connect children to parents
+    for i, node in enumerate(nodes):
+        node.type = _TREE_TYPES[rdw.sections[i].ntype]
+        node.section_id = i
+        parent_id = rdw.sections[i].pid
+        # only connect neurites
+        if parent_id >= start_node:
+            nodes[parent_id].add_child(node)
+
+    neurites = tuple(Neurite(nodes[i]) for i in trunks)
+
+    if post_action is not None:
+        for n in neurites:
+            post_action(n.root_node)
+
+    return neurites, nodes
+
+
+def _remove_soma_initial_point(tree):
+    '''Remove tree's initial point if soma'''
+    if tree.value[0][COLS.TYPE] == POINT_TYPE.SOMA:
+        tree.value = tree.value[1:]
+
+
+_TREE_TYPES = tuple(NeuriteType)
+
+_NEURITE_ACTION = {
+    'SWC': _remove_soma_initial_point,
+    'H5V1': None,
+    'H5V2': None,
+    'NL-ASCII': None
+}

--- a/neurom/fst/tests/test_core.py
+++ b/neurom/fst/tests/test_core.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test neurom.fst._core module'''
+
+from copy import deepcopy
+import numpy as np
+from nose import tools as nt
+import os
+from neurom.fst import _core
+from neurom.fst import _io
+
+_path = os.path.dirname(os.path.abspath(__file__))
+DATA_ROOT = os.path.join(_path, '../../../test_data')
+DATA_PATH = os.path.join(_path, '../../../test_data/valid_set')
+FILENAMES = [os.path.join(DATA_PATH, f)
+             for f in ['Neuron.swc', 'Neuron_h5v1.h5', 'Neuron_h5v2.h5']]
+
+NRN_NAMES = ('Neuron', 'Neuron_h5v1', 'Neuron_h5v2')
+
+
+def test_neuron_name():
+
+    d = _io.load_data(FILENAMES[0])
+    nrn = _core.Neuron(d, '12af3rg')
+    nt.eq_(nrn.name, '12af3rg')
+
+
+def _check_cloned_neurites(a, b):
+
+    nt.assert_true(a is not b)
+    nt.assert_true(a.root_node is not b.root_node)
+    nt.assert_equal(a.type, b.type)
+    for aa, bb in zip(a.iter_nodes(), b.iter_nodes()):
+        nt.assert_true(np.all(aa.value == bb.value))
+
+
+def test_neuron_deepcopy():
+
+    d = _io.load_neuron(FILENAMES[0])
+    dc = deepcopy(d)
+
+    nt.assert_true(d is not dc)
+
+    nt.assert_true(d.soma is not dc.soma)
+
+    nt.assert_true(np.all(d.soma.points == dc.soma.points))
+    nt.assert_true(np.all(d.soma.center == dc.soma.center))
+    nt.assert_equal(d.soma.radius, dc.soma.radius)
+
+    for a, b in zip(d.neurites, dc.neurites):
+        _check_cloned_neurites(a, b)
+
+
+def test_neurite_deepcopy():
+
+    d = _io.load_neuron(FILENAMES[0])
+    nrt = d.neurites[0]
+    nrt2 = deepcopy(nrt)
+
+    nt.assert_true(nrt is not nrt2)
+
+    _check_cloned_neurites(nrt, nrt2)

--- a/neurom/fst/tests/test_io.py
+++ b/neurom/fst/tests/test_io.py
@@ -47,7 +47,7 @@ NRN_NAMES = ('Neuron', 'Neuron_h5v1', 'Neuron_h5v2')
 
 def test_load_neuron():
 
-    nrn = _io.load_neuron(FILENAMES[0])
+    nrn = _io.load_neuron(FILENAMES[0],)
     nt.assert_true(isinstance(NRN, _io.Neuron))
     nt.assert_equal(NRN.name, 'Neuron')
 

--- a/neurom/geom/transform.py
+++ b/neurom/geom/transform.py
@@ -112,8 +112,7 @@ def translate(obj, t):
     Translate object of supported type.
 
     Parameters :
-        obj : object with one of the following types:
-             'NeuriteType', 'Neuron', 'fst.Neuron'
+        obj : object to be translated. Must implement a transform method.
 
     Returns:
         copy of the object with the applied translation
@@ -130,7 +129,8 @@ def rotate(obj, axis, angle, origin=None):
     Rotation around unit vector following the right hand rule
 
     Parameters:
-        obj : obj to be rotated (e.g. tree, neuron)
+        obj : obj to be rotated (e.g. neurite, neuron).
+            Must implement a transform method.
         axis : unit vector for the axis of rotation
         angle : rotation angle in rads
 

--- a/neurom/geom/transform.py
+++ b/neurom/geom/transform.py
@@ -26,13 +26,123 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''Transformation functions for tree objects'''
+'''Transformation functions for morphology objects'''
 
 import numpy as np
-from neurom.core.tree import Tree
-from neurom.core.neuron import Neuron
-from neurom.core.tree import make_copy, ipreorder, val_iter
-from neurom.core.dataformat import COLS
+
+
+_TRANSFDOC = '''
+
+    The transformation can be applied to [x, y, z] points via a call operator
+    with the following properties:
+
+    Parameters:
+        points: 2D numpy array of points, where the 3 columns
+            are the x, y, z coordinates respectively
+
+    Returns:
+        2D numpy array of transformed points
+'''
+
+
+class Transform3D(object):
+    '''Class representing a generic 3D transformation'''
+    __doc__ += _TRANSFDOC
+
+    def __call__(self, points):
+        '''Apply a 3D transformation to a set of points'''
+        raise NotImplementedError
+
+
+class Translation(Transform3D):
+    '''class representing a 3D translation'''
+    __doc__ += _TRANSFDOC
+
+    def __init__(self, translation):
+        '''
+        Parameters:
+            translation: 3-vector of x, y, z
+        '''
+        self._trans = np.array(translation)
+
+    def __call__(self, points):
+        '''Apply a 3D translation to a set of points'''
+        return points + self._trans
+
+
+class Rotation(Transform3D):
+    '''Class representing a 3D rotation'''
+    __doc__ += _TRANSFDOC
+
+    def __init__(self, dcm):
+        '''
+        Parameters:
+            cdm: a 3x3 direction cosine matrix
+        '''
+        self._dcm = np.array(dcm)
+
+    def __call__(self, points):
+        '''Apply a 3D rotation to a set of points'''
+        return np.dot(self._dcm, np.array(points).T).T
+
+
+class PivotRotation(Rotation):
+    '''Class representing a 3D rotation about a pivot point'''
+    __doc__ += _TRANSFDOC
+
+    def __init__(self, dcm, pivot=None):
+        '''
+        Parameters:
+            cdm: a 3x3 direction cosine matrix
+            pivot: a 3-vector specifying the origin of rotation
+        '''
+        super(PivotRotation, self).__init__(dcm)
+        self._origin = np.zeros(3) if pivot is None else np.array(pivot)
+
+    def __call__(self, points):
+        '''Apply a 3D pivoted rotation to a set of points'''
+        points = points - self._origin
+        points = np.dot(self._dcm, np.array(points).T).T
+        points += self._origin
+        return points
+
+
+def translate(obj, t):
+    '''
+    Translate object of supported type.
+
+    Parameters :
+        obj : object with one of the following types:
+             'NeuriteType', 'Neuron', 'fst.Neuron'
+
+    Returns:
+        copy of the object with the applied translation
+    '''
+
+    try:
+        return obj.transform(Translation(t))
+    except AttributeError:
+        raise NotImplementedError
+
+
+def rotate(obj, axis, angle, origin=None):
+    '''
+    Rotation around unit vector following the right hand rule
+
+    Parameters:
+        obj : obj to be rotated (e.g. tree, neuron)
+        axis : unit vector for the axis of rotation
+        angle : rotation angle in rads
+
+    Returns:
+        A copy of the object with the applied translation.
+    '''
+    R = _rodrigues_to_dcm(axis, angle)
+
+    try:
+        return obj.transform(PivotRotation(R, origin))
+    except AttributeError:
+        raise NotImplementedError
 
 
 def _sin(x):
@@ -40,7 +150,7 @@ def _sin(x):
     return 0. if np.isclose(np.mod(x, np.pi), 0.) else np.sin(x)
 
 
-def _rodriguesToRotationMatrix(axis, angle):
+def _rodrigues_to_dcm(axis, angle):
     '''
     Generates transformation matrix from unit vector
     and rotation angle. The rotation is applied in the direction
@@ -81,145 +191,3 @@ def _rodriguesToRotationMatrix(axis, angle):
     R[2, 2] = cs + uzz * cs1
 
     return R
-
-
-def translate(obj, t):
-    '''
-    Translate object of supported type.
-
-    Input :
-
-        obj : object with one of the following types:
-             'NeuriteType', 'Neuron', 'ezyNeuron'
-
-    Returns: copy of the object with the applied translation
-    '''
-    if isinstance(obj, Tree):
-
-        res_tree = make_copy(obj)
-        _affineTransformTree(res_tree, np.identity(3), t)
-        return res_tree
-
-    elif isinstance(obj, Neuron):
-
-        res_nrn = obj.copy()
-        _affineTransformNeuron(res_nrn, np.identity(3), t)
-        return res_nrn
-
-
-def rotate(obj, axis, angle, origin=None):
-    '''
-    Rotation around unit vector following the right hand rule
-
-    Input:
-
-        obj : obj to be rotated (e.g. tree, neuron)
-        axis : unit vector for the axis of rotation
-        angle : rotation angle in rads
-
-    Returns:
-
-        A copy of the object with the applied translation.
-    '''
-    R = _rodriguesToRotationMatrix(axis, angle)
-
-    if isinstance(obj, Tree):
-
-        res_tree = make_copy(obj)
-        _affineTransformTree(res_tree, R, np.zeros(3), origin)
-        return res_tree
-
-    elif isinstance(obj, Neuron):
-
-        res_nrn = obj.copy()
-        _affineTransformNeuron(res_nrn, R, np.zeros(3), origin)
-        return res_nrn
-
-
-def _affineTransformPoint(p, A, t, origin=None):
-    '''
-    Apply an affine transform on an iterable with x, y, z as its
-    first elements.
-    Input:
-
-        A : 3x3 transformation matrix
-        t : 3x1 translation array
-        point : iterable of the form (x, y, z, ....)
-        origin : the point with respect of which the rotation is applied.
-    '''
-
-    px, py, pz = p[:COLS.R]
-
-    if origin is not None:
-
-        px -= origin[0]
-        py -= origin[1]
-        pz -= origin[2]
-
-    x = A[0, 0] * px + A[0, 1] * py + A[0, 2] * pz + t[0]
-    y = A[1, 0] * px + A[1, 1] * py + A[1, 2] * pz + t[1]
-    z = A[2, 0] * px + A[2, 1] * py + A[2, 2] * pz + t[2]
-
-    if origin is not None:
-
-        x += origin[0]
-        y += origin[1]
-        z += origin[2]
-
-    p[COLS.X] = x
-    p[COLS.Y] = y
-    p[COLS.Z] = z
-
-
-def _affineTransformTree(tree, A, t, origin=None):
-    '''
-    Apply an affine transform on your tree by applying a linear
-    transform A (e.g. rotation) and a non-linear transform t (translation)
-
-    Input:
-
-        A : 3x3 transformation matrix
-        t : 3x1 translation array
-        tree : tree object
-        origin : the point with respect of which the rotation is applied. If
-                 None then the x,y,z of the root node is assumed to be the
-                 origin.
-    '''
-    # if no origin is specified, the position from the root node
-    # becomes the origin
-    if origin is None:
-
-        origin = tree.value[:COLS.R]
-
-    for value in val_iter(ipreorder(tree)):
-
-        _affineTransformPoint(value, A, t, origin)
-
-
-def _affineTransformNeuron(nrn, A, t, origin=None):
-    '''
-    Apply an affine transform on a neuron object by applying a linear
-    transform A (e.g. rotation) and a non-linear transform t (translation)
-
-    Input:
-
-        A : 3x3 transformation matrix
-        t : 3x1 translation array
-        neuron : neuron object
-        origin : the point with respect of which the rotation is applied. If
-                 None then the x,y,z of the root node is assumed to be the
-                 origin.
-    '''
-    # if no origin is specified, the position of the soma center
-    # is assumed as the origin
-    if origin is None:
-
-        origin = nrn.soma.center
-
-    for point in nrn.soma.iter():
-
-        _affineTransformPoint(point, A, t, origin=origin)
-
-    for neurite in nrn.neurites:
-
-        _affineTransformTree(neurite, A, t, origin=origin)

--- a/neurom/io/neurolucida.py
+++ b/neurom/io/neurolucida.py
@@ -257,4 +257,4 @@ class NeurolucidaASC(object):
         with open(morph_file) as morph_fd:
             sections = _parse_sections(morph_fd)
         raw_data = _sections_to_raw_data(sections, remove_duplicates)
-        return wrapper(raw_data, 'Beta Neurolucida ASCII')
+        return wrapper(raw_data, 'NL-ASCII')


### PR DESCRIPTION
Implemented generic 3D transformation types and added transform methods
to fst.Neuron and fst.Neurite.

Transformations implemented in neurom.geom.transform:

* pivot rotation
* rotation
* translation

fst.Neuron and fst.Neurite have transform methods that accept a
generic transformation object and return a transformed copy of
themselves. For example

```
nrn = load_neuron(....)
m = Translation([1,2,3])
nrn2 = m(nrn)
```

The neurom.geom.transform entry points use these transformations behind the scenes, but the interface remains the same:

```
from neurom.geom import transform as tr
nrn = load_neuron(...)
nrn2 = tr.translate(nrn, [1, 2, 3])
nrn3 = tr.rotate(nrn, [0, 0, 1], math.pi / 4.0)
```

Note: these transformations are not implemented for the deprecated
point neurite representation of morphologies. These have been removed
from neurom.geom.transform.

Re-factoring and clean-up related to efficient cloning of neurons and
neurites has been performed.