### PR TITLE
Add tests for split soma SWC parsing.

### DIFF
--- a/neurom/io/tests/test_swc_reader.py
+++ b/neurom/io/tests/test_swc_reader.py
@@ -93,6 +93,24 @@ def test_read_contour_soma_neuron():
         nt.eq_(s.ids, r)
 
 
+def test_read_contour_split_soma_neuron():
+    rdw = swc.read(os.path.join(SWC_PATH, 'contour_split_soma_neuron.swc'))
+    nt.eq_(rdw.neurite_trunks(), [1, 4, 5])
+    nt.eq_(len(rdw.soma_points()), 8)
+    nt.eq_(len(rdw.sections), 7) # includes one empty section
+
+    ref_ids = [[-1, 0, 1, 2],
+               [2, 3, 4, 5, 6, 7],
+               [2, 8, 9, 10],
+               [10, 11, 12],
+               [10, 13, 14, 15, 16, 17],
+               [12, 18, 19, 20, 21, 22],
+               []]
+
+    for s, r in zip(rdw.sections, ref_ids):
+        nt.eq_(s.ids, r)
+
+
 class TestRawDataWrapper_SingleSectionRandom(object):
     def setup(self):
         self.data = swc.read(

--- a/neurom/io/tests/test_swc_reader.py
+++ b/neurom/io/tests/test_swc_reader.py
@@ -111,6 +111,24 @@ def test_read_contour_split_soma_neuron():
         nt.eq_(s.ids, r)
 
 
+def test_read_contour_split_1st_soma_neuron():
+    rdw = swc.read(os.path.join(SWC_PATH, 'contour_split_1st_soma_neuron.swc'))
+    nt.eq_(rdw.neurite_trunks(), [1, 4, 5])
+    nt.eq_(len(rdw.soma_points()), 6)
+    nt.eq_(len(rdw.sections), 7) # includes one empty section
+
+    ref_ids = [[-1, 0],
+               [0, 1, 2, 3, 4, 5, 6, 7],
+               [0, 8, 9, 10],
+               [10, 11, 12],
+               [10, 13, 14, 15, 16, 17],
+               [12, 18, 19, 20, 21, 22],
+               []]
+
+    for s, r in zip(rdw.sections, ref_ids):
+        nt.eq_(s.ids, r)
+
+
 class TestRawDataWrapper_SingleSectionRandom(object):
     def setup(self):
         self.data = swc.read(

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -157,6 +157,13 @@ def test_load_contour_split_soma_neuron():
     nt.eq_(nrn.soma.radius, 2.125)
 
 
+def test_load_contour_split_1st_soma_neuron():
+    nrn = utils.load_neuron(os.path.join(DATA_PATH, 'swc', 'contour_split_1st_soma_neuron.swc'))
+    nt.eq_(len(nrn.neurites), 3)
+    nt.eq_(len(nrn.soma.points), 6)
+    nt.eq_(nrn.soma.radius, 2.0)
+
+
 NRN = utils.load_neuron(FILENAMES[0])
 
 

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -150,6 +150,13 @@ def test_load_contour_soma_neuron():
     nt.eq_(nrn.soma.radius, 2.125)
 
 
+def test_load_contour_split_soma_neuron():
+    nrn = utils.load_neuron(os.path.join(DATA_PATH, 'swc', 'contour_split_soma_neuron.swc'))
+    nt.eq_(len(nrn.neurites), 3)
+    nt.eq_(len(nrn.soma.points), 8)
+    nt.eq_(nrn.soma.radius, 2.125)
+
+
 NRN = utils.load_neuron(FILENAMES[0])
 
 

--- a/test_data/swc/contour_split_1st_soma_neuron.swc
+++ b/test_data/swc/contour_split_1st_soma_neuron.swc
@@ -1,0 +1,33 @@
+# Soma with neurites branching out of the middle
+# This is the layout of the "contour soma".
+# This special case has a neurite branching out of
+# the first point.
+# #
+1 1 0 0 0 0.0 -1
+# first neurite branch, from point 3
+2 2 0 0 2 0.0 1
+3 2 0 0 3 0.0 2
+4 2 1 0 3 0.5 3
+5 2 2 0 3 0.5 4
+6 2 3 0 3 0.5 5
+7 2 4 0 3 0.5 6
+8 2 5 0 3 0.5 7
+# second soma section
+# orig indices [4,8]
+9 1 0 0 4 0.0 1
+10 1 0 0 5 0.0 9
+11 1 0 0 6 0.0 10
+12 1 0 0 7 0.0 11
+13 1 0 0 8 0.0 12
+# second neurite branch, from soma point 11
+14 3 0 1 6 0.5 11
+15 3 0 2 6 0.5 14
+16 3 0 3 6 0.5 15
+17 3 0 4 6 0.5 16
+18 3 0 5 6 0.5 17
+# third neurite branch, from soma point 13
+19 4 0 0 9 0.5 13
+20 4 0 0 10 0.5 19
+21 4 0 0 11 0.5 20
+22 4 0 0 12 0.5 21
+23 4 0 0 13 0.5 22

--- a/test_data/swc/contour_split_soma_neuron.swc
+++ b/test_data/swc/contour_split_soma_neuron.swc
@@ -1,0 +1,32 @@
+# Soma with neurites branching out of the middle
+# This is the layout of the "contour soma".
+# #
+1 1 0 0 0 0.0 -1
+2 1 0 0 2 0.0 1
+3 1 0 0 3 0.0 2
+# first neurite branch, from point 3
+# orig indices [9,13]
+4 2 1 0 3 0.5 3
+5 2 2 0 3 0.5 4
+6 2 3 0 3 0.5 5
+7 2 4 0 3 0.5 6
+8 2 5 0 3 0.5 7
+# second soma section
+# orig indices [4,8]
+9 1 0 0 4 0.0 3
+10 1 0 0 5 0.0 9
+11 1 0 0 6 0.0 10
+12 1 0 0 7 0.0 11
+13 1 0 0 8 0.0 12
+# second neurite branch, from soma point 11
+14 3 0 1 6 0.5 11
+15 3 0 2 6 0.5 14
+16 3 0 3 6 0.5 15
+17 3 0 4 6 0.5 16
+18 3 0 5 6 0.5 17
+# third neurite branch, from soma point 13
+19 4 0 0 9 0.5 13
+20 4 0 0 10 0.5 19
+21 4 0 0 11 0.5 20
+22 4 0 0 12 0.5 21
+23 4 0 0 13 0.5 22


### PR DESCRIPTION
SWC does not restrict soma points to be contiguous. Write tests
to check parser can correctly unpack this kind of data.

Resolves #474