### PR TITLE
Update quick start documentation.

### DIFF
--- a/doc/source/quick.rst
+++ b/doc/source/quick.rst
@@ -29,16 +29,17 @@
 Quick and easy analysis
 =======================
 
-The :py:mod:`neurom.fst` module
--------------------------------
+The top level :py:mod:`neurom` module
+-------------------------------------
 
-The :py:mod:`neurom.fst` brings together various neurom components and helper functions
+The :py:mod:`neurom` module has various helper functions
 to simplify loading neuron morphologies from files into ``neurom`` data structures and
 obtaining morphometrics, either from single or multiple neurons.
-The functionality is limited, but it is hoped that it will suffice for most analyses. 
+The functionality available at the top level is limited, but it is hoped
+that it will suffice for most analyses.
 
 These are some of the properties can be obtained for a single neurite type or for all
-neurites regardless of type via the :py:func:`neurom.fst.get` function:
+neurites regardless of type via the :py:func:`neurom.get` function:
 
 * Segment lengths
 * Section lengths
@@ -58,7 +59,7 @@ This function also allows obtaining the soma radius and surface area.
 There are also helper functions to  plot a neuron in 2 and 3 dimensions.
 
 .. seealso::
-    The :py:mod:`neurom.fst` documentation for more details and examples.
+    The :py:mod:`neurom` documentation for more details and examples.
 
 The :py:mod:`neurom.viewer` module
 ----------------------------------

--- a/neurom/__init__.py
+++ b/neurom/__init__.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-''' NeuroM top level module
+'''NeuroM neurom morphology analysis package
 
 Examples:
 


### PR DESCRIPTION
Documentation now refers to `neurom` top level functionality instead of
`neurom.fst`.