### PR TITLE
Add BlockNeuronBuilder to ease creating DataWrapper blocks

### DIFF
--- a/neurom/io/tests/test_datawrapper.py
+++ b/neurom/io/tests/test_datawrapper.py
@@ -1,0 +1,59 @@
+'''Test neurom.io.utils'''
+import os
+import numpy as np
+from nose import tools as nt
+
+from neurom.io import datawrapper as dw
+from neurom.core.dataformat import POINT_TYPE, ROOT_ID
+
+
+def test__merge_sections():
+    default_sec = dw.Section()
+
+    sec_a = dw.Section([], ntype=0, pid=-1)
+    sec_b = dw.Section([], ntype=0, pid=-1)
+    dw._merge_sections(sec_a, sec_b)
+    nt.eq_(sec_a, default_sec)
+
+    sec_a = dw.Section(range(10), ntype=1, pid=1)
+    sec_b = dw.Section(range(9, 20), ntype=10, pid=10)
+    dw._merge_sections(sec_a, sec_b)
+    nt.eq_(sec_a, default_sec)
+    nt.eq_(sec_b.ids, range(20)) # Note: 9 is in this list from sec_a, not from sec_b
+    nt.eq_(sec_b.ntype, 1)
+    nt.eq_(sec_b.pid, 1)
+
+
+#def test__section_end_points():
+#    _section_end_points
+#
+#def test__extract_sections():
+#    pass
+
+#DataWrapper
+#neurite_root_section_ids
+#soma_points
+
+def test_BlockNeuronBuilder():
+    builder = dw.BlockNeuronBuilder()
+    soma_points = np.array([[0, 0, 0, 1]])
+    builder.add_section(0, ROOT_ID, POINT_TYPE.SOMA, soma_points)
+    wrapped = builder.get_datawrapper()
+    nt.eq_(len(wrapped.data_block), 1)
+
+    builder.add_section(1, 0, POINT_TYPE.AXON, np.array([[1, 0, 0, 1]]))
+    wrapped = builder.get_datawrapper()
+    nt.eq_(len(wrapped.data_block), 2)
+
+    #add child before parent, also, don't have contiguous section numbers
+    # meaning that the ids will be renumbered
+    builder.add_section(10, 2, POINT_TYPE.APICAL_DENDRITE, np.array([[10, 0, 0, 1]]))
+    builder.add_section(2, 0, POINT_TYPE.APICAL_DENDRITE, np.array([[2, 0, 0, 1]]))
+    wrapped = builder.get_datawrapper()
+    nt.eq_(len(wrapped.data_block), 4)
+    np.testing.assert_allclose(
+        wrapped.data_block,
+        np.array([[ 0., 0., 0., 1., 1., 0., -1.],
+                  [ 1., 0., 0., 1., 2., 1.,  0.],
+                  [ 2., 0., 0., 1., 4., 2.,  0.],
+                  [10., 0., 0., 1., 4., 3.,  2.]]))

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -115,7 +115,6 @@ def _check_neurites_have_no_parent(nrn):
         nt.assert_true(n.root_node.parent is None)
 
 
-
 def test_load_neurons():
     nrns = utils.load_neurons(FILES, neuron_loader=_mock_load_neuron)
     for i, nrn in enumerate(nrns):
@@ -327,7 +326,7 @@ def test_load_neuron_mixed_tree_h5():
 
 
 def test_load_h5_trunk_points_regression():
-    # regression test for issue encoutnered wile
+    # regression test for issue encountered while
     # implementing PR #479, related to H5 unpacking
     # of files with non-standard soma structure.
     # See #480.

--- a/neurom/point_neurite/io/tests/test_h5_reader.py
+++ b/neurom/point_neurite/io/tests/test_h5_reader.py
@@ -245,7 +245,6 @@ class DataWrapper_Neuron_with_duplicates(object):
                         DataWrapper_Neuron_with_duplicates.fork_pts)
 
     def test_get_endpoints(self):
-        print('test_here', self.data.get_end_points())
         nt.assert_equal(self.data.get_end_points(),
                         DataWrapper_Neuron_with_duplicates.end_pts)
 


### PR DESCRIPTION
* When loading morphologies, there are cases where all
  the segments are in one packed 'block' of points & radii.
  If one knows the parents for each of the sections w/ blocks
  of segments, this helper makes it easier to build the
  DataWrapper block
* Similar to the functionality in h5vX loader
* h5v1 and h5v2 ported over