### PR TITLE
Add neurite_volume_density feature to neurom.get.

### DIFF
--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -103,6 +103,7 @@ NEURITEFEATURES = {
     'neurite_lengths': _nrt.total_length_per_neurite,
     'section_lengths': partial(_nrt.map_sections, sec_len),
     'neurite_volumes': _nrt.total_volume_per_neurite,
+    'neurite_volume_density': _nrt.volume_density_per_neurite,
     'section_volumes': partial(_nrt.map_sections, _sec.section_volume),
     'section_areas': partial(_nrt.map_sections, _sec.section_area),
     'section_tortuosity': partial(_nrt.map_sections, _sec.section_tortuosity),

--- a/neurom/fst/_neuritefunc.py
+++ b/neurom/fst/_neuritefunc.py
@@ -34,6 +34,7 @@ import numpy as np
 from neurom.core import Tree, iter_neurites
 from neurom.core.types import tree_type_checker as is_type
 from neurom.core.types import NeuriteType
+from neurom.geom import convex_hull
 from neurom import morphmath as mm
 from .sectionfunc import branch_order, section_radial_distance
 from ._bifurcationfunc import (local_bifurcation_angle,
@@ -216,6 +217,20 @@ def total_length_per_neurite(neurites, neurite_type=NeuriteType.all):
 def total_volume_per_neurite(neurites, neurite_type=NeuriteType.all):
     '''Get the volume per neurite in a collection'''
     return list(sum(s.volume for s in n.iter_sections())
+                for n in iter_neurites(neurites, filt=is_type(neurite_type)))
+
+
+def volume_density_per_neurite(neurites, neurite_type=NeuriteType.all):
+    '''Get the volume density per neurite
+
+    The volume density is defined as the ratio of the neurite volume and
+    the volume of the neurite's enclosung convex hull
+    '''
+    def vol_density(neurite):
+        '''volume density of a single neurite'''
+        return neurite.volume / convex_hull(neurite).volume
+
+    return list(vol_density(n)
                 for n in iter_neurites(neurites, filt=is_type(neurite_type)))
 
 

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -493,6 +493,46 @@ def test_neurite_volumes_pop():
                        (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864)))
 
 
+def test_neurite_density_nrn():
+
+    feat = 'neurite_volume_density'
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, NRN)),
+                       (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.all)),
+                       (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.axon)),
+                       (0.26289304906104355, 0.26289304906104355, 0.26289304906104355, 0.26289304906104355)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
+                       (0.24068543213643726, 0.52464681266899216, 0.76533224480542938, 0.38266612240271469)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
+                       (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519)))
+
+
+def test_neurite_density_pop():
+
+    feat = 'neurite_volume_density'
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+                       (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+                       (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.axon)),
+                       (6.1847539631150784e-06, 0.26465213325053372, 0.5275513670655404, 0.17585045568851346)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+                       (0.00034968816544949771, 0.52464681266899216, 1.0116620531455183, 0.16861034219091972)))
+
+    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+                       (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519)))
+
+
 def test_segment_meander_angles_single_section():
 
     class Mock(object):

--- a/neurom/fst/tests/test_neuritefunc.py
+++ b/neurom/fst/tests/test_neuritefunc.py
@@ -33,6 +33,7 @@ import os
 import numpy as np
 import neurom as nm
 from neurom import fst
+from neurom.geom import convex_hull
 from neurom.fst import _neuritefunc as _nf
 from neurom.fst.sectionfunc import section_volume
 from neurom.point_neurite.io import utils as io_utils
@@ -185,3 +186,17 @@ def test_total_volume_per_neurite():
     # regression test
     ref_vol = [271.94122143951864, 281.24754646913954, 274.98039928781355, 276.73860261723024]
     nt.ok_(np.allclose(vol, ref_vol))
+
+
+def test_volume_density_per_neurite():
+
+    vol = np.array(_nf.total_volume_per_neurite(NRN))
+    hull_vol = np.array([convex_hull(n).volume for n in nm.iter_neurites(NRN)])
+
+    vol_density = _nf.volume_density_per_neurite(NRN)
+    nt.eq_(len(vol_density), 4)
+    nt.ok_(np.allclose(vol_density, vol / hull_vol))
+
+    ref_density = [0.43756606998299519, 0.52464681266899216,
+                   0.24068543213643726, 0.26289304906104355]
+    nt.ok_(np.allclose(vol_density, ref_density))


### PR DESCRIPTION
Returns array with the volume density of each neurite. The
volume density is the ratio of neurite volume to neurite convex hull
volume.