### PR TITLE
fix morph_stats.eval_stats by checking the returning type

### DIFF
--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -52,7 +52,11 @@ def eval_stats(values, mode):
         mode = 'sum'
 
     try:
-        return getattr(np, mode)(values)
+        tval = getattr(np, mode)(values)
+        if type(tval) is map:  # map cannot be dumped in json
+            return list(tval)
+        else:  # For "mean_soma_radius"
+            return tval
     except ValueError:
         pass
 


### PR DESCRIPTION
When I run morph_stats, it complained that 'map' cannot be dumped in json. It also would not work to change everything to list in eval_stats since the "mean_soma_radius" is only a float. So I made a small type check to only convert maps to list. It works now for me with python3.5