### PR TITLE
Remove unnecessary helper functions from fst module.

### DIFF
--- a/doc/source/definitions.rst
+++ b/doc/source/definitions.rst
@@ -94,7 +94,7 @@ whose first and last element are any of the following combinations:
 The first point of a section is a duplicate of the last point of its parent section,
 unless the latter is a soma section.
 
-In ``NeuroM``, a section is represented by class :py:class:`Section<neurom.fst.Section>`.
+In ``NeuroM``, a section is represented by class :py:class:`Section<neurom.core.Section>`.
 This pseudocode shows the relevant parts of the section class:
 
 .. code-block:: python
@@ -152,12 +152,12 @@ implies the following:
 * A node can have an arbitrary number of children.
 * No loops are present in the structure.
 
-Neurites are represented by the class :py:class:`Neurite<neurom.fst.Neurite>`, which contains
+Neurites are represented by the class :py:class:`Neurite<neurom.core.Neurite>`, which contains
 the root node of the aforementioned tree as well as some helper functions to aid iteration
 over sections and collection of points.
 
 In :py:mod:`NeuroM<neurom>` neurite trees are implemented using the recursive structure
-:py:class:`neurom.fst.Section`, :ref:`described above<section-label>`.
+:py:class:`neurom.core.Section`, :ref:`described above<section-label>`.
 
 
 Neuron
@@ -171,7 +171,7 @@ The trees that are expected to be present depend on the type of cell:
 * Interneuron (IN): basal dendrite, axon
 * Pyramidal cell (PC): basal dendrite, apical dendrite, axon
 
-Neurons are represented by the class :py:class:`Neuron<neurom.fst.Neuron>`. This is more
+Neurons are represented by the class :py:class:`Neuron<neurom.core.Neuron>`. This is more
 or less what it looks like:
 
 .. code-block:: python

--- a/examples/radius_of_gyration.py
+++ b/examples/radius_of_gyration.py
@@ -31,7 +31,7 @@
 
 import neurom as nm
 from neurom import morphmath as mm
-from neurom.fst import _neuritefunc as nf
+from neurom.fst import iter_segments
 from neurom.core.dataformat import COLS
 import numpy as np
 
@@ -54,8 +54,8 @@ def neurite_centre_of_mass(neurite):
     centre_of_mass = np.zeros(3)
     total_volume = 0
 
-    seg_vol = np.array(map(mm.segment_volume, nf.iter_segments(neurite)))
-    seg_centre_of_mass = np.array(map(segment_centre_of_mass, nf.iter_segments(neurite)))
+    seg_vol = np.array(map(mm.segment_volume, iter_segments(neurite)))
+    seg_centre_of_mass = np.array(map(segment_centre_of_mass, iter_segments(neurite)))
 
     # multiply array of scalars with array of arrays
     # http://stackoverflow.com/questions/5795700/multiply-numpy-array-of-scalars-by-array-of-vectors
@@ -77,7 +77,7 @@ def radius_of_gyration(neurite):
     centre_mass = neurite_centre_of_mass(neurite)
     sum_sqr_distance = 0
     N = 0
-    dist_sqr = [distance_sqr(centre_mass, s) for s in nf.iter_segments(neurite)]
+    dist_sqr = [distance_sqr(centre_mass, s) for s in iter_segments(neurite)]
     sum_sqr_distance = np.sum(dist_sqr)
     N = len(dist_sqr)
     return np.sqrt(sum_sqr_distance / N)

--- a/neurom/__init__.py
+++ b/neurom/__init__.py
@@ -59,8 +59,10 @@ Examples:
 '''
 
 from .version import VERSION as __version__
-from .core import iter_neurites, iter_sections
-from .fst import load_neuron, load_neurons, NeuriteType, get, NEURITE_TYPES
+from .core import iter_neurites, iter_sections, NeuriteType
+from .core.types import NEURITES as NEURITE_TYPES
+from .io.utils import load_neuron, load_neurons
+from .fst import get
 
 
 APICAL_DENDRITE = NeuriteType.apical_dendrite

--- a/neurom/check/tests/test_morphtree.py
+++ b/neurom/check/tests/test_morphtree.py
@@ -27,8 +27,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neurom import load_neuron
-from neurom.fst import Neurite, NeuriteType, Section
 from neurom.check import morphtree as mt
+from neurom.core import Neurite, NeuriteType, Section
 from neurom.core.dataformat import COLS
 from nose import tools as nt
 import numpy as np

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -32,34 +32,30 @@ Examples:
 
     Obtain some morphometrics
 
-    >>> ap_seg_len = fst.get('segment_lengths', nrn, neurite_type=fst.NeuriteType.apical_dendrite)
-    >>> ax_sec_len = fst.get('section_lengths', nrn, neurite_type=fst.NeuriteType.axon)
+    >>> ap_seg_len = fst.get('segment_lengths', nrn, neurite_type=neurom.APICAL_DENDRITE)
+    >>> ax_sec_len = fst.get('section_lengths', nrn, neurite_type=neurom.AXON)
 
 '''
 
 import numpy as _np
-from functools import partial, update_wrapper
+from functools import partial
 from itertools import chain
-from ._core import FstNeuron, Neurite, Section
-from . import _neuritefunc as _nrt
-from ._neuritefunc import iter_sections
+from ._core import FstNeuron
 from ._neuritefunc import iter_segments
+from . import _neuritefunc as _nrt
 from . import _neuronfunc as _nrn
 from . import sectionfunc as _sec
-from ..utils import deprecated
-from ..core.population import Population
-from ..core import Tree
-from ..core import NeuriteType
+from ..core import NeuriteType as _ntype
 from ..core.types import tree_type_checker as _is_type
-from ..morphmath import segment_radius as seg_rad
-from ..morphmath import segment_taper_rate as seg_taper
-from ..morphmath import section_length as sec_len
+from ..morphmath import segment_radius as _seg_rad
+from ..morphmath import segment_taper_rate as _seg_taper
+from ..morphmath import section_length as _sec_len
 
 
-sec_len = _sec.section_fun(sec_len)
+_sec_len = _sec.section_fun(_sec_len)
 
 
-def _iseg(nrn, neurite_type=NeuriteType.all):
+def _iseg(nrn, neurite_type=_ntype.all):
     '''Build a tree type filter from a neurite type and forward to functon
 
     TODO:
@@ -75,10 +71,10 @@ def _as_neurons(fun, nrns, **kwargs):
 
 
 NEURITEFEATURES = {
-    'total_length': partial(_as_neurons, lambda n, **kw: sum(_nrt.map_sections(sec_len, n, **kw))),
+    'total_length': partial(_as_neurons, lambda n, **kw: sum(_nrt.map_sections(_sec_len, n, **kw))),
     'total_length_per_neurite': _nrt.total_length_per_neurite,
     'neurite_lengths': _nrt.total_length_per_neurite,
-    'section_lengths': partial(_nrt.map_sections, sec_len),
+    'section_lengths': partial(_nrt.map_sections, _sec_len),
     'neurite_volumes': _nrt.total_volume_per_neurite,
     'neurite_volume_density': _nrt.volume_density_per_neurite,
     'section_volumes': partial(_nrt.map_sections, _sec.section_volume),
@@ -98,9 +94,9 @@ NEURITEFEATURES = {
     'partition': _nrt.bifurcation_partitions,
     'number_of_segments': partial(_as_neurons, _nrt.n_segments),
     'segment_lengths': _nrt.segment_lengths,
-    'segment_radii': lambda nrn, **kwargs: [seg_rad(s) for s in _iseg(nrn, **kwargs)],
+    'segment_radii': lambda nrn, **kwargs: [_seg_rad(s) for s in _iseg(nrn, **kwargs)],
     'segment_midpoints': _nrt.segment_midpoints,
-    'segment_taper_rates': lambda nrn, **kwargs: [seg_taper(s)
+    'segment_taper_rates': lambda nrn, **kwargs: [_seg_taper(s)
                                                   for s in _iseg(nrn, **kwargs)],
     'segment_radial_distances': _nrt.segment_radial_distances,
     'segment_meander_angles': lambda nrn, **kwargs: list(chain.from_iterable(_nrt.map_sections(

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -30,34 +30,16 @@
 
 Examples:
 
-    Load a neuron
-
-    >>> from neurom import fst
-    >>> nrn = fst.load_neuron('some/data/path/morph_file.swc')
-
     Obtain some morphometrics
 
     >>> ap_seg_len = fst.get('segment_lengths', nrn, neurite_type=fst.NeuriteType.apical_dendrite)
     >>> ax_sec_len = fst.get('section_lengths', nrn, neurite_type=fst.NeuriteType.axon)
-
-    Load neurons from a directory. This loads all SWC or HDF5 files it finds\
-    and returns a list of neurons
-
-    >>> import numpy as np  # For mean value calculation
-    >>> nrns = fst.load_neurons('some/data/directory')
-    >>> for nrn in nrns:
-    ...     print 'mean section length', np.mean(fst.get('section_lengths', nrn))
-
-    Iterate over all the sections in a neuron
-
-    >>> for s in fst.iter_sections(nrn): print s.points[0][:3]
 
 '''
 
 import numpy as _np
 from functools import partial, update_wrapper
 from itertools import chain
-from ..io.utils import load_neuron, load_neurons
 from ._core import FstNeuron, Neurite, Section
 from . import _neuritefunc as _nrt
 from ._neuritefunc import iter_sections
@@ -68,7 +50,6 @@ from ..utils import deprecated
 from ..core.population import Population
 from ..core import Tree
 from ..core import NeuriteType
-from ..core.types import NEURITES as NEURITE_TYPES
 from ..core.types import tree_type_checker as _is_type
 from ..morphmath import segment_radius as seg_rad
 from ..morphmath import segment_taper_rate as seg_taper
@@ -85,10 +66,6 @@ def _iseg(nrn, neurite_type=NeuriteType.all):
         This should be a decorator
     '''
     return _nrt.iter_segments(nrn, neurite_filter=_is_type(neurite_type))
-
-
-load_population = deprecated(msg='Use load_neurons instead.',
-                             fun_name='load_population')(load_neurons)
 
 
 def _as_neurons(fun, nrns, **kwargs):

--- a/neurom/fst/tests/test_feature_compat.py
+++ b/neurom/fst/tests/test_feature_compat.py
@@ -31,6 +31,7 @@
 import os
 import numpy as np
 from nose import tools as nt
+import neurom as nm
 from neurom.core.types import NeuriteType
 from neurom import fst
 from neurom.fst import _neuronfunc as _nrn
@@ -39,7 +40,7 @@ from neurom.fst import sectionfunc as _sec
 from neurom.fst import _bifurcationfunc as _bf
 from neurom.core import Tree
 from neurom.core.tree import i_chain2
-from neurom.point_neurite.io.utils import load_neuron
+from neurom.point_neurite.io.utils import load_neuron as load_pt_neuron
 from neurom.point_neurite.features import get
 from neurom.point_neurite import treefunc as mt
 
@@ -53,8 +54,8 @@ MORPH_FILENAME = 'Neuron.h5'
 SWC_MORPH_FILENAME = 'Neuron.swc'
 
 # Arbitrarily use h5 v1 as reference always
-REF_NRN = load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME),
-                      mt.set_tree_type)
+REF_NRN = load_pt_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME),
+                         mt.set_tree_type)
 
 REF_NEURITE_TYPES = [NeuriteType.apical_dendrite, NeuriteType.basal_dendrite,
                      NeuriteType.basal_dendrite, NeuriteType.axon]
@@ -214,7 +215,7 @@ class TestH5V1(SectionTreeBase):
 
     def setUp(self):
         super(TestH5V1, self).setUp()
-        self.sec_nrn = fst.load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
 
 
@@ -222,15 +223,15 @@ class TestH5V2(SectionTreeBase):
 
     def setUp(self):
         super(TestH5V2, self).setUp()
-        self.sec_nrn = fst.load_neuron(os.path.join(H5V2_DATA_PATH, MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(os.path.join(H5V2_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
 
 
 class TestSWC(SectionTreeBase):
 
     def setUp(self):
-        self.ref_nrn = load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME),
+        self.ref_nrn = load_pt_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME),
                                    mt.set_tree_type)
-        self.sec_nrn = fst.load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
         self.ref_types = [n.type for n in self.ref_nrn.neurites]

--- a/neurom/fst/tests/test_get_feature_compat.py
+++ b/neurom/fst/tests/test_get_feature_compat.py
@@ -31,10 +31,11 @@
 import os
 import numpy as np
 from nose import tools as nt
+import neurom as nm
 from neurom.core.types import NeuriteType
 from neurom.core.population import Population
 from neurom import fst
-from neurom.point_neurite.io.utils import load_neuron
+from neurom.point_neurite.io.utils import load_neuron as load_pt_neuron
 from neurom.point_neurite.features import get
 from neurom.point_neurite import treefunc as mt
 
@@ -65,8 +66,8 @@ class TestSectionTree(object):
     '''Base class for section tree tests'''
 
     def setUp(self):
-        self.ref_pop = Population([load_neuron(f, mt.set_tree_type) for f in NRN_PATHS])
-        self.fst_pop = Population([fst.load_neuron(f) for f in NRN_PATHS])
+        self.ref_pop = Population([load_pt_neuron(f, mt.set_tree_type) for f in NRN_PATHS])
+        self.fst_pop = Population([nm.load_neuron(f) for f in NRN_PATHS])
         self.ref_types = [t.type for t in self.ref_pop.neurites]
 
     def _check_neuron_feature(self, ftr, debug=False, rtol=1e-05, atol=1e-08):
@@ -130,7 +131,7 @@ class TestSectionTree(object):
 
     def test_get_segment_midpoint(self):
 
-        for ntyp in fst.NEURITE_TYPES:
+        for ntyp in nm.NEURITE_TYPES:
             pts = fst.get('segment_midpoints', self.fst_pop, neurite_type=ntyp)
             ref_xyz = (get('segment_x_coordinates', self.ref_pop, neurite_type=ntyp),
                        get('segment_y_coordinates', self.ref_pop, neurite_type=ntyp),

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''Test neurom.fst.get features'''
+'''Test neurom.fst_get features'''
 
 import os
 import math
@@ -34,14 +34,16 @@ import numpy as np
 from nose import tools as nt
 from neurom.core.types import NeuriteType
 from neurom.core.population import Population
-from neurom import fst
+from neurom import core, load_neurons
+from neurom.fst import get as fst_get
+from neurom.fst import NEURITEFEATURES
 
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 NRN_FILES = [os.path.join(_PWD, '../../../test_data/h5/v1', f)
              for f in ('Neuron.h5', 'Neuron_2_branch.h5', 'bio_neuron-001.h5')]
 
-NRNS = fst.load_neurons(NRN_FILES)
+NRNS = load_neurons(NRN_FILES)
 NRN = NRNS[0]
 POP = Population(NRNS)
 
@@ -58,18 +60,18 @@ def test_number_of_sections_pop():
 
     feat = 'number_of_sections'
 
-    nt.assert_items_equal(fst.get(feat, POP), [84, 42, 202])
+    nt.assert_items_equal(fst_get(feat, POP), [84, 42, 202])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [84, 42, 202])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [21, 21, 179])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [21, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [42, 21, 23])
 
 
@@ -77,18 +79,18 @@ def test_number_of_sections_nrn():
 
     feat = 'number_of_sections'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [84])
+    nt.assert_items_equal(fst_get(feat, NRN), [84])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [84])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [21])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [21])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [42])
 
 
@@ -96,25 +98,25 @@ def test_section_tortuosity_pop():
 
     feat = 'section_tortuosity'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP)),
                        (1.0,
                         4.6571118550276704,
                         440.40884450374455,
                         1.3427098917797089)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.all)),
                        (1.0,
                         4.6571118550276704,
                         440.40884450374455,
                         1.3427098917797089)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
                        (1.0702760052031615,
                         1.5732825321954913,
                         26.919574286670883,
                         1.2818844898414707)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
                        (1.042614577410971,
                         1.6742599832295344,
                         106.5960839640893,
@@ -130,18 +132,18 @@ def test_number_of_segments_pop():
 
     feat = 'number_of_segments'
 
-    nt.assert_items_equal(fst.get(feat, POP), [840, 419, 5179])
+    nt.assert_items_equal(fst_get(feat, POP), [840, 419, 5179])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [840, 419, 5179])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [210, 209, 4508])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [210, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [420, 210, 671])
 
 
@@ -149,18 +151,18 @@ def test_number_of_segments_nrn():
 
     feat = 'number_of_segments'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [840])
+    nt.assert_items_equal(fst_get(feat, NRN), [840])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [840])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [210])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [210])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [420])
 
 
@@ -168,18 +170,18 @@ def test_number_of_neurites_pop():
 
     feat = 'number_of_neurites'
 
-    nt.assert_items_equal(fst.get(feat, POP), [4, 2, 4])
+    nt.assert_items_equal(fst_get(feat, POP), [4, 2, 4])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [4, 2, 4])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [1, 1, 1])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [1, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [2, 1, 3])
 
 
@@ -187,18 +189,18 @@ def test_number_of_neurites_nrn():
 
     feat = 'number_of_neurites'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [4])
+    nt.assert_items_equal(fst_get(feat, NRN), [4])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [4])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [1])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [1])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [2])
 
 
@@ -206,18 +208,18 @@ def test_number_of_bifurcations_nrn():
 
     feat = 'number_of_bifurcations'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [40])
+    nt.assert_items_equal(fst_get(feat, NRN), [40])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [40])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [10])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [10])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [20])
 
 
@@ -225,18 +227,18 @@ def test_number_of_bifurcations_pop():
 
     feat = 'number_of_bifurcations'
 
-    nt.assert_items_equal(fst.get(feat, POP), [40, 20, 97])
+    nt.assert_items_equal(fst_get(feat, POP), [40, 20, 97])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [40, 20, 97])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [10, 10, 87])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [10, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [20, 10, 10])
 
 
@@ -244,18 +246,18 @@ def test_number_of_forking_points_nrn():
 
     feat = 'number_of_forking_points'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [40])
+    nt.assert_items_equal(fst_get(feat, NRN), [40])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [40])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [10])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [10])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [20])
 
 
@@ -263,18 +265,18 @@ def test_number_of_forking_points_pop():
 
     feat = 'number_of_forking_points'
 
-    nt.assert_items_equal(fst.get(feat, POP), [40, 20, 98])
+    nt.assert_items_equal(fst_get(feat, POP), [40, 20, 98])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [40, 20, 98])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [10, 10, 88])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [10, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [20, 10, 10])
 
 
@@ -282,18 +284,18 @@ def test_number_of_terminations_nrn():
 
     feat = 'number_of_terminations'
 
-    nt.assert_items_equal(fst.get(feat, NRN), [44])
+    nt.assert_items_equal(fst_get(feat, NRN), [44])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                           [44])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                           [11])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                           [11])
 
-    nt.assert_items_equal(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                           [22])
 
 
@@ -301,18 +303,18 @@ def test_number_of_terminations_pop():
 
     feat = 'number_of_terminations'
 
-    nt.assert_items_equal(fst.get(feat, POP), [44, 22, 103])
+    nt.assert_items_equal(fst_get(feat, POP), [44, 22, 103])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.all),
                           [44, 22, 103])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                           [11, 11, 90])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                           [11, 0, 0])
 
-    nt.assert_items_equal(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.assert_items_equal(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                           [22, 11, 13])
 
 
@@ -320,19 +322,19 @@ def test_total_length_pop():
 
     feat = 'total_length'
 
-    nt.ok_(np.allclose(fst.get(feat, POP),
+    nt.ok_(np.allclose(fst_get(feat, POP),
                        [840.68522362, 418.83424432, 13250.82577394]))
 
-    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.all),
+    nt.ok_(np.allclose(fst_get(feat, POP, neurite_type=NeuriteType.all),
                        [840.68522362, 418.83424432, 13250.82577394]))
 
-    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.axon),
+    nt.ok_(np.allclose(fst_get(feat, POP, neurite_type=NeuriteType.axon),
                        [207.8797736, 207.81088342, 11767.15611522]))
 
-    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
+    nt.ok_(np.allclose(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite),
                        [214.37302709, 0, 0]))
 
-    nt.ok_(np.allclose(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
+    nt.ok_(np.allclose(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite),
                        [418.43242293, 211.0233609, 1483.66965872]))
 
 
@@ -340,19 +342,19 @@ def test_total_length_nrn():
 
     feat = 'total_length'
 
-    nt.ok_(np.allclose(fst.get(feat, NRN),
+    nt.ok_(np.allclose(fst_get(feat, NRN),
                        [840.68522362]))
 
-    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.all),
+    nt.ok_(np.allclose(fst_get(feat, NRN, neurite_type=NeuriteType.all),
                        [840.68522362]))
 
-    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.axon),
+    nt.ok_(np.allclose(fst_get(feat, NRN, neurite_type=NeuriteType.axon),
                        [207.8797736]))
 
-    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
+    nt.ok_(np.allclose(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite),
                        [214.37302709]))
 
-    nt.ok_(np.allclose(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
+    nt.ok_(np.allclose(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite),
                        [418.43242293]))
 
 
@@ -360,25 +362,25 @@ def test_segment_radii_pop():
 
     feat = 'segment_radii'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP)),
                        (0.079999998211860657,
                         1.2150000333786011,
                         1301.9191725363567,
                         0.20222416473071708)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.all)),
                        (0.079999998211860657,
                         1.2150000333786011,
                         1301.9191725363567,
                         0.20222416473071708)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
                        (0.13142434507608414,
                         1.0343990325927734,
                         123.41135908663273,
                         0.58767313850777492)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
                        (0.079999998211860657,
                         1.2150000333786011,
                         547.43900821779164,
@@ -389,25 +391,25 @@ def test_segment_radii_nrn():
 
     feat = 'segment_radii'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN)),
                        (0.12087134271860123,
                         1.0343990325927734,
                         507.01994501426816,
                         0.60359517263603357)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.all)),
                        (0.12087134271860123,
                         1.0343990325927734,
                         507.01994501426816,
                         0.60359517263603357)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
                        (0.13142434507608414,
                         1.0343990325927734,
                         123.41135908663273,
                         0.58767313850777492)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
                        (0.14712842553853989,
                         1.0215770602226257,
                         256.71241207793355,
@@ -418,17 +420,17 @@ def test_segment_meander_angles_pop():
 
     feat = 'segment_meander_angles'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP)),
                        (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395)
                        ))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.all)),
                        (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
                        (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
                        (0.0, 3.1415926535897931, 2926.2411975307768, 2.4084289691611334)))
 
 
@@ -436,16 +438,16 @@ def test_segment_meander_angles_nrn():
 
     feat = 'segment_meander_angles'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN)),
                        (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.all)),
                        (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
                        (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
                        (0.47318725279312024, 3.129961675751181, 926.33847274926438, 2.4506308802890593)))
 
 
@@ -453,21 +455,21 @@ def test_neurite_volumes_nrn():
 
     feat = 'neurite_volumes'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN)),
                        (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.all)),
                        (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.axon)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.axon)),
                        (276.73860261723024, 276.73860261723024, 276.73860261723024, 276.73860261723024)))
 
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
                        (274.98039928781355, 281.24754646913954, 556.22794575695309, 278.11397287847655)))
 
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
                        (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864)))
 
 
@@ -476,20 +478,20 @@ def test_neurite_volumes_pop():
     feat = 'neurite_volumes'
 
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP)),
                        (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.all)),
                        (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.axon)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.axon)),
                        (276.58135508666612, 277.5357232437392, 830.85568094763551, 276.95189364921185)))
 
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
                        (28.356406629821159, 281.24754646913954, 1146.6644894516851, 191.1107482419475)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
                        (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864)))
 
 
@@ -497,19 +499,19 @@ def test_neurite_density_nrn():
 
     feat = 'neurite_volume_density'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN)),
                        (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.all)),
                        (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.axon)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.axon)),
                        (0.26289304906104355, 0.26289304906104355, 0.26289304906104355, 0.26289304906104355)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
                        (0.24068543213643726, 0.52464681266899216, 0.76533224480542938, 0.38266612240271469)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
                        (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519)))
 
 
@@ -517,19 +519,19 @@ def test_neurite_density_pop():
 
     feat = 'neurite_volume_density'
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP)),
                        (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.all)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.all)),
                        (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.axon)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.axon)),
                        (6.1847539631150784e-06, 0.26465213325053372, 0.5275513670655404, 0.17585045568851346)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
                        (0.00034968816544949771, 0.52464681266899216, 1.0116620531455183, 0.16861034219091972)))
 
-    nt.ok_(np.allclose(_stats(fst.get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
+    nt.ok_(np.allclose(_stats(fst_get(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
                        (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519)))
 
 
@@ -540,28 +542,28 @@ def test_segment_meander_angles_single_section():
 
     feat = 'segment_meander_angles'
 
-    sec = fst.Section(np.array([[0, 0, 0],
-                                [1, 0, 0],
-                                [1, 1, 0],
-                                [2, 1, 0],
-                                [2, 2, 0]]))
+    sec = core.Section(np.array([[0, 0, 0],
+                                 [1, 0, 0],
+                                 [1, 1, 0],
+                                 [2, 1, 0],
+                                 [2, 2, 0]]))
 
-    nrt = fst.Neurite(sec)
+    nrt = core.Neurite(sec)
     nrn = Mock()
     nrn.neurites = [nrt]
     nrn.soma = None
-    pop = fst.Population([nrn])
+    pop = core.Population([nrn])
 
     ref = [math.pi / 2, math.pi / 2, math.pi / 2]
 
-    nt.assert_equal(ref, fst.get(feat, nrt).tolist())
-    nt.assert_equal(ref, fst.get(feat, nrn).tolist())
-    nt.assert_equal(ref, fst.get(feat, pop).tolist())
+    nt.assert_equal(ref, fst_get(feat, nrt).tolist())
+    nt.assert_equal(ref, fst_get(feat, nrn).tolist())
+    nt.assert_equal(ref, fst_get(feat, pop).tolist())
 
 
 def test_neurite_features_accept_single_tree():
 
-    features = fst.NEURITEFEATURES.keys()
+    features = NEURITEFEATURES.keys()
 
     for f in features:
-        fst.get(f, NRN.neurites[0])
+        fst_get(f, NRN.neurites[0])

--- a/neurom/fst/tests/test_neuritefunc.py
+++ b/neurom/fst/tests/test_neuritefunc.py
@@ -32,13 +32,12 @@ from nose import tools as nt
 import os
 import numpy as np
 import neurom as nm
-from neurom import fst
 from neurom.geom import convex_hull
 from neurom.fst import _neuritefunc as _nf
 from neurom.fst.sectionfunc import section_volume
 from neurom.point_neurite.io import utils as io_utils
 from neurom.core import tree as tr
-from neurom.core import Population
+from neurom.core import Section, Neurite, Population
 from neurom.point_neurite import point_tree as ptr
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
@@ -92,47 +91,47 @@ def test_principal_direction_extents():
     _close(np.array(p), np.array(p_ref))
 
 
-s0 = fst.Section(42)
-s1 = s0.add_child(fst.Section(42))
-s2 = s0.add_child(fst.Section(42))
-s3 = s0.add_child(fst.Section(42))
-s4 = s1.add_child(fst.Section(42))
-s5 = s1.add_child(fst.Section(42))
-s6 = s4.add_child(fst.Section(42))
-s7 = s4.add_child(fst.Section(42))
+s0 = Section(42)
+s1 = s0.add_child(Section(42))
+s2 = s0.add_child(Section(42))
+s3 = s0.add_child(Section(42))
+s4 = s1.add_child(Section(42))
+s5 = s1.add_child(Section(42))
+s6 = s4.add_child(Section(42))
+s7 = s4.add_child(Section(42))
 
 
 def test_n_bifurcation_points():
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s0)), 2)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s1)), 2)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s2)), 0)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s3)), 0)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s4)), 1)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s5)), 0)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s6)), 0)
-    nt.assert_equal(_nf.n_bifurcation_points(fst.Neurite(s7)), 0)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s0)), 2)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s1)), 2)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s2)), 0)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s3)), 0)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s4)), 1)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s5)), 0)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s6)), 0)
+    nt.assert_equal(_nf.n_bifurcation_points(Neurite(s7)), 0)
 
 
 def test_n_forking_points():
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s0)), 3)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s1)), 2)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s2)), 0)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s3)), 0)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s4)), 1)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s5)), 0)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s6)), 0)
-    nt.assert_equal(_nf.n_forking_points(fst.Neurite(s7)), 0)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s0)), 3)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s1)), 2)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s2)), 0)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s3)), 0)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s4)), 1)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s5)), 0)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s6)), 0)
+    nt.assert_equal(_nf.n_forking_points(Neurite(s7)), 0)
 
 
 def test_n_leaves():
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s0)), 5)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s1)), 3)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s2)), 1)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s3)), 1)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s4)), 2)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s5)), 1)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s6)), 1)
-    nt.assert_equal(_nf.n_leaves(fst.Neurite(s7)), 1)
+    nt.assert_equal(_nf.n_leaves(Neurite(s0)), 5)
+    nt.assert_equal(_nf.n_leaves(Neurite(s1)), 3)
+    nt.assert_equal(_nf.n_leaves(Neurite(s2)), 1)
+    nt.assert_equal(_nf.n_leaves(Neurite(s3)), 1)
+    nt.assert_equal(_nf.n_leaves(Neurite(s4)), 2)
+    nt.assert_equal(_nf.n_leaves(Neurite(s5)), 1)
+    nt.assert_equal(_nf.n_leaves(Neurite(s6)), 1)
+    nt.assert_equal(_nf.n_leaves(Neurite(s7)), 1)
 
 
 def test_section_radial_distances_displaced_neurite():

--- a/neurom/fst/tests/test_neuronfunc.py
+++ b/neurom/fst/tests/test_neuronfunc.py
@@ -31,7 +31,7 @@
 from nose import tools as nt
 import os
 import numpy as np
-from neurom import fst
+from neurom import fst, load_neuron
 from neurom.fst import _neuronfunc as _nf
 from neurom.point_neurite.io import utils as io_utils
 from neurom.core import make_soma
@@ -41,7 +41,7 @@ _PWD = os.path.dirname(os.path.abspath(__file__))
 H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
 DATA_PATH = os.path.join(H5_PATH, 'Neuron.h5')
 
-NRN = fst.load_neuron(DATA_PATH)
+NRN = load_neuron(DATA_PATH)
 NRN_OLD = io_utils.load_neuron(DATA_PATH)
 
 

--- a/neurom/fst/tests/test_neuronfunc.py
+++ b/neurom/fst/tests/test_neuronfunc.py
@@ -31,10 +31,10 @@
 from nose import tools as nt
 import os
 import numpy as np
-from neurom import fst, load_neuron
+from neurom import fst, load_neuron, NeuriteType
 from neurom.fst import _neuronfunc as _nf
 from neurom.point_neurite.io import utils as io_utils
-from neurom.core import make_soma
+from neurom.core import make_soma, Neurite, Section
 from neurom.core.population import Population
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
@@ -70,16 +70,16 @@ def test_trunk_origin_elevations():
     n1 = Mock()
 
     s = make_soma([[0, 0, 0, 4]])
-    t0 = fst.Section(((1, 0, 0, 2), (2, 1, 1, 2)))
-    t0.type = fst.NeuriteType.basal_dendrite
-    t1 = fst.Section(((0, 1, 0, 2), (1, 2, 1, 2)))
-    t1.type = fst.NeuriteType.basal_dendrite
-    n0.neurites = [fst.Neurite(t0), fst.Neurite(t1)]
+    t0 = Section(((1, 0, 0, 2), (2, 1, 1, 2)))
+    t0.type = NeuriteType.basal_dendrite
+    t1 = Section(((0, 1, 0, 2), (1, 2, 1, 2)))
+    t1.type = NeuriteType.basal_dendrite
+    n0.neurites = [Neurite(t0), Neurite(t1)]
     n0.soma = s
 
-    t2 = fst.Section(((0, -1, 0, 2), (-1, -2, -1, 2)))
-    t2.type = fst.NeuriteType.basal_dendrite
-    n1.neurites = [fst.Neurite(t2)]
+    t2 = Section(((0, -1, 0, 2), (-1, -2, -1, 2)))
+    t2.type = NeuriteType.basal_dendrite
+    n1.neurites = [Neurite(t2)]
     n1.soma = s
 
     pop = Population([n0, n1])
@@ -87,19 +87,19 @@ def test_trunk_origin_elevations():
                           [0.0, np.pi/2., -np.pi/2.])
 
     nt.assert_items_equal(
-        _nf.trunk_origin_elevations(pop, neurite_type=fst.NeuriteType.basal_dendrite),
+        _nf.trunk_origin_elevations(pop, neurite_type=NeuriteType.basal_dendrite),
         [0.0, np.pi/2., -np.pi/2.]
     )
 
     nt.eq_(
         len(_nf.trunk_origin_elevations(pop,
-                                        neurite_type=fst.NeuriteType.axon)),
+                                        neurite_type=NeuriteType.axon)),
         0
     )
 
     nt.eq_(
         len(_nf.trunk_origin_elevations(pop,
-                                        neurite_type=fst.NeuriteType.apical_dendrite)),
+                                        neurite_type=NeuriteType.apical_dendrite)),
         0
     )
 

--- a/neurom/fst/tests/test_sectionfunc.py
+++ b/neurom/fst/tests/test_sectionfunc.py
@@ -35,7 +35,7 @@ import numpy as np
 from neurom import load_neuron
 from neurom.fst import sectionfunc as _sf
 from neurom.fst import _neuritefunc as _nf
-from neurom.fst import Section
+from neurom.core import Section
 from neurom import morphmath as mmth
 from neurom.point_neurite.io import utils as io_utils
 

--- a/neurom/fst/tests/test_sectionfunc.py
+++ b/neurom/fst/tests/test_sectionfunc.py
@@ -32,7 +32,7 @@ from nose import tools as nt
 import os
 import math
 import numpy as np
-from neurom import fst
+from neurom import load_neuron
 from neurom.fst import sectionfunc as _sf
 from neurom.fst import _neuritefunc as _nf
 from neurom.fst import Section
@@ -43,7 +43,7 @@ _PWD = os.path.dirname(os.path.abspath(__file__))
 H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
 DATA_PATH = os.path.join(H5_PATH, 'Neuron.h5')
 
-NRN = fst.load_neuron(DATA_PATH)
+NRN = load_neuron(DATA_PATH)
 NRN_OLD = io_utils.load_neuron(DATA_PATH)
 
 

--- a/neurom/geom/tests/test_transform.py
+++ b/neurom/geom/tests/test_transform.py
@@ -28,7 +28,7 @@
 
 import math
 import neurom.geom.transform as gtr
-from neurom import fst
+from neurom import load_neuron
 from neurom.fst import _neuritefunc as _nf
 from nose import tools as nt
 from itertools import izip
@@ -227,7 +227,7 @@ def _check_fst_neurite_translate(nrts_a, nrts_b, t):
 def test_translate_fst_neuron_swc():
 
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(SWC_NRN_PATH)
+    nrn = load_neuron(SWC_NRN_PATH)
     tnrn = gtr.translate(nrn, t)
     _check_fst_nrn_translate(nrn, tnrn, t)
 
@@ -235,7 +235,7 @@ def test_translate_fst_neuron_swc():
 def test_translate_fst_neurite_swc():
 
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(SWC_NRN_PATH)
+    nrn = load_neuron(SWC_NRN_PATH)
     nrt_a = nrn.neurites[0]
     nrt_b = gtr.translate(nrt_a, t)
     _check_fst_neurite_translate(nrt_a, nrt_b, t)
@@ -243,7 +243,7 @@ def test_translate_fst_neurite_swc():
 
 def test_transform_translate_neuron_swc():
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(SWC_NRN_PATH)
+    nrn = load_neuron(SWC_NRN_PATH)
     tnrn = nrn.transform(gtr.Translation(t))
     _check_fst_nrn_translate(nrn, tnrn, t)
 
@@ -251,7 +251,7 @@ def test_transform_translate_neuron_swc():
 def test_translate_fst_neuron_h5():
 
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(H5_NRN_PATH)
+    nrn = load_neuron(H5_NRN_PATH)
     tnrn = gtr.translate(nrn, t)
 
     _check_fst_nrn_translate(nrn, tnrn, t)
@@ -260,7 +260,7 @@ def test_translate_fst_neuron_h5():
 def test_translate_fst_neurite_h5():
 
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(H5_NRN_PATH)
+    nrn = load_neuron(H5_NRN_PATH)
     nrt_a = nrn.neurites[0]
     nrt_b = gtr.translate(nrt_a, t)
     _check_fst_neurite_translate(nrt_a, nrt_b, t)
@@ -268,7 +268,7 @@ def test_translate_fst_neurite_h5():
 
 def test_transform_translate_neuron_h5():
     t = np.array([100.,100.,100.])
-    nrn = fst.load_neuron(H5_NRN_PATH)
+    nrn = load_neuron(H5_NRN_PATH)
     tnrn = nrn.transform(gtr.Translation(t))
     _check_fst_nrn_translate(nrn, tnrn, t)
 
@@ -294,14 +294,14 @@ def _check_fst_neurite_rotate(nrt_a, nrt_b, rot_mat):
 
 
 def test_rotate_neuron_swc():
-    nrn_a = fst.load_neuron(SWC_NRN_PATH)
+    nrn_a = load_neuron(SWC_NRN_PATH)
     nrn_b = gtr.rotate(nrn_a, [0,0,1], math.pi/2.0)
     rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
     _check_fst_nrn_rotate(nrn_a, nrn_b, rot)
 
 
 def test_rotate_neurite_swc():
-    nrn_a = fst.load_neuron(SWC_NRN_PATH)
+    nrn_a = load_neuron(SWC_NRN_PATH)
     nrt_a = nrn_a.neurites[0]
     nrt_b = gtr.rotate(nrt_a, [0,0,1], math.pi/2.0)
     rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
@@ -310,20 +310,20 @@ def test_rotate_neurite_swc():
 
 def test_transform_rotate_neuron_swc():
     rot = gtr.Rotation(ROT_90)
-    nrn_a = fst.load_neuron(SWC_NRN_PATH)
+    nrn_a = load_neuron(SWC_NRN_PATH)
     nrn_b = nrn_a.transform(rot)
     _check_fst_nrn_rotate(nrn_a, nrn_b, ROT_90)
 
 
 def test_rotate_neuron_h5():
-    nrn_a = fst.load_neuron(H5_NRN_PATH)
+    nrn_a = load_neuron(H5_NRN_PATH)
     nrn_b = gtr.rotate(nrn_a, [0,0,1], math.pi/2.0)
     rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
     _check_fst_nrn_rotate(nrn_a, nrn_b, rot)
 
 
 def test_rotate_neurite_h5():
-    nrn_a = fst.load_neuron(H5_NRN_PATH)
+    nrn_a = load_neuron(H5_NRN_PATH)
     nrt_a = nrn_a.neurites[0]
     nrt_b = gtr.rotate(nrt_a, [0,0,1], math.pi/2.0)
     rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
@@ -332,7 +332,7 @@ def test_rotate_neurite_h5():
 
 def test_transform_rotate_neuron_h5():
     rot = gtr.Rotation(ROT_90)
-    nrn_a = fst.load_neuron(H5_NRN_PATH)
+    nrn_a = load_neuron(H5_NRN_PATH)
     nrn_b = nrn_a.transform(rot)
     _check_fst_nrn_rotate(nrn_a, nrn_b, ROT_90)
 

--- a/neurom/view/_compat.py
+++ b/neurom/view/_compat.py
@@ -34,6 +34,7 @@ from neurom.point_neurite import segments as seg
 from neurom.point_neurite.point_tree import PointTree
 from neurom.point_neurite.dendrogram import Dendrogram as PointDendrogram
 from neurom.point_neurite.treefunc import find_tree_type, get_bounding_box
+from neurom.core import Section, Neurite
 from neurom import fst
 from neurom.fst import sectionfunc as secfun
 from neurom import geom
@@ -41,7 +42,7 @@ from neurom import geom
 
 def is_new_style(obj):
     '''Determine whether a neuron or neurite is new or old style'''
-    if isinstance(obj, (fst.FstNeuron, fst.Neurite, fst.Section)):
+    if isinstance(obj, (fst.FstNeuron, Neurite, Section)):
         return True
     elif isinstance(obj, PointTree):
         return len(obj.value.shape) == 2
@@ -52,8 +53,8 @@ def is_new_style(obj):
 def bounding_box(neurite):
     '''Get a neurite's X,Y,Z bounding box'''
     if is_new_style(neurite):
-        if isinstance(neurite, fst.Section):
-            neurite = fst.Neurite(neurite)
+        if isinstance(neurite, Section):
+            neurite = Neurite(neurite)
         return geom.bounding_box(neurite)
     else:
         return get_bounding_box(neurite)
@@ -76,8 +77,8 @@ def map_segments(neurite, fun):
     '''map a function to the segments in a tree'''
 
     if is_new_style(neurite):
-        if isinstance(neurite, fst.Section):
-            neurite = fst.Neurite(neurite)
+        if isinstance(neurite, Section):
+            neurite = Neurite(neurite)
         return [s for ss in neurite.iter_sections()
                 for s in secfun.map_segments(fun, ss)]
     else:

--- a/neurom/view/_dendrogram.py
+++ b/neurom/view/_dendrogram.py
@@ -28,9 +28,8 @@
 
 '''Dendrogram helper functions and class'''
 
-from neurom.core import Tree
+from neurom.core import Tree, Neurite
 from neurom.core.dataformat import COLS
-from neurom.fst import Neurite
 
 from copy import deepcopy
 import numpy as np

--- a/neurom/view/tests/test_compat.py
+++ b/neurom/view/tests/test_compat.py
@@ -31,18 +31,18 @@ import numpy as np
 from nose import tools as nt
 from neurom.view import _compat
 from neurom.view._dendrogram import Dendrogram
-from neurom.point_neurite.io.utils import load_neuron
+from neurom.point_neurite.io.utils import load_neuron as load_pt_neuron
 from neurom.point_neurite.dendrogram import Dendrogram as PointDendrogram
 from neurom.core.types import NeuriteType
-from neurom import fst
+from neurom import load_neuron
 from neurom.morphmath import segment_radius as segrad
 
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/Neuron.h5')
 
-NRN0 = load_neuron(DATA_PATH)
-NRN1 = fst.load_neuron(DATA_PATH)
+NRN0 = load_pt_neuron(DATA_PATH)
+NRN1 = load_neuron(DATA_PATH)
 
 
 def _close(a, b, debug=False):

--- a/neurom/view/tests/test_dendrogram.py
+++ b/neurom/view/tests/test_dendrogram.py
@@ -3,7 +3,7 @@ import numpy as np
 from nose import tools as nt
 from neurom.core.types import NeuriteType
 import neurom.view._dendrogram as dm
-from neurom.fst import load_neuron, iter_sections, get
+from neurom import load_neuron, get
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/Neuron.h5')

--- a/neurom/viewer.py
+++ b/neurom/viewer.py
@@ -47,8 +47,7 @@ from .view.view import tree3d as draw_tree3d
 from .view.view import soma as draw_soma
 from .view.view import soma3d as draw_soma3d
 from .view.view import dendrogram as draw_dendrogram
-from .core import Soma, Neuron
-from .fst import Neurite, Tree
+from .core import Tree, Neurite, Soma, Neuron
 
 
 MODES = ('2d', '3d', 'dendrogram')


### PR DESCRIPTION
Functions and objects that ara available from the piblic API, directly in
the neurom module, have been removed:

* load_neuron
* load_neurons
* NEURITE_TYPES

Deprecated function fst.load_population has been removed.