### PR TITLE
Fix bug in neurom.fst._neuritefunc.section_radial_distances.

### DIFF
--- a/neurom/core/__init__.py
+++ b/neurom/core/__init__.py
@@ -33,6 +33,7 @@ from .tree import Tree
 from .types import NeuriteType
 from ._soma import Soma, make_soma, SomaError
 from ._neuron import Section, Neurite, Neuron
+from .population import Population
 
 
 def iter_neurites(obj, mapfun=None, filt=None):

--- a/neurom/fst/_neuritefunc.py
+++ b/neurom/fst/_neuritefunc.py
@@ -161,8 +161,8 @@ def segment_radial_distances(neurites, neurite_type=NeuriteType.all, origin=None
 
     dist = []
     for n in iter_neurites(neurites, filt=is_type(neurite_type)):
-        origin = n.root_node.points[0] if origin is None else origin
-        dist.extend([s for ss in n.iter_sections() for s in _seg_rd(ss, origin)])
+        pos = n.root_node.points[0] if origin is None else origin
+        dist.extend([s for ss in n.iter_sections() for s in _seg_rd(ss, pos)])
 
     return dist
 
@@ -195,8 +195,8 @@ def section_radial_distances(neurites, neurite_type=NeuriteType.all, origin=None
     '''Remote bifurcation angles in a collection of neurites'''
     dist = []
     for n in iter_neurites(neurites, filt=is_type(neurite_type)):
-        origin = n.root_node.points[0] if origin is None else origin
-        dist.extend([section_radial_distance(s, origin) for s in n.iter_sections()])
+        pos = n.root_node.points[0] if origin is None else origin
+        dist.extend([section_radial_distance(s, pos) for s in n.iter_sections()])
 
     return dist
 

--- a/neurom/fst/tests/test_neuritefunc.py
+++ b/neurom/fst/tests/test_neuritefunc.py
@@ -148,3 +148,21 @@ def test_section_radial_distances_displaced_neurite():
     rad_dist_pop = nm.get('section_radial_distances', pop)
 
     nt.ok_(np.alltrue(rad_dist_pop == rad_dist_nrns))
+
+
+
+def test_segment_radial_distances_displaced_neurite():
+    nrns = [nm.load_neuron(os.path.join(SWC_PATH, f)) for
+            f in ('point_soma_single_neurite.swc', 'point_soma_single_neurite2.swc')]
+
+    pop = Population(nrns)
+
+    rad_dist_nrns = []
+    for nrn in nrns:
+        rad_dist_nrns.extend( nm.get('segment_radial_distances', nrn))
+
+    rad_dist_nrns = np.array(rad_dist_nrns)
+
+    rad_dist_pop = nm.get('segment_radial_distances', pop)
+
+    nt.ok_(np.alltrue(rad_dist_pop == rad_dist_nrns))

--- a/neurom/fst/tests/test_neuritefunc.py
+++ b/neurom/fst/tests/test_neuritefunc.py
@@ -31,17 +31,20 @@
 from nose import tools as nt
 import os
 import numpy as np
+import neurom as nm
 from neurom import fst
 from neurom.fst import _neuritefunc as _nf
 from neurom.point_neurite.io import utils as io_utils
 from neurom.core import tree as tr
+from neurom.core import Population
 from neurom.point_neurite import point_tree as ptr
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
 DATA_PATH = os.path.join(H5_PATH, 'Neuron.h5')
+SWC_PATH = os.path.join(_PWD, '../../../test_data/swc')
 
-NRN = fst.load_neuron(DATA_PATH)
+NRN = nm.load_neuron(DATA_PATH)
 NRN_OLD = io_utils.load_neuron(DATA_PATH)
 
 
@@ -77,7 +80,7 @@ def test_iter_segments():
 
 def test_principal_direction_extents():
     # test with a realistic neuron
-    nrn = fst.load_neuron(os.path.join(H5_PATH, 'bio_neuron-000.h5'))
+    nrn = nm.load_neuron(os.path.join(H5_PATH, 'bio_neuron-000.h5'))
 
     p_ref = [1672.9694359427331, 142.43704397865031, 226.45895382204986,
              415.50612748523838, 429.83008974193206, 165.95410536922873,
@@ -128,3 +131,20 @@ def test_n_leaves():
     nt.assert_equal(_nf.n_leaves(fst.Neurite(s5)), 1)
     nt.assert_equal(_nf.n_leaves(fst.Neurite(s6)), 1)
     nt.assert_equal(_nf.n_leaves(fst.Neurite(s7)), 1)
+
+
+def test_section_radial_distances_displaced_neurite():
+    nrns = [nm.load_neuron(os.path.join(SWC_PATH, f)) for
+            f in ('point_soma_single_neurite.swc', 'point_soma_single_neurite2.swc')]
+
+    pop = Population(nrns)
+
+    rad_dist_nrns = []
+    for nrn in nrns:
+        rad_dist_nrns.extend( nm.get('section_radial_distances', nrn))
+
+    rad_dist_nrns = np.array(rad_dist_nrns)
+
+    rad_dist_pop = nm.get('section_radial_distances', pop)
+
+    nt.ok_(np.alltrue(rad_dist_pop == rad_dist_nrns))

--- a/test_data/swc/point_soma_single_neurite2.swc
+++ b/test_data/swc/point_soma_single_neurite2.swc
@@ -1,0 +1,9 @@
+# A simple neuron consisting of a point soma
+# and a single branch neurite.
+# Topologically, the soma doesn't form a separate section, so this
+# can be used for testing whether the SWC reader treats the soma specially.
+1 1 0 0 0 3.0 -1
+2 3 -8 -8 -8 0.5 1
+3 3 0 0 3 0.5 2
+4 3 0 0 4 0.5 3
+5 3 0 0 5 0.5 4


### PR DESCRIPTION
In the case where no origin is set, was calculating distances WRT the
origin of the first neurite in a population, instead of updating the
origin for each neurite.

Similar fix for segment_radial_distances.

Resolves #501.