### PR TITLE
Simplify NL ASCII reader.

### DIFF
--- a/neurom/io/tests/test_neurolucida.py
+++ b/neurom/io/tests/test_neurolucida.py
@@ -237,7 +237,7 @@ def test_read():
         os.close(fd)
         with open(temp_file, 'w') as fd:
             fd.write(MORPH_ASC)
-        rdw = nasc.read(temp_file, remove_duplicates=False)
+        rdw = nasc.read(temp_file)
         raw_data = rdw.data_block
 
         eq_(raw_data.shape, (19, 7))

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -113,6 +113,5 @@ _READERS = {
                    data_wrapper=SecDataWrapper),
     'h5': _load_h5,
     'asc': partial(neurolucida.read,
-                   remove_duplicates=False,
                    data_wrapper=SecDataWrapper)
 }

--- a/neurom/point_neurite/io/utils.py
+++ b/neurom/point_neurite/io/utils.py
@@ -181,7 +181,6 @@ def load_data(filename):
         '''Lazy loading of Neurolucida ASCII reader'''
         from neurom.io import neurolucida
         return neurolucida.read(filename,
-                                remove_duplicates=False,
                                 data_wrapper=RawDataWrapper)
 
     _READERS = {


### PR DESCRIPTION
Disable duplicate removal option. This is not used, and adds
complexity and scope for confusion.