### PR TITLE
Simplify installation instructions.

### DIFF
--- a/doc/source/dependencies.rst
+++ b/doc/source/dependencies.rst
@@ -38,20 +38,16 @@ Build and runtime
 
 ``NeuroM`` requires Python version 2.6 or higher (but not version 3.x).
 When installed using `pip <https://pip.pypa.io/en/stable/>`_, ``NeuroM``
-will take care of installing unmet dependencies.
-However, for best performance, it may be preferable to pre-install the following
-subset into your system before installing ``NeuroM``. These typically have installation
-packages available for must common Linux distributions and Mac OSX:
+will take care of installing unmet dependencies, although it is also possible
+to pre-install before ``NeuroM``.
 
-* `numpy <http://www.numpy.org/>`_
-* `scipy <http://www.scipy.org/>`_
-* `matplotlib <http://www.matplotlib.org/>`_
-* `h5py <http://www.h5py.org/>`_
-
-These remaining dependencies are lightweight and can be left to the automatic installation:
-
-* `enum34 <https://pypi.python.org/pypi/enum34/>`_
-* `pyyaml <http://www.pyyaml.org/>`_
+* `numpy <http://www.numpy.org/>`_ >= 1.8.0
+* `scipy <http://www.scipy.org/>`_ >= 0.17.0
+* `matplotlib <http://www.matplotlib.org/>`_ >= 1.3.1
+* `h5py <http://www.h5py.org/>`_ >= 2.2.1
+* `enum34 <https://pypi.python.org/pypi/enum34/>`_ >= 1.0.4
+* `pyyaml <http://www.pyyaml.org/>`_ >= 3.10.0
+* `tqdm <https://pypi.python.org/pypi/tqdm/>`_ tqdm >= 4.8.4
 
 
 Installing and building

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -98,13 +98,18 @@ Virtualenv setup
 
 .. code-block:: bash
 
-    $ virtualenv --system-site-packages nrm   # creates a virtualenv called "nrm" in nrm directory
-    $ source nrm/bin/activate                 # activates virtualenv
-    (nrm)$                                    # now we are in the nrm virtualenv
+    $ virtualenv nrm           # creates a virtualenv called "nrm" in nrm directory
+    $ source nrm/bin/activate  # activates virtualenv
+    (nrm)$                     # now we are in the nrm virtualenv
 
-Here, the ``--system-site-packages`` option has been used. This is because dependencies such as
-``matplotlib`` aren't trivial to build in a ``virtualenv``. This setting allows python packages
-installed in the system to be used inside the ``virtualenv``.
+This will create a virtualenv that is isolated from system-wide python packages. If you
+prefer to use :ref:`pre-installed dependencies<pre-dep-label>`, you may use
+the ``--system-site-packages`` option, which allows globally installed python packages
+to be used inside the ``virtualenv``:
+
+.. code-block:: bash
+
+    $ virtualenv --system-site-packages nrm   # creates a virtualenv called "nrm" in nrm directory
 
 The prompt indicates that the ``virtualenv`` has been activated.
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from pip.req import parse_requirements
 from optparse import Option
 
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 
 def parse_reqs(reqs_file):


### PR DESCRIPTION
* No longer suggest virtualenv --system-site-packages as default,
  but let NeuroM install all dependencies into clean virtualenv.
  Mention --system-site-packages as an alternative, allowing to use
  system-wide packages.

* Increase version to 1.1.1.