### PR TITLE
tests failing due to imprecision, make them less exact

### DIFF
--- a/neurom/fst/tests/test_feature_compat.py
+++ b/neurom/fst/tests/test_feature_compat.py
@@ -132,13 +132,6 @@ class SectionTreeBase(object):
         pl = [_sec.section_path_length(s) for s in i_chain2(self.sec_nrn_trees)]
         _close(pl, get('section_path_distances', self.ref_nrn))
 
-    @nt.nottest
-    def test_get_segment_lengths(self):
-        _equal(_nrt.segment_lengths(self.sec_nrn), get('segment_lengths', self.ref_nrn))
-        for t in NeuriteType:
-            _equal(_nrt.segment_lengths(self.sec_nrn, neurite_type=t),
-                   get('segment_lengths', self.ref_nrn, neurite_type=t))
-
     def test_get_soma_radius(self):
         nt.assert_equal(self.sec_nrn.soma.radius, get('soma_radii', self.ref_nrn)[0])
 
@@ -186,9 +179,9 @@ class SectionTreeBase(object):
                    get('trunk_origin_radii', self.ref_nrn, neurite_type=t))
 
     def test_get_trunk_section_lengths(self):
-        _equal(_nrn.trunk_section_lengths(self.sec_nrn), get('trunk_section_lengths', self.ref_nrn))
+        _close(_nrn.trunk_section_lengths(self.sec_nrn), get('trunk_section_lengths', self.ref_nrn))
         for t in NeuriteType:
-            _equal(_nrn.trunk_section_lengths(self.sec_nrn, neurite_type=t),
+            _close(_nrn.trunk_section_lengths(self.sec_nrn, neurite_type=t),
                    get('trunk_section_lengths', self.ref_nrn, neurite_type=t))
 
 

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -64,7 +64,7 @@ def assert_items_equal(a, b):
     nt.eq_(sorted(a), sorted(b))
 
 
-def assert_features_for_neurite(feat, neurons, expected):
+def assert_features_for_neurite(feat, neurons, expected, exact=True):
     for neurite_type, expected_values in expected.items():
         print('neurite_type: %s' % neurite_type)
 
@@ -75,7 +75,10 @@ def assert_features_for_neurite(feat, neurons, expected):
             res_pop = fst_get(feat, neurons, neurite_type=neurite_type)
             res = fst_get(feat, neurons[0], neurite_type=neurite_type)
 
-        assert_items_equal(res_pop, expected_values)
+        if exact:
+            assert_items_equal(res_pop, expected_values)
+        else:
+            assert_allclose(res_pop, expected_values)
 
         #test for single neuron
         if isinstance(res, np.ndarray):
@@ -83,7 +86,10 @@ def assert_features_for_neurite(feat, neurons, expected):
             # called on a single neuron
             nt.eq_(len(res), 1)
             res = res[0]
-        nt.eq_(res, expected_values[0])
+        if exact:
+            nt.eq_(res, expected_values[0])
+        else:
+            assert_allclose(res, expected_values[0])
 
 
 def _stats(seq):
@@ -225,7 +231,7 @@ def test_total_length_pop():
                 NeuriteType.apical_dendrite: [214.37302709169489, 0, 0],
                 NeuriteType.basal_dendrite: [418.43242292524889, 211.02336090452931, 1483.6696587152967],
                 }
-    assert_features_for_neurite(feat, POP, expected)
+    assert_features_for_neurite(feat, POP, expected, exact=False)
 
 def test_segment_radii_pop():
 


### PR DESCRIPTION
* On some systems, the results aren't exactly the same, have those tests use 'close', when appropriate.