### PR TITLE
Code simplifications

### DIFF
--- a/examples/comparison.py
+++ b/examples/comparison.py
@@ -29,7 +29,7 @@
 '''Module for the comparison of the morphometrics between two sets of trees.'''
 
 import numpy as np
-from neurom.core import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 
 from neurom.point_neurite import triplets as tri
 from neurom.point_neurite import segments as seg

--- a/examples/meander_angles.py
+++ b/examples/meander_angles.py
@@ -33,7 +33,7 @@ import numpy as np
 from neurom.core.dataformat import COLS
 from neurom.point_neurite import triplets as trip
 from neurom.point_neurite.io.utils import load_data, make_neuron
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 
 
 # root level logger. This would be a top level application logger.

--- a/examples/neuron_iteration_analysis.py
+++ b/examples/neuron_iteration_analysis.py
@@ -83,7 +83,6 @@ if __name__ == '__main__':
           sum(mm.segment_area(s) for s in iter_segments(nrn)))
 
     # get total number of neurite points in cell.
-    # iter_neurites needs a mapping function, so we pass the identity.
     def n_points(sec):
         '''number of points in a section'''
         n = len(sec.points)

--- a/neurom/__init__.py
+++ b/neurom/__init__.py
@@ -61,16 +61,3 @@ BASAL_DENDRITE = NeuriteType.basal_dendrite
 AXON = NeuriteType.axon
 SOMA = NeuriteType.soma
 ANY_NEURITE = NeuriteType.all
-
-__all__ = [
-    'load_neuron',
-    'load_neurons',
-    'get',
-    'iter_neurites',
-    'NeuriteType',
-    'APICAL_DENDRITE',
-    'BASAL_DENDRITE',
-    'AXON',
-    'SOMA',
-    'ANY_NEURITE',
-]

--- a/neurom/io/tests/test_neurolucida.py
+++ b/neurom/io/tests/test_neurolucida.py
@@ -237,7 +237,7 @@ def test_read():
         os.close(fd)
         with open(temp_file, 'w') as fd:
             fd.write(MORPH_ASC)
-        rdw = nasc.read(temp_file, remove_duplicates=False)
+        rdw = nasc.read(temp_file)
         raw_data = rdw.data_block
 
         eq_(raw_data.shape, (19, 7))

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -113,6 +113,5 @@ _READERS = {
                    data_wrapper=SecDataWrapper),
     'h5': _load_h5,
     'asc': partial(neurolucida.read,
-                   remove_duplicates=False,
                    data_wrapper=SecDataWrapper)
 }

--- a/neurom/point_neurite/bifurcations.py
+++ b/neurom/point_neurite/bifurcations.py
@@ -33,7 +33,7 @@ import functools
 from neurom.core import Tree
 from . import point_tree as ptr
 from . import treefunc as mt
-from neurom import iter_neurites
+from .core import iter_neurites
 from neurom.analysis import morphmath as mm
 from neurom.utils import deprecated_module
 

--- a/neurom/point_neurite/core.py
+++ b/neurom/point_neurite/core.py
@@ -28,6 +28,7 @@
 
 '''Neuron classes and functions'''
 from neurom.core import Neuron
+from neurom.core.tree import i_chain2, Tree
 
 
 class PointNeuron(Neuron):
@@ -42,3 +43,26 @@ class PointNeuron(Neuron):
         '''
         super(PointNeuron, self).__init__(soma=soma, neurites=neurites)
         self.name = name
+
+
+def iter_neurites(obj, mapfun=None, filt=None):
+    '''Iterator to a neurite, neuron or neuron population
+
+    Applies optional neurite filter and element mapping functions.
+
+    Example:
+        Get the lengths of sections in a neuron and a population
+
+        >>> from neurom import sections as sec
+        >>> neuron_lengths = [l for l in iter_neurites(nrn, sec.length)]
+        >>> population_lengths = [l for l in iter_neurites(pop, sec.length)]
+        >>> neurite = nrn.neurites[0]
+        >>> tree_lengths = [l for l in iter_neurites(neurite, sec.length)]
+
+    '''
+    #  TODO: optimize case of single neurite and move code to neurom.core.tree
+    neurites = ([obj] if isinstance(obj, Tree)
+                else (obj.neurites if hasattr(obj, 'neurites') else obj))
+    iter_type = None if mapfun is None else mapfun.iter_type
+
+    return i_chain2(neurites, iter_type, mapfun, filt)

--- a/neurom/point_neurite/features/_impl.py
+++ b/neurom/point_neurite/features/_impl.py
@@ -31,6 +31,7 @@
 from functools import wraps
 from functools import partial
 from .. import point_tree as _tr
+from ..core import iter_neurites
 from neurom.core.types import NeuriteType
 from neurom.point_neurite.core import Neuron
 from neurom.point_neurite import treefunc as _mt
@@ -40,7 +41,6 @@ from neurom.point_neurite import segments as _seg
 from neurom.point_neurite import sections as _sec
 from neurom.point_neurite import bifurcations as _bifs
 from neurom.point_neurite import points as _pts
-from neurom import iter_neurites
 from neurom.analysis.morphmath import sphere_area
 
 

--- a/neurom/point_neurite/features/tests/test_features.py
+++ b/neurom/point_neurite/features/tests/test_features.py
@@ -10,7 +10,7 @@ import neurom.point_neurite.sections as sec
 import neurom.point_neurite.segments as seg
 import neurom.point_neurite.bifurcations as bifs
 from neurom.point_neurite.features import get as get_feat
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 from neurom.point_neurite.io.utils import load_neuron as _load
 from neurom.point_neurite.treefunc import set_tree_type as _set_tt
 

--- a/neurom/point_neurite/io/tests/test_utils.py
+++ b/neurom/point_neurite/io/tests/test_utils.py
@@ -34,9 +34,8 @@ from neurom.point_neurite.io import utils
 from neurom.point_neurite import points as pts
 from neurom.point_neurite import point_tree as ptree
 from neurom.point_neurite.io.datawrapper import RawDataWrapper
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 from neurom.core.dataformat import COLS
-from neurom.core import tree
 from neurom.exceptions import (SomaError, IDSequenceError,
                                MultipleTrees, MissingParentError)
 from nose import tools as nt

--- a/neurom/point_neurite/io/utils.py
+++ b/neurom/point_neurite/io/utils.py
@@ -181,7 +181,6 @@ def load_data(filename):
         '''Lazy loading of Neurolucida ASCII reader'''
         from neurom.io import neurolucida
         return neurolucida.read(filename,
-                                remove_duplicates=False,
                                 data_wrapper=RawDataWrapper)
 
     _READERS = {

--- a/neurom/point_neurite/points.py
+++ b/neurom/point_neurite/points.py
@@ -31,7 +31,7 @@
 '''
 import functools
 from neurom.core import Tree
-from neurom import iter_neurites
+from .core import iter_neurites
 from neurom.core.dataformat import COLS
 from neurom.utils import deprecated_module
 

--- a/neurom/point_neurite/sections.py
+++ b/neurom/point_neurite/sections.py
@@ -31,7 +31,7 @@
 '''
 from itertools import izip
 from functools import wraps
-from neurom import iter_neurites
+from .core import iter_neurites
 import neurom.analysis.morphmath as mm
 from . import point_tree as tr
 from . import treefunc as mt

--- a/neurom/point_neurite/segments.py
+++ b/neurom/point_neurite/segments.py
@@ -31,8 +31,8 @@
 '''
 import functools
 from . import point_tree as tr
+from .core import iter_neurites
 from neurom.core.dataformat import COLS
-from neurom import iter_neurites
 import neurom.analysis.morphmath as mm
 from neurom.utils import deprecated_module
 

--- a/neurom/point_neurite/tests/test_bifurcations.py
+++ b/neurom/point_neurite/tests/test_bifurcations.py
@@ -32,7 +32,7 @@ from neurom.point_neurite import io
 from neurom.point_neurite.io.utils import make_neuron
 from neurom.point_neurite.point_tree import PointTree
 from neurom.point_neurite import bifurcations as bif
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 import math
 
 

--- a/neurom/point_neurite/tests/test_points.py
+++ b/neurom/point_neurite/tests/test_points.py
@@ -31,7 +31,7 @@ from neurom import io
 from neurom.point_neurite.point_tree import PointTree
 from neurom.point_neurite.io.utils import make_neuron
 from neurom.point_neurite import points as pts
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 
 
 class MockNeuron(object):

--- a/neurom/point_neurite/tests/test_sections.py
+++ b/neurom/point_neurite/tests/test_sections.py
@@ -28,7 +28,7 @@
 
 from nose import tools as nt
 import os
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 from neurom.point_neurite import io
 from neurom.point_neurite.io.utils import make_neuron
 from neurom.point_neurite.point_tree import PointTree, isection

--- a/neurom/point_neurite/tests/test_segments.py
+++ b/neurom/point_neurite/tests/test_segments.py
@@ -32,7 +32,7 @@ from neurom.point_neurite import io
 from neurom.point_neurite.io.utils import make_neuron
 from neurom.point_neurite.point_tree import PointTree
 from neurom.point_neurite import segments as seg
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 
 import math
 from itertools import izip

--- a/neurom/point_neurite/triplets.py
+++ b/neurom/point_neurite/triplets.py
@@ -31,7 +31,7 @@
 '''
 import functools
 from .point_tree import PointTree
-from neurom import iter_neurites
+from .core import iter_neurites
 from neurom.analysis import morphmath as mm
 from neurom.utils import deprecated_module
 

--- a/neurom/view/_compat.py
+++ b/neurom/view/_compat.py
@@ -29,7 +29,7 @@
 '''Old-style new-style neurite compatibility hacks'''
 
 from neurom.view._dendrogram import Dendrogram
-from neurom import iter_neurites
+from neurom.point_neurite.core import iter_neurites
 from neurom.point_neurite import segments as seg
 from neurom.point_neurite.point_tree import PointTree
 from neurom.point_neurite.dendrogram import Dendrogram as PointDendrogram


### PR DESCRIPTION
Simplify iter_neurites and NL ASCII reader.

* Simplify NL ASCII reader.  Disable duplicate removal option. This is not used, and adds complexity and scope for confusion.
* Update neurom.core.iter_neurites. The existing implementation was only useful for the deprecated neurom.point_neurite code. It has been moved to neurom.point_neurite.core. A new, simplified version has been added back to neuro.core and is imported directly in neurom.
