### PR TITLE
Fix parsing of split-soma SWC neurites.

### DIFF
--- a/neurom/core/_neuron.py
+++ b/neurom/core/_neuron.py
@@ -36,10 +36,11 @@ from . import NeuriteType
 
 class Section(Tree):
     '''Class representing a neurite section'''
-    def __init__(self, points, section_id=None):
+    def __init__(self, points, section_id=None, section_type=NeuriteType.undefined):
         super(Section, self).__init__()
         self.id = section_id
         self.points = points
+        self.type = section_type
 
     def __str__(self):
         return 'Section(id = %s, points=%s) <parent: %s, nchildren: %d>' % \

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -112,6 +112,13 @@ def _mock_load_neuron(filename):
     return MockNeuron(_get_name(filename))
 
 
+def _check_neurites_have_no_parent(nrn):
+
+    for n in nrn.neurites:
+        nt.assert_true(n.root_node.parent is None)
+
+
+
 def test_load_neurons():
     nrns = utils.load_neurons(FILES, neuron_loader=_mock_load_neuron)
     for i, nrn in enumerate(nrns):
@@ -134,6 +141,7 @@ def test_load_neuron():
     nrn = utils.load_neuron(FILENAMES[0])
     nt.assert_true(isinstance(NRN, Neuron))
     nt.assert_equal(NRN.name, 'Neuron')
+    _check_neurites_have_no_parent(nrn)
 
 
 def test_neuron_name():
@@ -148,6 +156,7 @@ def test_load_contour_soma_neuron():
     nt.eq_(len(nrn.neurites), 3)
     nt.eq_(len(nrn.soma.points), 8)
     nt.eq_(nrn.soma.radius, 2.125)
+    _check_neurites_have_no_parent(nrn)
 
 
 def test_load_contour_split_soma_neuron():
@@ -155,6 +164,7 @@ def test_load_contour_split_soma_neuron():
     nt.eq_(len(nrn.neurites), 3)
     nt.eq_(len(nrn.soma.points), 8)
     nt.eq_(nrn.soma.radius, 2.125)
+    _check_neurites_have_no_parent(nrn)
 
 
 def test_load_contour_split_1st_soma_neuron():
@@ -162,6 +172,7 @@ def test_load_contour_split_1st_soma_neuron():
     nt.eq_(len(nrn.neurites), 3)
     nt.eq_(len(nrn.soma.points), 6)
     nt.eq_(nrn.soma.radius, 2.0)
+    _check_neurites_have_no_parent(nrn)
 
 
 NRN = utils.load_neuron(FILENAMES[0])
@@ -172,6 +183,11 @@ def test_neuron_section_ids():
     # check section IDs
     for i, sec in enumerate(NRN.sections):
         nt.eq_(i, sec.id)
+
+def test_neurites_have_no_parent():
+
+    _check_neurites_have_no_parent(NRN)
+
 
 def test_neuron_sections():
     all_nodes = set(NRN.sections)


### PR DESCRIPTION
The neurom.fst neurite builder was assuming all soma sections are
before neurite ones. This resulted in split-soma sections being
added as parents to neurite sections, whereas neurites should be
disconnected trees.

Fixes #477.
Fixes #438.