### PR TITLE
fix: ensure SWC reader makes soma sections.

### DIFF
--- a/neurom/io/datawrapper.py
+++ b/neurom/io/datawrapper.py
@@ -153,4 +153,7 @@ def _extract_sections(data_block):
         if sec.pid in _gap_sections:
             _merge_sections(_sections[sec.pid], sec)
 
+    # TODO find a way to remove empty sections.
+    # Currently they are required to maintain
+    # tree integrity.
     return _sections

--- a/neurom/io/tests/test_swc_reader.py
+++ b/neurom/io/tests/test_swc_reader.py
@@ -52,6 +52,11 @@ def test_read_swc_basic():
     check_single_section_random_swc(rdw.data_block, rdw.fmt)
 
 
+def test_read_single_neurite():
+    rdw = swc.read(os.path.join(SWC_PATH, 'point_soma_single_neurite.swc'))
+    nt.eq_(rdw.neurite_trunks(), [1])
+
+
 class TestRawDataWrapper_SingleSectionRandom(object):
     def setup(self):
         self.data = swc.read(

--- a/neurom/io/tests/test_swc_reader.py
+++ b/neurom/io/tests/test_swc_reader.py
@@ -28,7 +28,7 @@
 
 import os
 import numpy as np
-from neurom.io import ROOT_ID, COLS
+from neurom.io import COLS
 from neurom.io import swc
 from nose import tools as nt
 
@@ -55,6 +55,24 @@ def test_read_swc_basic():
 def test_read_single_neurite():
     rdw = swc.read(os.path.join(SWC_PATH, 'point_soma_single_neurite.swc'))
     nt.eq_(rdw.neurite_trunks(), [1])
+    nt.eq_(len(rdw.soma_points()), 1)
+    nt.eq_(len(rdw.sections), 3) # includes one empty section
+
+
+def test_read_split_soma():
+    rdw = swc.read(os.path.join(SWC_PATH, 'split_soma_single_neurites.swc'))
+    nt.eq_(rdw.neurite_trunks(), [1, 3])
+    nt.eq_(len(rdw.soma_points()), 3)
+    nt.eq_(len(rdw.sections), 5) # includes one empty section
+
+    ref_ids = [[-1, 0],
+               [0, 1, 2, 3, 4],
+               [0, 5, 6],
+               [6, 7, 8, 9, 10],
+               []]
+
+    for s, r in zip(rdw.sections, ref_ids):
+        nt.eq_(s.ids, r)
 
 
 class TestRawDataWrapper_SingleSectionRandom(object):

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -252,6 +252,7 @@ def test_load_neuron_mixed_tree_swc():
 def test_load_neuron_section_order_break_swc():
     nrn_mix =  utils.load_neuron(os.path.join(SWC_PATH, 'sample_disordered.swc'))
 
+
     nt.assert_items_equal(get('number_of_sections_per_neurite', nrn_mix), [5, 3])
 
     nt.assert_items_equal(get('number_of_sections_per_neurite', nrn_mix),

--- a/test_data/swc/point_soma_single_neurite.swc
+++ b/test_data/swc/point_soma_single_neurite.swc
@@ -1,0 +1,9 @@
+# A simple neuron consisting of a point soma
+# and a single branch neurite.
+# Topologically, the soma doesn't form a separate section, so this
+# can be used for testing whether the SWC reader treats the soma specially.
+1 1 0 0 0 3.0 -1
+2 3 0 0 2 0.5 1
+3 3 0 0 3 0.5 2
+4 3 0 0 4 0.5 3
+5 3 0 0 5 0.5 4

--- a/test_data/swc/split_soma_single_neurites.swc
+++ b/test_data/swc/split_soma_single_neurites.swc
@@ -1,0 +1,18 @@
+# A simple neuron consisting of a two-branch soma
+# with a single branch neurite on each branch.
+#
+# initial soma point
+1 1 0 0 0 0.0 -1
+# first neurite
+2 3 0 0 2 0.5 1
+3 3 0 0 3 0.5 2
+4 3 0 0 4 0.5 3
+5 3 0 0 5 0.5 4
+# soma branch, off initial point
+6 1 0 0 0 0.0 1
+7 1 0 0 0 0.0 6
+# second neurite, off soma branch
+8 3 0 0 2 0.5 7
+9 3 0 0 3 0.5 8
+10 3 0 0 4 0.5 9
+11 3 0 0 5 0.5 10


### PR DESCRIPTION
Soma sections were not being detected when soma had only one emerging
branch. This is because the method to detect sections is topological.
New algorithm treats soma specially, creating a section when there is
a change of type from soma to something else, regardless of whether
a bifurcation point arises.

Fixes #463