### PR TITLE
pip installs dependencies if not found.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
   - sudo pip install --upgrade pip
   - sudo apt-get install -y python-virtualenv
   - sudo apt-get install -y python-numpy
+  - sudo apt-get install -y python-scipy
   - sudo apt-get install -y python-h5py
-  - sudo pip install scipy==0.17
   - sudo apt-get install -y python-matplotlib
 script:
   - make -f Makefile test

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#These requirements are assumed installed in the system.
-#numpy>=1.8.0
-#h5py>=2.2.1
-#matplotlib>=1.3.1
-#scipy>=0.17.0
-
-# These can be installed with pip if necessary.
+# pip will install these dependencies with neurom if not found on the system
+numpy>=1.8.0
+scipy>=0.17.0
 enum34>=1.0.4
 pyyaml>=3.10
 tqdm>=4.8.4
+matplotlib>=1.3.1
+h5py>=2.2.1


### PR DESCRIPTION
This simplifies the installation for most users.
With recent versions of pip, wheels are installed,
resulting in a fast installation. Otherwise this would be
prohibitively slow.