### PR TITLE
Add convex_hull function to neurom.geom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
   - sudo apt-get install -y python-virtualenv
   - sudo apt-get install -y python-numpy
   - sudo apt-get install -y python-h5py
-  - sudo apt-get install -y python-scipy
   - sudo apt-get install -y python-matplotlib
+  - sudp pip install --force-reinstall scipy==0.17
 script:
   - make -f Makefile test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
   - sudo apt-get install -y python-virtualenv
   - sudo apt-get install -y python-numpy
   - sudo apt-get install -y python-h5py
+  - sudo pip install scipy==0.17
   - sudo apt-get install -y python-matplotlib
-  - sudp pip install --force-reinstall scipy==0.17
 script:
   - make -f Makefile test
 after_success:

--- a/neurom/geom/__init__.py
+++ b/neurom/geom/__init__.py
@@ -29,6 +29,7 @@
 ''' Geometrical Operations for NeuroM '''
 
 import numpy as np
+from scipy.spatial import ConvexHull
 from .transform import translate, rotate
 
 
@@ -40,3 +41,13 @@ def bounding_box(obj):
     '''
     return np.array([np.min(obj.points[:, 0:3], axis=0),
                      np.max(obj.points[:, 0:3], axis=0)])
+
+
+def convex_hull(obj):
+    '''Get the convex hull of an object containing points
+
+    Returns:
+        scipy.spatial.ConvexHull object built from obj.points
+
+    '''
+    return ConvexHull(obj.points[:, :3])

--- a/neurom/geom/tests/test_geom.py
+++ b/neurom/geom/tests/test_geom.py
@@ -73,3 +73,19 @@ def test_bounding_box_neurite():
     nrt = NRN.neurites[0]
     ref = np.array([[-33.25305769, -57.600172, 0.], [0., 0., 49.70137991]])
     nt.assert_true(np.allclose(geom.bounding_box(nrt), ref))
+
+
+def test_convex_hull_points():
+
+    # This leverages scipy ConvexHull and we don't want
+    # to re-test scipy, so simply check that the points are the same.
+    hull = geom.convex_hull(NRN)
+    nt.ok_(np.alltrue(hull.points == NRN.points[:, :3]))
+
+
+def test_convex_hull_volume():
+
+    # This leverages scipy ConvexHull and we don't want
+    # to re-test scipy, so simply regression test the volume
+    hull = geom.convex_hull(NRN)
+    nt.assert_almost_equal(hull.volume, 208641.65, places=3)

--- a/pylintrc
+++ b/pylintrc
@@ -58,6 +58,10 @@ ignore-docstrings=yes
 [TYPECHECK]
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
+#ignored-classes=foo.bar
 
-#as of numpy 1.8.0, name resolution seems to be a problem.  Ignore lookups in numpy
-ignored-classes=numpy,numpy.linalg,numpy.random,numpy.testing,scipy.stats
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=numpy,numpy.linalg,numpy.random,numpy.testing,scipy.stats,scipy.spatial

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@
 #numpy>=1.8.0
 #h5py>=2.2.1
 #matplotlib>=1.3.1
-#scipy>=0.13.3
+#scipy>=0.17.0
 
 # These can be installed with pip if necessary.
 enum34>=1.0.4


### PR DESCRIPTION
Returns a scipy.spatial.ConvexHull object.

Note: for volume calculation, scipy>=0.17 is required.