### PR TITLE
Make h5py dependency optional.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include requirements.txt
 include requirements_dev.txt
-include requirements_hbp.txt
 include README.rst

--- a/doc/source/dependencies.rst
+++ b/doc/source/dependencies.rst
@@ -42,7 +42,6 @@ subset into your system before installing ``NeuroM``. These typically have insta
 packages available for must common Linux distributions and Mac OSX:
 
 * `numpy <http://www.numpy.org/>`_
-* `h5py <http://www.h5py.org/>`_
 * `scipy <http://www.scipy.org/>`_
 * `matplotlib <http://www.matplotlib.org/>`_
 
@@ -50,6 +49,12 @@ These remaining dependencies are lightweight and can be left to the automatic in
 
 * `enum34 <https://pypi.python.org/pypi/enum34/>`_
 * `pyyaml <http://www.pyyaml.org/>`_
+
+Finally, `h5py <http://www.h5py.org/>`_ is an optional dependency, required for processing
+of morphology files in an internal BBP format. If required, It is up to the user to ensure
+it is pre-installed before installing ``NeuroM``.
+
+* `h5py <http://www.h5py.org/>`_
 
 
 Installing and building

--- a/doc/source/tour.rst
+++ b/doc/source/tour.rst
@@ -45,8 +45,8 @@ Trees
 =====
 
 Trees are hierachical, recursive structures used to represent individual
-neurites in a morphology. NeuroM represents neurites as :ref:`trees containing
-measurement point information at each node<tree-label>`. The role of a tree is
+neurites in a morphology. NeuroM represents neurites as trees containing
+measurement point information at each node. The role of a tree is
 simply to maintain the hierarchy of its components. As will be shown, most of
 the interesting work is done through a combination of different types of tree 
 :ref:`iteration<iterator-label>`,

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,6 @@ enum34>=1.0.4
 pyyaml>=3.10
 tqdm>=4.8.4
 matplotlib>=1.3.1
-h5py>=2.2.1
+
+# This optional dependency must be pre-installed if needed
+#h5py>=2.2.1


### PR DESCRIPTION
* Users who need it must pre-install.
* Fixes documentation building error.
* Remove obsolete include from MANIFEST.in.