### PR TITLE
Re-factor morph_check code.

### DIFF
--- a/apps/config.yaml
+++ b/apps/config.yaml
@@ -40,27 +40,36 @@ color : true
 # CHECKS
 ##############################################
 
-neuron_checks :
-
-    - has_axon
-    - has_basal_dendrite
-    - has_apical_dendrite
-    - nonzero_neurite_radii
-    - nonzero_segment_lengths
-    - nonzero_section_lengths
-    - has_all_monotonic_neurites
-    - has_no_flat_neurites
+checks:
+    structural_checks:
+        - is_single_tree
+        - has_soma_points
+        - has_sequential_ids
+        - has_increasing_ids
+        - has_valid_soma
+        - has_valid_neurites
+    neuron_checks:
+        - has_basal_dendrite
+        - has_axon
+        - has_apical_dendrite
+        - has_all_nonzero_segment_lengths
+        - has_all_nonzero_section_lengths
+        - has_all_nonzero_neurite_radii
+        - has_all_monotonic_neurites
+        - has_no_flat_neurites
+        - has_nonzero_soma_radius
 
 ##############################################
 # OPTIONS
 ##############################################
 
 options :
-    
+
     # threshold
-    nonzero_neurite_radii   : 0.007
-    nonzero_segment_lengths : 0.01
-    nonzero_section_lengths : 0.01
+    has_nonzero_soma_radius         : 0.0
+    has_all_nonzero_neurite_radii   : 0.007
+    has_all_nonzero_segment_lengths : 0.01
+    has_all_nonzero_section_lengths : 0.01
 
     # tolerance/ratio, method
     has_no_flat_neurites       : [0.1, 'ratio']

--- a/apps/morph_check
+++ b/apps/morph_check
@@ -29,17 +29,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 '''Examples of basic data checks'''
-from neurom.io.utils import get_morph_files
-from neurom import load_neuron
-from neurom.check import ok as chk_ok
-from neurom.check import morphology as morph_chk
-from neurom.exceptions import SomaError, IDSequenceError, MultipleTrees, MissingParentError
-from collections import OrderedDict
+from neurom.check.runner import CheckRunner
 import argparse
-import functools
 import logging
 import yaml
-import os
 import sys
 import json
 
@@ -56,13 +49,34 @@ Description
 Performs checks on reconstructed morphologies from data contained in
 morphology files.
 
-Files are unloaded into neuron objects before testing. This means they must
-have a soma and no format errors.
+The tests are performed in two steps:
+
+1. Files are loaded into an intermediary "raw data" format. If this fails, the
+tests for that particular file are aborted. Reasons for failure can include
+structural issues that are too difficult to recover from.
+
+2. Structural tests are carried out. Failure in some of these may make further
+tests fail.
+
+3. A neuron object is built from the data loaded in 1. Failure at this stage
+results in further tests for this particular file being aborted.
+
+4. Soma and neurite tests are performed.
+
+It is very likely that a failure in the structural tests will make the neurite
+and soma tests fail. Furthermore, inability to build a soma typically results
+in an inability to build neurites. Failure to build a soma or neurites results
+in an early faulure for a given morphology file.
 
 Default errors checked for
-------------------
-* No soma
-* Disconnected points
+--------------------------
+* Not a single tree structure
+* No soma points detectes
+* Missing parents
+* IDs not in increasing order
+* IDs not sequential
+* No soma could be reconstructed
+* No neurites could be reconstructed
 * Zero radius soma
 * No axon
 * No apical dendrite
@@ -74,9 +88,9 @@ Default errors checked for
 Default values for options
 --------------
 * has_nonzero_soma_radius 0.0
-* nonzero_neurite_radii: 0.007
-* nonzero_segment_lengths: 0.01
-* nonzero_section_lengths: 0.01
+* has_all_nonzero_neurite_radii: 0.007
+* has_all_nonzero_segment_lengths: 0.01
+* has_all_nonzero_section_lengths: 0.01
 
 Examples
 --------
@@ -130,115 +144,38 @@ def parse_args():
     return parser.parse_args()
 
 
-def log_msg(msg, ok, color=False):
-    '''Helper to log message to the right level'''
-    if color:
-        CGREEN, CRED, CEND = '\033[92m', '\033[91m', '\033[0m'
-    else:
-        CGREEN = CRED = CEND = ''
-
-    LOG_LEVELS = {False: logging.ERROR, True: logging.INFO}
-
-    L.log(LOG_LEVELS[ok],
-          '%35s %s' + CEND, msg, CGREEN + 'PASS' if ok else CRED + 'FAIL')
-
-
-def check_file(f, config):
-    '''Run tests on a morphology file'''
-
-    L.info('File: %s', f)
-    if 'color' in config:
-        _log_msg = functools.partial(log_msg, color=config['color'])
-
-    summary = OrderedDict()
-
-    try:
-        nrn = load_neuron(f)
-        summary['Has valid soma'] = True
-        summary['All points connected'] = True
-    except SomaError:
-        summary['Has valid soma'] = False
-        L.error('No valid soma detected... Aborting')
-        return False, None
-    except (MissingParentError, MultipleTrees) as e:
-        summary['All points connected'] = False
-        L.error(e.message)
-        return False, None
-
-    result = True
-
-    for check in config['neuron_checks']:
-
-        if check in config['options']:
-            fargs = config['options'][check]
-            if isinstance(fargs, list):
-                out = getattr(morph_chk, check)(nrn, *fargs)
-            else:
-                out = getattr(morph_chk, check)(nrn, fargs)
-        else:
-            out = getattr(morph_chk, check)(nrn)
-
-        ok = chk_ok(out)
-        msg = check.replace('_', ' ').capitalize()
-        summary[msg] = ok
-
-        try:
-            if len(out) > 0:
-                L.debug('%s: %d failing ids detected: %s', msg, len(out), out)
-        except TypeError:
-            pass
-
-        result &= ok
-
-    summary['ALL'] = result
-
-    for m, s in summary.iteritems():
-        _log_msg(m, s)
-
-    return result, {f: summary}
-
-
-def check_files(files, config):
-    '''Test a bunch of files'''
-
-    SEPARATOR = '=' * 40
-    summary = {}
-    res = True
-
-    for _f in files:
-        L.info(SEPARATOR)
-        try:
-            status, summ = check_file(_f, config)
-            res &= status
-            summary.update(summ)
-        except IDSequenceError as e:
-            L.error('ID ERROR in file %s: %s', _f, e.message)
-        except StandardError as e:
-            L.error('Could not read file %s: %s', _f, e.message)
-
-    L.info(SEPARATOR)
-
-    status = 'PASS' if res else 'FAIL'
-
-    return {'files': summary, 'STATUS': status}
-
-
 # Default check configuration parameters
-CONFIG = {'neuron_checks': ['has_nonzero_soma_radius',
-                            'has_basal_dendrite',
-                            'has_axon',
-                            'has_apical_dendrite',
-                            'nonzero_segment_lengths',
-                            'nonzero_section_lengths',
-                            'nonzero_neurite_radii'],
-          'options': {'has_nonzero_soma_radius': 0.0,
-                      "nonzero_neurite_radii": 0.007,
-                      "nonzero_segment_lengths": 0.01,
-                      "nonzero_section_lengths": 0.01},
-          'color': False}
+CONFIG = {
+    'checks': {
+        'structural_checks': [
+            'is_single_tree',
+            'has_soma_points',
+            'has_sequential_ids',
+            'has_increasing_ids',
+            'has_valid_soma',
+            'has_valid_neurites'
+        ],
+        'neuron_checks': [
+            'has_basal_dendrite',
+            'has_axon',
+            'has_apical_dendrite',
+            'has_all_nonzero_segment_lengths',
+            'has_all_nonzero_section_lengths',
+            'has_all_nonzero_neurite_radii',
+            'has_nonzero_soma_radius'
+        ]
+    },
+    'options': {
+        'has_nonzero_soma_radius': 0.0,
+        "has_all_nonzero_neurite_radii": 0.007,
+        "has_all_nonzero_segment_lengths": 0.01,
+        "has_all_nonzero_section_lengths": 0.01
+    },
+    'color': False
+}
 
 
-def run_checks(args):
+def main(args):
     '''Run all the checks'''
     _setup_logging(args.debug, args.log_file)
 
@@ -253,25 +190,15 @@ def run_checks(args):
         # set default checks
         _config = CONFIG
 
-    if os.path.isfile(args.datapath):
-        _files = [args.datapath]
-    elif os.path.isdir(args.datapath):
-        L.info('Checking files in directory %s', args.datapath)
-        _files = get_morph_files(args.datapath)
-    else:
-        L.error('Invalid data path %s', args.datapath)
-        sys.exit(1)
-
-    summary_ = check_files(_files, _config)
+    checker = CheckRunner(_config)
+    summary = checker.run(args.datapath)
 
     with open(args.output_file, 'w') as json_output:
-        json.dump(summary_, json_output, indent=4)
+        json.dump(summary, json_output, indent=4)
 
-    return 0 if summary_['STATUS'] == 'PASS' else 1
+    return 0 if summary['STATUS'] == 'PASS' else 1
 
 
 if __name__ == '__main__':
 
-    _args = parse_args()
-    exit_status = run_checks(_args)
-    sys.exit(exit_status)
+    sys.exit(main(parse_args()))

--- a/apps/raw_data_check
+++ b/apps/raw_data_check
@@ -29,7 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 '''Examples of basic data checks'''
-from neurom.io import check as io_chk
+from neurom.check import structural_checks as st_chk
 from neurom.io.utils import get_morph_files
 from neurom.fst._io import load_data
 import argparse
@@ -93,9 +93,9 @@ if __name__ == '__main__':
     for f in files:
         rd = load_data(f)
         print '\nCheck file %s...' % f
-        print 'Has soma points? %s' % io_chk.has_soma_points(rd)
+        print 'Has soma points? %s' % st_chk.has_soma_points(rd)
 
-        ci = io_chk.has_sequential_ids(rd)
+        ci = st_chk.has_sequential_ids(rd)
         print 'Consecutive indices? %s' % ci[0]
         if not ci[0]:
             print'Non consecutive IDs detected:', ci[1]

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -34,6 +34,14 @@ API Documentation
 
    neurom
    neurom.viewer
+   neurom.fst
+   neurom.fst.sectionfunc
+   neurom.exceptions
+   neurom.stats
+   neurom.check
+   neurom.check.structural_checks
+   neurom.check.neurite_checks
+   neurom.check.soma_checks
    neurom.core
    neurom.core.types
    neurom.core.tree
@@ -42,7 +50,6 @@ API Documentation
    neurom.core.dataformat
    neurom.io
    neurom.io.readers
-   neurom.io.check
    neurom.io.utils
    neurom.io.swc
    neurom.io.hdf5
@@ -52,7 +59,3 @@ API Documentation
    neurom.analysis
    neurom.analysis.morphmath
    neurom.analysis.morphtree
-   neurom.fst
-   neurom.fst.sectionfunc
-   neurom.exceptions
-   neurom.stats

--- a/doc/source/quick.rst
+++ b/doc/source/quick.rst
@@ -70,15 +70,14 @@ plots of neurites, somata and neurons. It also has a dendrogram neurom plotting 
 .. seealso::
     The :py:mod:`neurom.viewer` documentation for more details and examples.
 
-Data checking applications
---------------------------
+Data checking application
+-------------------------
 
-There are two user-friendly data checking applications. ``raw_data_check`` checks for basic 
-consistency
-of raw data, and ``morph_check`` applies some further semantic checks to the data in order to
+The ``morph_check`` application applies some structural and semantic 
+checks to morphology data files in order to
 determine whether it is suitable to construct a neuron structure and whether certain
-defects within the structure are detected. Both can be invoked from the command line, and
-take as main argument the path to either a single file or a directory of morphology files.
+defects within the structure are detected. It can be invoked from the command line, and
+takes as main argument the path to either a single file or a directory of morphology files.
 
 For example,
 
@@ -86,20 +85,59 @@ For example,
 
     $ morph_check test_data/swc/Neuron.swc # single file
     INFO: ========================================
-    INFO: Check file test_data/swc/Neuron.swc...
-    INFO:                     Has valid soma? PASS
-    INFO:               All points connected? PASS
-    INFO:                 Has basal dendrite? PASS
-    INFO:                           Has axon? PASS
-    INFO:                Has apical dendrite? PASS
-    INFO:            Nonzero segment lengths? PASS
-    INFO:            Nonzero section lengths? PASS
-    INFO:              Nonzero neurite radii? PASS
-    INFO:                       Check result: PASS
+    INFO: File: test_data/swc/Neuron.swc
+    INFO:                      Is single tree PASS
+    INFO:                     Has soma points PASS
+    INFO:                  No missing parents PASS
+    INFO:                  Has sequential ids PASS
+    INFO:                  Has increasing ids PASS
+    INFO:                      Has valid soma PASS
+    INFO:                  Has valid neurites PASS
+    INFO:                  Has basal dendrite PASS
+    INFO:                            Has axon PASS
+    INFO:                 Has apical dendrite PASS
+    INFO:     Has all nonzero segment lengths PASS
+    INFO:     Has all nonzero section lengths PASS
+    INFO:       Has all nonzero neurite radii PASS
+    INFO:             Has nonzero soma radius PASS
+    INFO:                                 ALL PASS
     INFO: ========================================
 
     $ morph_check test_data/swc # all files in directory
     # loops over all morphology files found in test_data/swc
+
+The application also produces a summary json file, which can be useful when
+processing more than one file:
+
+.. code-block:: javascript
+
+    {
+        "files": {
+            "test_data/swc/Neuron.swc": {
+                "Is single tree": true,
+                "Has soma points": true,
+                "No missing parents": true,
+                "Has sequential ids": true,
+                "Has increasing ids": true,
+                "Has valid soma": true,
+                "Has valid neurites": true,
+                "Has basal dendrite": true,
+                "Has axon": true,
+                "Has apical dendrite": true,
+                "Has all nonzero segment lengths": true,
+                "Has all nonzero section lengths": true,
+                "Has all nonzero neurite radii": true,
+                "Has nonzero soma radius": true,
+                "ALL": true
+            }
+        },
+        "STATUS": "PASS"
+    }
+
+
+The tests run are in submodules of :py:mod:`neurom.check`, particularly :py:mod:`structural_checks<neurom.check.structural_checks>`, :py:mod:`neurite_checks<neurom.check.neurite_checks>` and
+:py:mod:`soma_checks<neurom.check.soma_checks>`.
+
 
 For more information, use the help option:
 
@@ -107,7 +145,3 @@ For more information, use the help option:
 
     $ morph_check --help
     ....
-
-    $ raw_data_check --help
-    ....
-

--- a/neurom/check/__init__.py
+++ b/neurom/check/__init__.py
@@ -28,18 +28,34 @@
 
 ''' Basic tools to check neuronal morphologies. '''
 
+from functools import wraps
+
+
+def check_wrapper(fun):
+    '''Wrapp a checking function'''
+    @wraps(fun)
+    def _wrapper(*args, **kwargs):
+        '''Sets the title property of the result of ijviking a checker'''
+        title = fun.__name__.replace('_', ' ').capitalize()
+        result = fun(*args, **kwargs)
+        result.title = title
+        return result
+
+    return _wrapper
+
+
+class CheckResult(object):
+    '''Class representing a check result'''
+    def __init__(self, status, info=None, title=None):
+        self.status = bool(status)
+        self.info = info
+        self.title = title
+
+    def __nonzero__(self):
+        '''boolean conversion method'''
+        return self.status
+
 
 def ok(result):
-    '''Boolean test result
-
-    Return a boolean pass status for a test result. Some tests
-    return iterables of failures. A non empty iterable result is
-    a failure.
-
-    Returns: True if result is True or an empty iterable,\
-    False otherwise.
-    '''
-    try:
-        return len(result) == 0
-    except TypeError:
-        return bool(result)
+    '''Return a boolean pass status for a test result.'''
+    return result.status

--- a/neurom/check/runner.py
+++ b/neurom/check/runner.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''runner for neuron morphology checks'''
+
+from collections import OrderedDict
+from importlib import import_module
+import os
+import logging
+from neurom.io.utils import get_morph_files
+from neurom.fst import _io as fst_io
+from neurom.fst import _core as fst_core
+from neurom.check import check_wrapper
+
+L = logging.getLogger(__name__)
+
+
+class CheckRunner(object):
+    '''Class managing checks, config and output'''
+    def __init__(self, config):
+        self._config = config
+        if 'color' not in self._config:
+            self._config['color'] = False
+        self.summary = OrderedDict()
+        self._check_modules = {k: import_module('neurom.check.%s' % k)
+                               for k in config['checks']}
+
+    def run(self, file_path):
+        '''Test a bunch of files and return a summary JSON report'''
+
+        def _get_files():
+            '''Get a file or set of files from a file path'''
+            if os.path.isfile(file_path):
+                return [file_path]
+            elif os.path.isdir(file_path):
+                L.info('Checking files in directory %s', file_path)
+                return get_morph_files(file_path)
+            else:
+                msg = 'Invalid data path %s' % file_path
+                L.error(msg)
+                raise IOError(msg)
+
+        SEPARATOR = '=' * 40
+        summary = {}
+        res = True
+
+        for _f in _get_files():
+            L.info(SEPARATOR)
+            status, summ = self._check_file(_f)
+            res &= status
+            if summ is not None:
+                summary.update(summ)
+
+        L.info(SEPARATOR)
+
+        status = 'PASS' if res else 'FAIL'
+
+        return {'files': summary, 'STATUS': status}
+
+    def _do_check(self, obj, check_module, check_str):
+        '''Run a check function on obj'''
+        opts = self._config['options']
+        if check_str in opts:
+            fargs = opts[check_str]
+            if isinstance(fargs, list):
+                out = check_wrapper(getattr(check_module, check_str))(obj, *fargs)
+            else:
+                out = check_wrapper(getattr(check_module, check_str))(obj, fargs)
+        else:
+            out = check_wrapper(getattr(check_module, check_str))(obj)
+
+        try:
+            if len(out.info) > 0:
+                L.debug('%s: %d failing ids detected: %s',
+                        out.title, len(out.info), out.info)
+        except TypeError:
+            pass
+
+        return out
+
+    def _check_loop(self, obj, check_mod_str):
+        '''Run all the checks in a check_module'''
+        check_module = self._check_modules[check_mod_str]
+        checks = self._config['checks'][check_mod_str]
+        result = True
+        for check in checks:
+            ok = self._do_check(obj, check_module, check)
+            self.summary[ok.title] = ok.status
+            result &= ok.status
+
+        return result
+
+    def _check_file(self, f):
+        '''Run tests on a morphology file'''
+
+        L.info('File: %s', f)
+
+        result = True
+
+        try:
+            data = fst_io.load_data(f)
+            result &= self._check_loop(data, 'structural_checks')
+            nrn = fst_core.Neuron(data)
+            result &= self._check_loop(nrn, 'neuron_checks')
+        except StandardError as e:
+            L.error('Failed to load data... skipping tests for this file')
+            L.error(e.message)
+            result = False
+
+        self.summary['ALL'] = result
+
+        for m, s in self.summary.iteritems():
+            self._log_msg(m, s)
+
+        return result, {f: self.summary}
+
+    def _log_msg(self, msg, ok):
+        '''Helper to log message to the right level'''
+        if self._config['color']:
+            CGREEN, CRED, CEND = '\033[92m', '\033[91m', '\033[0m'
+        else:
+            CGREEN = CRED = CEND = ''
+
+        LOG_LEVELS = {False: logging.ERROR, True: logging.INFO}
+
+        L.log(LOG_LEVELS[ok],
+              '%35s %s' + CEND, msg, CGREEN + 'PASS' if ok else CRED + 'FAIL')

--- a/neurom/check/tests/test_check.py
+++ b/neurom/check/tests/test_check.py
@@ -26,69 +26,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from neurom.check import ok
-import numpy as np
+from collections import namedtuple
+from neurom.check import ok, check_wrapper
 from nose import tools as nt
 
 
-def _eq(a, b):
-    '''Return a different type of bool'''
-    return np.bool_(a == b)
+MockResult = namedtuple('MockResult', 'status')
 
 
-def test_true_is_ok():
-    nt.assert_true(ok(True))
-    nt.assert_true(ok(_eq(1, 1)))
+def test_ok_true_is_ok():
+    nt.assert_true(ok(MockResult(True)))
 
 
-def test_false_is_not_ok():
-    nt.assert_true(not ok(False))
-    nt.assert_true(not ok(_eq(1, 2)))
+def test_ok_false_is_not_ok():
+    nt.assert_true(not ok(MockResult(False)))
 
 
-def test_empty_list_is_ok():
-    nt.assert_true(ok([]))
+def test_check_wrapper_title():
+    class Mock(object):
+        pass
 
+    def mock_fun():
+        return Mock()
 
-def test_empty_dict_is_ok():
-    nt.assert_true(ok({}))
-
-
-def test_empty_tuple_is_ok():
-    nt.assert_true(ok(tuple()))
-
-
-def test_empty_set_is_ok():
-    nt.assert_true(ok(set()))
-
-
-def test_empty_string_is_ok():
-    nt.assert_true(ok(""))
-
-
-def test_empty_ndarray_is_ok():
-    nt.assert_true(ok(np.array([])))
-
-
-def test_list_is_not_ok():
-    nt.assert_false(ok([1,2,3]))
-
-
-def test_dict_is_not_ok():
-    nt.assert_false(ok({1:1, 2:2, 3:3}))
-
-
-def test_tuple_is_not_ok():
-    nt.assert_false(ok((1,2,3)))
-
-
-def test_ndarray_is_not_ok():
-    nt.assert_false(ok(np.array([1,2,3])))
-
-
-def test_set_is_not_ok():
-    nt.assert_false(ok({1,2,3}))
-
-
-def test_string_is_not_ok():
-    nt.assert_false(ok("123"))
+    f = check_wrapper(mock_fun)
+    nt.assert_equal(f().title, "Mock fun")

--- a/neurom/check/tests/test_neuron_checks.py
+++ b/neurom/check/tests/test_neuron_checks.py
@@ -30,7 +30,7 @@ import os
 from copy import deepcopy
 from neurom import load_neuron
 from neurom.fst import _io as io
-from neurom.check import morphology as check_morph
+from neurom.check import neuron_checks as nrn_chk
 from neurom.core.dataformat import COLS
 from nose import tools as nt
 
@@ -86,18 +86,6 @@ def _pick(files):
     return [NEURONS[f] for f in files]
 
 
-def test_has_soma_good_data():
-    dw = io.load_data(os.path.join(SWC_PATH, 'Neuron.swc'))
-    nt.ok_(check_morph.has_valid_soma(dw))
-    dw = io.load_data(os.path.join(H5V1_PATH, 'Neuron.h5'))
-    nt.ok_(check_morph.has_valid_soma(dw))
-
-
-def test_has_soma_bad_data():
-    dw = io.load_data(os.path.join(SWC_PATH, 'Single_apical_no_soma.swc'))
-    nt.ok_(not check_morph.has_valid_soma(dw))
-
-
 def test_has_axon_good_data():
     files = ['Neuron.swc',
              'Neuron_small_radius.swc',
@@ -105,7 +93,7 @@ def test_has_axon_good_data():
              'Neuron.h5',
              ]
     for n in _pick(files):
-        nt.ok_(check_morph.has_axon(n))
+        nt.ok_(nrn_chk.has_axon(n))
 
 
 def test_has_axon_bad_data():
@@ -114,7 +102,7 @@ def test_has_axon_bad_data():
              ]
 
     for n in _pick(files):
-        nt.ok_(not check_morph.has_axon(n))
+        nt.ok_(not nrn_chk.has_axon(n))
 
 
 def test_has_apical_dendrite_good_data():
@@ -125,7 +113,7 @@ def test_has_apical_dendrite_good_data():
              ]
 
     for n in _pick(files):
-        nt.ok_(check_morph.has_apical_dendrite(n))
+        nt.ok_(nrn_chk.has_apical_dendrite(n))
 
 
 def test_has_apical_dendrite_bad_data():
@@ -134,7 +122,7 @@ def test_has_apical_dendrite_bad_data():
              ]
 
     for n in _pick(files):
-        nt.ok_(not check_morph.has_apical_dendrite(n))
+        nt.ok_(not nrn_chk.has_apical_dendrite(n))
 
 
 def test_has_basal_dendrite_good_data():
@@ -146,7 +134,7 @@ def test_has_basal_dendrite_good_data():
              ]
 
     for n in _pick(files):
-        nt.ok_(check_morph.has_basal_dendrite(n))
+        nt.ok_(nrn_chk.has_basal_dendrite(n))
 
 
 def test_has_basal_dendrite_bad_data():
@@ -155,93 +143,61 @@ def test_has_basal_dendrite_bad_data():
              ]
 
     for n in _pick(files):
-        nt.ok_(not check_morph.has_basal_dendrite(n))
-
-
-def test_has_nonzero_soma_radius():
-
-    nrn = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn))
-
-
-def test_has_nonzero_soma_radius_bad_data():
-
-    nrn = load_neuron(os.path.join(SWC_PATH, 'Single_basal.swc'))
-    nt.assert_false(check_morph.has_nonzero_soma_radius(nrn))
-
-
-def test_has_nonzero_soma_radius_threshold():
-
-    class Dummy(object):
-        pass
-
-    nrn = Dummy()
-    nrn.soma = Dummy()
-    nrn.soma.radius = 1.5
-
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn))
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn, 0.25))
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn, 0.75))
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn, 1.25))
-    nt.assert_true(check_morph.has_nonzero_soma_radius(nrn, 1.499))
-    nt.assert_false(check_morph.has_nonzero_soma_radius(nrn, 1.5))
-    nt.assert_false(check_morph.has_nonzero_soma_radius(nrn, 1.75))
-    nt.assert_false(check_morph.has_nonzero_soma_radius(nrn, 2.5))
-
+        nt.ok_(not nrn_chk.has_basal_dendrite(n))
 
 
 def test_get_flat_neurites():
 
     _, n = _load_neuron('Neuron.swc')
 
-    nt.assert_equal(len(check_morph.get_flat_neurites(n, 1e-6, method='tolerance')), 0)
-    nt.assert_equal(len(check_morph.get_flat_neurites(n, 0.1, method='ratio')), 0)
+    nt.assert_equal(len(nrn_chk.get_flat_neurites(n, 1e-6, method='tolerance')), 0)
+    nt.assert_equal(len(nrn_chk.get_flat_neurites(n, 0.1, method='ratio')), 0)
 
     n = _make_flat(n)
 
-    nt.assert_equal(len(check_morph.get_flat_neurites(n, 1e-6, method='tolerance')), 4)
-    nt.assert_equal(len(check_morph.get_flat_neurites(n, 0.1, method='ratio')), 4)
+    nt.assert_equal(len(nrn_chk.get_flat_neurites(n, 1e-6, method='tolerance')), 4)
+    nt.assert_equal(len(nrn_chk.get_flat_neurites(n, 0.1, method='ratio')), 4)
 
 
 def test_has_no_flat_neurites():
 
     _, n = _load_neuron('Neuron.swc')
 
-    nt.assert_true(check_morph.has_no_flat_neurites(n, 1e-6, method='tolerance'))
-    nt.assert_true(check_morph.has_no_flat_neurites(n, 0.1, method='ratio'))
+    nt.assert_true(nrn_chk.has_no_flat_neurites(n, 1e-6, method='tolerance'))
+    nt.assert_true(nrn_chk.has_no_flat_neurites(n, 0.1, method='ratio'))
 
     n = _make_flat(n)
 
-    nt.assert_false(check_morph.has_no_flat_neurites(n, 1e-6, method='tolerance'))
-    nt.assert_false(check_morph.has_no_flat_neurites(n, 0.1, method='ratio'))
+    nt.assert_false(nrn_chk.has_no_flat_neurites(n, 1e-6, method='tolerance'))
+    nt.assert_false(nrn_chk.has_no_flat_neurites(n, 0.1, method='ratio'))
 
 
 def test_has_all_monotonic_neurites():
 
     _, n = _load_neuron('Neuron.swc')
 
-    nt.assert_false(check_morph.has_all_monotonic_neurites(n))
+    nt.assert_false(nrn_chk.has_all_monotonic_neurites(n))
 
     _make_monotonic(n)
 
-    nt.assert_true(check_morph.has_all_monotonic_neurites(n))
+    nt.assert_true(nrn_chk.has_all_monotonic_neurites(n))
 
 
 def test_get_nonmonotonic_neurites():
 
     _, n = _load_neuron('Neuron.swc')
 
-    nt.assert_equal(len(check_morph.get_nonmonotonic_neurites(n)), 4)
+    nt.assert_equal(len(nrn_chk.get_nonmonotonic_neurites(n)), 4)
 
     _make_monotonic(n)
 
-    nt.assert_equal(len(check_morph.get_nonmonotonic_neurites(n)), 0)
+    nt.assert_equal(len(nrn_chk.get_nonmonotonic_neurites(n)), 0)
 
 
 def test_get_back_tracking_neurites():
 
     _, n = _load_neuron('Neuron.swc')
-    nt.assert_equal(len(check_morph.get_back_tracking_neurites(n)), 4)
+    nt.assert_equal(len(nrn_chk.get_back_tracking_neurites(n)), 4)
 
 
 def test_nonzero_neurite_radii_good_data():
@@ -253,33 +209,34 @@ def test_nonzero_neurite_radii_good_data():
              ]
 
     for n in _pick(files):
-        ids = check_morph.nonzero_neurite_radii(n)
-        nt.ok_(len(ids) == 0)
+        ids = nrn_chk.has_all_nonzero_neurite_radii(n)
+        nt.ok_(len(ids.info) == 0)
 
 
-def test_nonzero_neurite_radii_threshold():
+def test_has_all_nonzero_neurite_radii_threshold():
     nrn = NEURONS['Neuron.swc']
 
-    ids = check_morph.nonzero_neurite_radii(nrn)
-    nt.ok_(len(ids) == 0)
+    ids = nrn_chk.has_all_nonzero_neurite_radii(nrn)
+    nt.ok_(ids.status)
 
-    ids = check_morph.nonzero_neurite_radii(nrn, threshold=0.25)
-    nt.assert_equal(len(ids), 122)
+    ids = nrn_chk.has_all_nonzero_neurite_radii(nrn, threshold=0.25)
+    nt.assert_equal(len(ids.info), 122)
 
 
 def test_nonzero_neurite_radii_bad_data():
     nrn = NEURONS['Neuron_zero_radius.swc']
-    ids = check_morph.nonzero_neurite_radii(nrn)
-    nt.assert_equal(ids, [(21, 10), (22, 0),
-                          (23, 0), (23, 6),
-                          (27, 1), (32, 9),
-                          (51, 7)])
+    ids = nrn_chk.has_all_nonzero_neurite_radii(nrn)
+    nt.assert_equal(ids.info, [(21, 10), (22, 0),
+                               (23, 0), (23, 6),
+                               (27, 1), (32, 9),
+                               (51, 7)])
 
 
 def test_nonzero_segment_lengths_good_data():
     nrn = NEURONS['Neuron.swc']
-    ids = check_morph.nonzero_segment_lengths(nrn)
-    nt.ok_(len(ids) == 0)
+    ids = nrn_chk.has_all_nonzero_segment_lengths(nrn)
+    nt.ok_(ids.status)
+    nt.ok_(len(ids.info) == 0)
 
 
 def test_nonzero_segment_lengths_bad_data():
@@ -296,19 +253,20 @@ def test_nonzero_segment_lengths_bad_data():
                [(3, 0)]]
 
     for i, nrn in enumerate(_pick(files)):
-        ids = check_morph.nonzero_segment_lengths(nrn)
-        nt.assert_equal(ids, bad_ids[i])
+        ids = nrn_chk.has_all_nonzero_segment_lengths(nrn)
+        nt.assert_equal(ids.info, bad_ids[i])
 
 
 def test_nonzero_segment_lengths_threshold():
     nrn = NEURONS['Neuron.swc']
 
-    ids = check_morph.nonzero_segment_lengths(nrn)
-    nt.assert_equal(len(ids), 0)
+    ids = nrn_chk.has_all_nonzero_segment_lengths(nrn)
+    nt.ok_(ids.status)
+    nt.assert_equal(len(ids.info), 0)
 
-    ids = check_morph.nonzero_segment_lengths(nrn, threshold=0.25)
-    nt.assert_equal(ids, [(3, 0), (24, 0), (39, 9), (45, 0),
-                          (55, 7), (63, 2), (66, 0), (73, 4), (79, 6)])
+    ids = nrn_chk.has_all_nonzero_segment_lengths(nrn, threshold=0.25)
+    nt.assert_equal(ids.info, [(3, 0), (24, 0), (39, 9), (45, 0),
+                               (55, 7), (63, 2), (66, 0), (73, 4), (79, 6)])
 
 
 def test_nonzero_section_lengths_good_data():
@@ -319,22 +277,57 @@ def test_nonzero_section_lengths_good_data():
              ]
 
     for i, nrn in enumerate(_pick(files)):
-        ids = check_morph.nonzero_section_lengths(nrn)
-        nt.ok_(len(ids) == 0)
+        ids = nrn_chk.has_all_nonzero_section_lengths(nrn)
+        nt.ok_(ids.status)
+        nt.ok_(len(ids.info) == 0)
 
 
 def test_nonzero_section_lengths_bad_data():
     nrn = NEURONS['Neuron_zero_length_sections.swc']
 
-    ids = check_morph.nonzero_section_lengths(nrn)
-    nt.assert_equal(ids, [16])
+    ids = nrn_chk.has_all_nonzero_section_lengths(nrn)
+    nt.ok_(not ids.status)
+    nt.assert_equal(ids.info, [16])
 
 
 def test_nonzero_section_lengths_threshold():
     nrn = NEURONS['Neuron.swc']
 
-    ids = check_morph.nonzero_section_lengths(nrn)
-    nt.ok_(len(ids) == 0)
+    ids = nrn_chk.has_all_nonzero_section_lengths(nrn)
+    nt.ok_(ids.status)
+    nt.ok_(len(ids.info) == 0)
 
-    ids = check_morph.nonzero_section_lengths(nrn, threshold=15.)
-    nt.assert_equal(len(ids), 84)
+    ids = nrn_chk.has_all_nonzero_section_lengths(nrn, threshold=15.)
+    nt.ok_(not ids.status)
+    nt.assert_equal(len(ids.info), 84)
+
+
+def test_has_nonzero_soma_radius():
+
+    nrn = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn))
+
+
+def test_has_nonzero_soma_radius_bad_data():
+
+    nrn = load_neuron(os.path.join(SWC_PATH, 'Single_basal.swc'))
+    nt.assert_false(nrn_chk.has_nonzero_soma_radius(nrn).status)
+
+
+def test_has_nonzero_soma_radius_threshold():
+
+    class Dummy(object):
+        pass
+
+    nrn = Dummy()
+    nrn.soma = Dummy()
+    nrn.soma.radius = 1.5
+
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn))
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn, 0.25))
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn, 0.75))
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn, 1.25))
+    nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn, 1.499))
+    nt.assert_false(nrn_chk.has_nonzero_soma_radius(nrn, 1.5))
+    nt.assert_false(nrn_chk.has_nonzero_soma_radius(nrn, 1.75))
+    nt.assert_false(nrn_chk.has_nonzero_soma_radius(nrn, 2.5))

--- a/neurom/check/tests/test_runner.py
+++ b/neurom/check/tests/test_runner.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
+# All rights reserved.
+#
+# This file is part of NeuroM <https://github.com/BlueBrain/NeuroM>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#     3. Neither the name of the copyright holder nor the names of
+#        its contributors may be used to endorse or promote products
+#        derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from copy import copy
+from neurom.check.runner import CheckRunner
+from nose import tools as nt
+
+_path = os.path.dirname(os.path.abspath(__file__))
+SWC_PATH = os.path.join(_path, '../../../test_data/swc/')
+NRN_PATH_0 = os.path.join(_path, '../../../test_data/swc/Neuron.swc')
+NRN_PATH_1 = os.path.join(_path, '../../../test_data/swc/Neuron_zero_length_sections.swc')
+NRN_PATH_2 = os.path.join(_path, '../../../test_data/swc/Single_apical.swc')
+NRN_PATH_3 = os.path.join(_path, '../../../test_data/swc/Single_basal.swc')
+NRN_PATH_4 = os.path.join(_path, '../../../test_data/swc/Single_axon.swc')
+NRN_PATH_5 = os.path.join(_path, '../../../test_data/swc/Single_apical_no_soma.swc')
+
+CONFIG = {
+    'checks': {
+        'structural_checks': [
+            'is_single_tree',
+            'has_soma_points',
+            'has_sequential_ids',
+            'has_increasing_ids',
+            'has_valid_soma',
+            'has_valid_neurites'
+        ],
+        'neuron_checks': [
+            'has_basal_dendrite',
+            'has_axon',
+            'has_apical_dendrite',
+            'has_all_nonzero_segment_lengths',
+            'has_all_nonzero_section_lengths',
+            'has_all_nonzero_neurite_radii',
+            'has_nonzero_soma_radius'
+        ]
+    },
+    'options': {
+        'has_nonzero_soma_radius': 0.0,
+        "has_all_nonzero_neurite_radii": 0.007,
+        "has_all_nonzero_segment_lengths": 0.01,
+        "has_all_nonzero_section_lengths": [0.01]
+    },
+}
+
+CONFIG_COLOR = copy(CONFIG)
+CONFIG_COLOR['color'] = True
+
+REF_0 = {
+    'files': {
+        NRN_PATH_0: {
+            "Is single tree": True,
+            "Has soma points": True,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": True,
+            "Has valid neurites": True,
+            "Has basal dendrite": True,
+            "Has axon": True,
+            "Has apical dendrite": True,
+            "Has all nonzero segment lengths": True,
+            "Has all nonzero section lengths": True,
+            "Has all nonzero neurite radii": True,
+            "Has nonzero soma radius": True,
+            "ALL": True
+        }
+    },
+    "STATUS": "PASS"
+}
+
+REF_1 = {
+    'files': {
+        NRN_PATH_1: {
+            "Is single tree": True,
+            "Has soma points": True,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": True,
+            "Has valid neurites": True,
+            "Has basal dendrite": True,
+            "Has axon": True,
+            "Has apical dendrite": True,
+            "Has all nonzero segment lengths": False,
+            "Has all nonzero section lengths": False,
+            "Has all nonzero neurite radii": True,
+            "Has nonzero soma radius": True,
+            "ALL": False
+        }
+    },
+    "STATUS": "FAIL"
+}
+
+REF_2 = {
+    'files': {
+        NRN_PATH_2: {
+            "Is single tree": True,
+            "Has soma points": True,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": True,
+            "Has valid neurites": True,
+            "Has basal dendrite": False,
+            "Has axon": False,
+            "Has apical dendrite": True,
+            "Has all nonzero segment lengths": False,
+            "Has all nonzero section lengths": True,
+            "Has all nonzero neurite radii": True,
+            "Has nonzero soma radius": True,
+            "ALL": False
+        }
+    },
+    "STATUS": "FAIL"
+}
+
+REF_3 = {
+    'files': {
+        NRN_PATH_3: {
+            "Is single tree": True,
+            "Has soma points": True,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": True,
+            "Has valid neurites": True,
+            "Has basal dendrite": True,
+            "Has axon": False,
+            "Has apical dendrite": False,
+            "Has all nonzero segment lengths": False,
+            "Has all nonzero section lengths": True,
+            "Has all nonzero neurite radii": True,
+            "Has nonzero soma radius": False,
+            "ALL": False
+        }
+    },
+    "STATUS": "FAIL"
+}
+
+REF_4 = {
+    'files': {
+        NRN_PATH_4: {
+            "Is single tree": True,
+            "Has soma points": True,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": True,
+            "Has valid neurites": True,
+            "Has basal dendrite": False,
+            "Has axon": True,
+            "Has apical dendrite": False,
+            "Has all nonzero segment lengths": False,
+            "Has all nonzero section lengths": True,
+            "Has all nonzero neurite radii": True,
+            "Has nonzero soma radius": True,
+            "ALL": False
+        }
+    },
+    "STATUS": "FAIL"
+}
+
+
+REF_5 = {
+    'files': {
+        NRN_PATH_5: {
+            "Is single tree": True,
+            "Has soma points": False,
+            "Has sequential ids": True,
+            "Has increasing ids": True,
+            "Has valid soma": False,
+            "Has valid neurites": False,
+            "ALL": False
+        }
+    },
+    "STATUS": "FAIL"
+}
+
+
+def test_ok_neuron():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_0)
+    nt.assert_equal(summ, REF_0)
+
+
+def test_ok_neuron_color():
+    checker = CheckRunner(CONFIG_COLOR)
+    summ = checker.run(NRN_PATH_0)
+    nt.assert_equal(summ, REF_0)
+
+
+def test_zero_length_sections_neuron():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_1)
+    nt.assert_equal(summ, REF_1)
+
+
+def test_single_apical_neuron():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_2)
+    nt.assert_equal(summ, REF_2)
+
+
+def test_single_basal_neuron():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_3)
+    nt.assert_equal(summ, REF_3)
+
+
+def test_single_axon_neuron():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_4)
+    nt.assert_equal(summ, REF_4)
+
+
+def test_single_apical_no_soma():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(NRN_PATH_5)
+    nt.assert_equal(summ, REF_5)
+
+
+def test_directory_input():
+    checker = CheckRunner(CONFIG)
+    summ = checker.run(SWC_PATH)
+
+
+@nt.raises(IOError)
+def test_invalid_data_path_raises_IOError():
+    checker = CheckRunner(CONFIG)
+    _ = checker.run('foo/bar/baz')

--- a/neurom/check/tests/test_structural_checks.py
+++ b/neurom/check/tests/test_structural_checks.py
@@ -28,6 +28,7 @@
 
 import os
 from neurom import io
+from neurom.check import structural_checks as chk
 from neurom.fst import _io as fst_io
 from nose import tools as nt
 
@@ -59,9 +60,9 @@ class TestIOCheck(object):
                  ]
 
         for f in files:
-            ok, ids = io.check.has_sequential_ids(self.load_data(f))
+            ok = chk.has_sequential_ids(self.load_data(f))
             nt.ok_(ok)
-            nt.ok_(len(ids) == 0)
+            nt.ok_(len(ok.info) == 0)
 
 
 
@@ -69,9 +70,9 @@ class TestIOCheck(object):
 
         f = os.path.join(SWC_PATH, 'Neuron_missing_ids.swc')
 
-        ok, ids = io.check.has_sequential_ids(self.load_data(f))
+        ok = chk.has_sequential_ids(self.load_data(f))
         nt.ok_(not ok)
-        nt.assert_items_equal(ids, [6, 217, 428, 639])
+        nt.assert_items_equal(ok.info, [6, 217, 428, 639])
 
     def test_has_increasing_ids_good_data(self):
 
@@ -89,55 +90,54 @@ class TestIOCheck(object):
                  ]
 
         for f in files:
-            ok, ids = io.check.has_increasing_ids(self.load_data(f))
+            ok = chk.has_increasing_ids(self.load_data(f))
             nt.ok_(ok)
-            nt.ok_(len(ids) == 0)
-
+            nt.ok_(len(ok.info) == 0)
 
 
     def test_has_increasing_ids_bad_data(self):
 
         f = os.path.join(SWC_PATH, 'non_increasing_trunk_off_1_16pt.swc')
 
-        ok, ids = io.check.has_increasing_ids(self.load_data(f))
+        ok = chk.has_increasing_ids(self.load_data(f))
         nt.ok_(not ok)
-        nt.assert_items_equal(ids, [6, 12])
+        nt.assert_items_equal(ok.info, [6, 12])
 
 
     def test_is_single_tree_bad_data(self):
 
         f = os.path.join(SWC_PATH, 'Neuron_disconnected_components.swc')
 
-        ok, ids = io.check.is_single_tree(self.load_data(f))
+        ok = chk.is_single_tree(self.load_data(f))
         nt.ok_(not ok)
-        nt.eq_(ids, [6, 217, 428, 639])
+        nt.eq_(ok.info, [6, 217, 428, 639])
 
 
     def test_is_single_tree_good_data(self):
 
         f = os.path.join(SWC_PATH, 'Neuron.swc')
 
-        ok, ids = io.check.is_single_tree(self.load_data(f))
+        ok = chk.is_single_tree(self.load_data(f))
         nt.ok_(ok)
-        nt.eq_(len(ids), 0)
+        nt.eq_(len(ok.info), 0)
 
 
     def test_has_no_missing_parents_bad_data(self):
 
         f = os.path.join(SWC_PATH, 'Neuron_missing_parents.swc')
 
-        ok, ids = io.check.no_missing_parents(self.load_data(f))
+        ok = chk.no_missing_parents(self.load_data(f))
         nt.ok_(not ok)
-        nt.eq_(list(ids), [6, 217, 428, 639])
+        nt.eq_(list(ok.info), [6, 217, 428, 639])
 
 
     def test_has_no_missing_parents_good_data(self):
 
         f = os.path.join(SWC_PATH, 'Neuron.swc')
 
-        ok, ids = io.check.no_missing_parents(self.load_data(f))
+        ok = chk.no_missing_parents(self.load_data(f))
         nt.ok_(ok)
-        nt.eq_(len(ids), 0)
+        nt.eq_(len(ok.info), 0)
 
 
     def test_has_soma_points_good_data(self):
@@ -150,13 +150,25 @@ class TestIOCheck(object):
         files.append(os.path.join(H5V1_PATH, 'Neuron_2_branch.h5'))
 
         for f in files:
-            nt.ok_(io.check.has_soma_points(self.load_data(f)))
+            nt.ok_(chk.has_soma_points(self.load_data(f)))
 
 
     def test_has_soma_points_bad_data(self):
         f = os.path.join(SWC_PATH, 'Single_apical_no_soma.swc')
-        nt.ok_(not io.check.has_soma_points(self.load_data(f)))
+        nt.ok_(not chk.has_soma_points(self.load_data(f)))
 
+
+
+    def test_has_valid_soma_good_data(self):
+        dw = self.load_data(os.path.join(SWC_PATH, 'Neuron.swc'))
+        nt.ok_(chk.has_valid_soma(dw))
+        dw = self.load_data(os.path.join(H5V1_PATH, 'Neuron.h5'))
+        nt.ok_(chk.has_valid_soma(dw))
+
+
+    def test_has_valid_soma_bad_data(self):
+        dw = self.load_data(os.path.join(SWC_PATH, 'Single_apical_no_soma.swc'))
+        nt.ok_(not chk.has_valid_soma(dw))
 
     def test_has_finite_radius_neurites_good_data(self):
         files = [os.path.join(SWC_PATH, f)
@@ -168,16 +180,16 @@ class TestIOCheck(object):
         files.append(os.path.join(H5V1_PATH, 'Neuron_2_branch.h5'))
 
         for f in files:
-            ok, ids = io.check.has_all_finite_radius_neurites(self.load_data(f))
+            ok = chk.has_all_finite_radius_neurites(self.load_data(f))
             nt.ok_(ok)
-            nt.ok_(len(ids) == 0)
+            nt.ok_(len(ok.info) == 0)
 
 
     def test_has_finite_radius_neurites_bad_data(self):
         f = os.path.join(SWC_PATH, 'Neuron_zero_radius.swc')
-        ok, ids = io.check.has_all_finite_radius_neurites(self.load_data(f))
+        ok = chk.has_all_finite_radius_neurites(self.load_data(f))
         nt.ok_(not ok)
-        nt.ok_(ids == [194, 210, 246, 304, 493])
+        nt.ok_(ok.info == [194, 210, 246, 304, 493])
 
 
 
@@ -197,3 +209,13 @@ class TestIOCheckFST(TestIOCheck):
             return super(TestIOCheckFST, self).test_has_sequential_ids_bad_data()
         except Exception:
             return False
+
+    def test_has_valid_neurites_good_data(self):
+        dw = self.load_data(os.path.join(SWC_PATH, 'Neuron.swc'))
+        nt.ok_(chk.has_valid_neurites(dw))
+        dw = self.load_data(os.path.join(H5V1_PATH, 'Neuron.h5'))
+        nt.ok_(chk.has_valid_neurites(dw))
+
+    def test_has_valid_neurites_bad_data(self):
+        dw = self.load_data(os.path.join(SWC_PATH, 'Soma_origin.swc'))
+        nt.ok_(not chk.has_valid_neurites(dw))

--- a/neurom/fst/_core.py
+++ b/neurom/fst/_core.py
@@ -86,12 +86,21 @@ class Neurite(object):
         return Neurite(deepcopy(self.root_node, memo))
 
 
-class Neuron(object):
+class BaseNeuron(object):
+    '''Class representing a simple neuron'''
+    def __init__(self, soma=None, neurites=None, sections=None):
+        self.soma = soma
+        self.neurites = neurites
+        self.sections = sections
+
+
+class Neuron(BaseNeuron):
     '''Class representing a neuron'''
     def __init__(self, data_wrapper, name='Neuron'):
         self._data = data_wrapper
-        self.neurites, self.sections = make_neurites(self._data)
-        self.soma = make_soma(self._data.soma_points())
+        neurites, sections = make_neurites(self._data)
+        soma = make_soma(self._data.soma_points())
+        super(Neuron, self).__init__(soma, neurites, sections)
         self.name = name
         self._points = None
 

--- a/neurom/io/__init__.py
+++ b/neurom/io/__init__.py
@@ -29,6 +29,5 @@
 ''' IO operations module for NeuroM '''
 
 from .readers import load_data
-from . import check
 from ..core.dataformat import COLS
 from ..core.dataformat import ROOT_ID

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -36,7 +36,7 @@ from neurom.core.neuron import Neuron, make_soma
 from neurom.core.population import Population
 from neurom.exceptions import IDSequenceError, MultipleTrees, MissingParentError
 from . import load_data
-from . import check
+from neurom.check import structural_checks as check
 from neurom.utils import memoize
 import os
 
@@ -115,11 +115,11 @@ def load_neuron(filename, tree_action=None):
     """
 
     data = load_data(filename)
-    if not check.has_increasing_ids(data)[0]:
+    if not check.has_increasing_ids(data):
         raise IDSequenceError('Invald ID sequence found in raw data')
-    if not check.is_single_tree(data)[0]:
+    if not check.is_single_tree(data):
         raise MultipleTrees('Multiple trees detected')
-    if not check.no_missing_parents(data)[0]:
+    if not check.no_missing_parents(data):
         raise MissingParentError('Missing parents detected')
 
     nrn = make_neuron(data, tree_action)
@@ -141,7 +141,7 @@ def load_trees(filename, tree_action=None):
     """
     data = load_data(filename)
 
-    if not check.has_increasing_ids(data)[0]:
+    if not check.has_increasing_ids(data):
         raise IDSequenceError('Invald ID sequence found in raw data')
 
     _ids = get_initial_neurite_segment_ids(data)


### PR DESCRIPTION
* Re-structured checker code into separate modules
  neurom.check.structural_checks and neurom.check.neuron_checks.
* Re-structured configuration to map to above modules, with lists
  of checks to apply per module.
* Moved all checking logic to neurom.check.runner.CheckRunner class.
  The morph_check script is responsible for parsing command line
  options, passing them on to CheckRunner, and producing a summary
  file from its output.
* Tests for various pass/fail scenarios added.

Resolves issue #247.