### PR TITLE
Update documentation examples page.

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -29,35 +29,6 @@
 Examples
 ========
 
-Morphology file data consistency checks
-***************************************
-
-.. code-block:: bash
-
-    (nrm)$ morph_check some/data/path/morph_file.swc # single file
-    INFO: ========================================
-    INFO: File: some/data/path/morph_file.swc
-    INFO:                      Is single tree PASS
-    INFO:                     Has soma points PASS
-    INFO:                  No missing parents PASS
-    INFO:                  Has sequential ids PASS
-    INFO:                  Has increasing ids PASS
-    INFO:                      Has valid soma PASS
-    INFO:                  Has valid neurites PASS
-    INFO:                  Has basal dendrite PASS
-    INFO:                            Has axon PASS
-    INFO:                 Has apical dendrite PASS
-    INFO:     Has all nonzero segment lengths PASS
-    INFO:     Has all nonzero section lengths PASS
-    INFO:       Has all nonzero neurite radii PASS
-    INFO:             Has nonzero soma radius PASS
-    INFO:                                 ALL PASS
-    INFO: ========================================
-
-    (nrm)$ morph_check some/data/path # all files in directory
-    ....
-
-
 Fast analysis with :py:mod:`neurom`
 ***********************************
 


### PR DESCRIPTION
Remove morphology checker application example. Already covered in
applications section.