### PR TITLE
Cleanup view code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ run_pylint: $(VENV_INSTALLED)
 	$(VENV_BIN)/pylint --rcfile=pylintrc --extension-pkg-whitelist=numpy $(LINT_PYFILES) > pylint.txt
 
 run_tests: $(VENV_INSTALLED)
-	$(VENV_BIN)/nosetests -v --with-coverage --cover-min-percentage=$(MIN_COV) --cover-package neurom
+	$(VENV_BIN)/nosetests -v --with-coverage --cover-min-percentage=$(MIN_COV) --cover-erase --cover-package neurom
 
 run_tests_xunit: $(VENV_INSTALLED)
 	@mkdir -p $(ROOT_DIR)/test-reports
-	$(VENV_BIN)/nosetests neurom --with-coverage --cover-min-percentage=$(MIN_COV) --cover-inclusive --cover-package=neurom  --with-xunit --xunit-file=test-reports/nosetests_neurom.xml
+	$(VENV_BIN)/nosetests neurom --with-coverage --cover-min-percentage=$(MIN_COV) --cover-inclusive --cover-erase --cover-package=neurom  --with-xunit --xunit-file=test-reports/nosetests_neurom.xml
 
 lint: run_pep8 run_pylint
 

--- a/examples/plot_features.py
+++ b/examples/plot_features.py
@@ -176,7 +176,7 @@ def main(data_dir, mtype_file): # pylint: disable=too-many-locals
             # print 'DATA:', data
             # print 'BIN HEIGHT', histo[0]
             plot = Plot(*view_utils.get_figure(new_fig=True, subplot=111))
-            view_utils.plot_limits(plot.fig, plot.ax, xlim=limits, no_ylim=True)
+            view_utils.plot_limits(plot.ax, xlim=limits, no_ylim=True)
             plot.ax.bar(histo[1][:-1], histo[0], width=bin_widths(histo[1]))
             dp, bc = dist_points(histo[1], dist)
             # print 'BIN CENTERS:', bc, len(bc)

--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -27,11 +27,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from nose import tools as nt
-from matplotlib import pyplot as plt
 
+from neurom.view import common
 from neurom import load_neuron
 from neurom import viewer
+
+from nose import tools as nt
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_PWD, '../../test_data/swc')
@@ -42,36 +43,36 @@ nrn = load_neuron(MORPH_FILENAME)
 
 def test_draw_neuron():
     viewer.draw(nrn)
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_neuron3d():
     viewer.draw(nrn, mode='3d')
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_tree():
     viewer.draw(nrn.neurites[0])
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_tree3d():
     viewer.draw(nrn.neurites[0], mode='3d')
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_soma():
     viewer.draw(nrn.soma)
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_soma3d():
     viewer.draw(nrn.soma, mode='3d')
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_draw_dendrogram():
-    plt.close('all')
+    common.plt.close('all')
 
 
 @nt.raises(viewer.InvalidDrawModeError)

--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -336,7 +336,7 @@ def save_plot(fig, **kwargs):
 
     output = os.path.join(output_path, prefile + output_name + postfile + "." + output_format)
 
-    plt.savefig(output, dpi=dpi, transparent=transparent)
+    fig.savefig(output, dpi=dpi, transparent=transparent)
 
 
 def plot_style(fig, ax, **kwargs):
@@ -371,7 +371,7 @@ def plot_style(fig, ax, **kwargs):
         fig.set_tight_layout(True)
 
     if output_path is not None:
-        fig = save_plot(fig=ax, **kwargs)
+        save_plot(fig=fig, **kwargs)
 
     show_plot = kwargs.get('show_plot', True)
     final = kwargs.get('final', False)
@@ -381,11 +381,8 @@ def plot_style(fig, ax, **kwargs):
         plt.show()  # pragma no cover
 
 
-def plot_title(fig, ax, **kwargs):
-
-    """
-    Function that defines the title options
-    of a matplotlib plot.
+def plot_title(_, ax, **kwargs):
+    """Function that defines the title options of a matplotlib plot.
 
     Parameters:
         fig: matplotlib figure
@@ -423,11 +420,8 @@ def plot_title(fig, ax, **kwargs):
                  fontsize=title_fontsize, **title_arg)
 
 
-def plot_labels(fig, ax, **kwargs):
-
-    """
-    Function that defines the labels options
-    of a matplotlib plot.
+def plot_labels(_, ax, **kwargs):
+    """ Function that defines the labels options of a matplotlib plot.
 
     Parameters:
         fig: matplotlib figure
@@ -486,7 +480,7 @@ def plot_labels(fig, ax, **kwargs):
         ax.set_zlabel(zlabel, fontsize=label_fontsize, **zlabel_arg)
 
 
-def plot_ticks(fig, ax, **kwargs):
+def plot_ticks(_, ax, **kwargs):
 
     """
     Function that defines the labels options
@@ -551,7 +545,7 @@ def plot_ticks(fig, ax, **kwargs):
         ax.zaxis.set_tick_params(labelsize=tick_fontsize, **zticks_arg)
 
 
-def plot_limits(fig, ax, **kwargs):
+def plot_limits(_, ax, **kwargs):
     """Sets the limit options of a matplotlib plot.
 
     Parameters:
@@ -578,7 +572,7 @@ def plot_limits(fig, ax, **kwargs):
         ax.set_zlim(zlim)
 
 
-def plot_legend(fig, ax, **kwargs):
+def plot_legend(_, ax, **kwargs):
 
     """
     Function that defines the legend options
@@ -607,7 +601,7 @@ def plot_legend(fig, ax, **kwargs):
         ax.legend(**legend_arg)
 
 
-def plot_sphere(fig, ax, center, radius, color='black', alpha=1.):
+def plot_sphere(_, ax, center, radius, color='black', alpha=1.):
     """Plots a 3d sphere, given the center and the radius."""
 
     u = np.linspace(0, 2 * np.pi, 300)

--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -32,12 +32,12 @@ to be used by view-plot modules.
 """
 from neurom import NeuriteType
 import os
-import matplotlib
 
-#  Awful hack to use non-GUI backend when no display
+#  TODO: Awful hack to use non-GUI backend when no display
 #  is available. For unixy systems.
-if 'DISPLAY' not in os.environ: # noqa
-    matplotlib.use('Agg')
+import matplotlib
+if 'DISPLAY' not in os.environ:  # noqa
+    matplotlib.use('Agg')  # noqa
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -264,7 +264,7 @@ def get_figure(new_fig=True, new_axes=True, subplot=False, params=None, no_axes=
             Default value is False.
 
     Returns:
-        Figure is no_axes is True, otherwise axes.
+        Figure if no_axes is True, otherwise axes.
     """
     if new_fig:
         fig = plt.figure()
@@ -321,9 +321,6 @@ def save_plot(fig, **kwargs):
         transparent (Optional(bool):\
             If True the saved figure will have a transparent background.\
             Default value is False.
-
-    Returns:
-       input matplotlib figure
     """
 
     prefile = kwargs.get('prefile', '')
@@ -335,13 +332,11 @@ def save_plot(fig, **kwargs):
     transparent = kwargs.get('transparent', False)
 
     if not os.path.exists(output_path):
-        os.makedirs(output_path) # Make output directory if non-exsiting
+        os.makedirs(output_path)  # Make output directory if non-exsiting
 
     output = os.path.join(output_path, prefile + output_name + postfile + "." + output_format)
 
     plt.savefig(output, dpi=dpi, transparent=transparent)
-
-    return fig
 
 
 def plot_style(fig, ax, **kwargs):
@@ -353,55 +348,37 @@ def plot_style(fig, ax, **kwargs):
         fig: matplotlib figure
         ax: matplotlib axes
     """
-    # Definition of title/file naming variables
-    prefile = kwargs.get('prefile', '')
-    postfile = kwargs.get('postfile', '')
-    pretitle = kwargs.get('pretitle', '')
-    posttitle = kwargs.get('posttitle', '')
-
-    # Definition of global options
-    no_axes = kwargs.get('no_axes', False)
-    show_plot = kwargs.get('show_plot', True)
-    tight = kwargs.get('tight', False)
-    aspect_ratio = kwargs.get('aspect_ratio', 'equal')
-
-    final = kwargs.get('final', False)
-
     # Definition of save options
     output_path = kwargs.get('output_path', None)
 
-    pretitle, posttitle, prefile, postfile = figure_naming(pretitle, posttitle, prefile, postfile)
+    plot_title(fig, ax, **kwargs)
+    plot_labels(fig, ax, **kwargs)
+    plot_ticks(fig, ax, **kwargs)
+    plot_limits(fig, ax, **kwargs)
+    plot_legend(fig, ax, **kwargs)
 
-    fig, ax = plot_title(fig, ax, **kwargs)
-
-    fig, ax = plot_labels(fig, ax, **kwargs)
-
-    fig, ax = plot_ticks(fig, ax, **kwargs)
-
-    fig, ax = plot_limits(fig, ax, **kwargs)
-
-    fig, ax = plot_legend(fig, ax, **kwargs)
-
+    no_axes = kwargs.get('no_axes', False)
     if no_axes:
         ax.set_frame_on(False)
         ax.xaxis.set_visible(False)
         ax.yaxis.set_visible(False)
 
+    aspect_ratio = kwargs.get('aspect_ratio', 'equal')
     ax.set_aspect(aspect_ratio)
 
+    tight = kwargs.get('tight', False)
     if tight:
         fig.set_tight_layout(True)
 
     if output_path is not None:
         fig = save_plot(fig=ax, **kwargs)
 
+    show_plot = kwargs.get('show_plot', True)
+    final = kwargs.get('final', False)
     if not show_plot:
         plt.close()
-        return (None, None)
-    else:
-        if final:
-            plt.show()  # pragma no cover
-        return fig, ax
+    elif final:
+        plt.show()  # pragma no cover
 
 
 def plot_title(fig, ax, **kwargs):
@@ -430,9 +407,6 @@ def plot_title(fig, ax, **kwargs):
             Defines the arguments that will be passsed \
             into matplotlib as title arguments. \
             Default value is None.
-
-    Returns:
-        Matplotlib figure, axes
     """
 
     # Definition of title options
@@ -447,8 +421,6 @@ def plot_title(fig, ax, **kwargs):
 
     ax.set_title(pretitle + title + posttitle,
                  fontsize=title_fontsize, **title_arg)
-
-    return fig, ax
 
 
 def plot_labels(fig, ax, **kwargs):
@@ -487,9 +459,6 @@ def plot_labels(fig, ax, **kwargs):
             Defines the arguments that will be passsed, \
             into matplotlib as zlabel arguments. \
             Default value is None.
-
-    Returns:
-        Matplotlib figure, axes
     """
 
     # Definition of label options
@@ -515,8 +484,6 @@ def plot_labels(fig, ax, **kwargs):
 
     if hasattr(ax, 'zaxis'):
         ax.set_zlabel(zlabel, fontsize=label_fontsize, **zlabel_arg)
-
-    return fig, ax
 
 
 def plot_ticks(fig, ax, **kwargs):
@@ -558,28 +525,18 @@ def plot_ticks(fig, ax, **kwargs):
             Defines the arguments that will be passsed \
             into matplotlib as zticks arguments. \
             Default value is None.
-
-    Returns:
-        Matplotlib figure, axes
     """
 
     # Definition of tick options
     xticks = kwargs.get('xticks', None)
     yticks = kwargs.get('yticks', None)
     zticks = kwargs.get('zticks', None)
+
     tick_fontsize = kwargs.get('tickfontsize', 12)
-    xticks_arg = kwargs.get('xticksarg', None)
-    yticks_arg = kwargs.get('yticksarg', None)
-    zticks_arg = kwargs.get('zticksarg', None)
 
-    if xticks_arg is None:
-        xticks_arg = {}
-
-    if yticks_arg is None:
-        yticks_arg = {}
-
-    if zticks_arg is None:
-        zticks_arg = {}
+    xticks_arg = kwargs.get('xticksarg', {})
+    yticks_arg = kwargs.get('yticksarg', {})
+    zticks_arg = kwargs.get('zticksarg', {})
 
     if xticks is not None:
         ax.set_xticks(xticks)
@@ -593,14 +550,9 @@ def plot_ticks(fig, ax, **kwargs):
         ax.set_zticks(zticks)
         ax.zaxis.set_tick_params(labelsize=tick_fontsize, **zticks_arg)
 
-    return fig, ax
-
 
 def plot_limits(fig, ax, **kwargs):
-
-    """
-    Function that defines the limit options
-    of a matplotlib plot.
+    """Sets the limit options of a matplotlib plot.
 
     Parameters:
         fig: matplotlib figure
@@ -614,9 +566,6 @@ def plot_limits(fig, ax, **kwargs):
         zlim (Optional[list of two floats]): \
             Defines the min and the max values in z-axis. \
             To use default limits select None.
-
-    Returns:
-        Matplotlib figure, axes
     """
     # Definition of limit options
     xlim = kwargs.get('xlim', None)
@@ -625,11 +574,8 @@ def plot_limits(fig, ax, **kwargs):
 
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
-
     if hasattr(ax, 'zaxis'):
         ax.set_zlim(zlim)
-
-    return fig, ax
 
 
 def plot_legend(fig, ax, **kwargs):
@@ -649,9 +595,6 @@ def plot_legend(fig, ax, **kwargs):
             Defines the arguments that will be passsed \
             into matplotlib as legend arguments. \
             Default value is None.
-
-    Returns:
-        Matplotlib figure, axes
     """
     # Definition of legend options
     no_legend = kwargs.get('no_legend', True)
@@ -663,13 +606,9 @@ def plot_legend(fig, ax, **kwargs):
     if not no_legend:
         ax.legend(**legend_arg)
 
-    return fig, ax
-
 
 def plot_sphere(fig, ax, center, radius, color='black', alpha=1.):
-    """
-    Plots a 3d sphere, given the center and the radius.
-    """
+    """Plots a 3d sphere, given the center and the radius."""
 
     u = np.linspace(0, 2 * np.pi, 300)
     v = np.linspace(0, np.pi, 300)
@@ -680,6 +619,4 @@ def plot_sphere(fig, ax, center, radius, color='black', alpha=1.):
 
     ax.plot_surface(x, y, z, linewidth=0.0, color=color, alpha=alpha)
 
-    return fig, ax
-
-plot_style.__doc__ += PLOT_STYLE_PARAMS # pylint: disable=no-member
+plot_style.__doc__ += PLOT_STYLE_PARAMS  # pylint: disable=no-member

--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -351,11 +351,11 @@ def plot_style(fig, ax, **kwargs):
     # Definition of save options
     output_path = kwargs.get('output_path', None)
 
-    plot_title(fig, ax, **kwargs)
-    plot_labels(fig, ax, **kwargs)
-    plot_ticks(fig, ax, **kwargs)
-    plot_limits(fig, ax, **kwargs)
-    plot_legend(fig, ax, **kwargs)
+    plot_title(ax, **kwargs)
+    plot_labels(ax, **kwargs)
+    plot_ticks(ax, **kwargs)
+    plot_limits(ax, **kwargs)
+    plot_legend(ax, **kwargs)
 
     no_axes = kwargs.get('no_axes', False)
     if no_axes:
@@ -381,11 +381,10 @@ def plot_style(fig, ax, **kwargs):
         plt.show()  # pragma no cover
 
 
-def plot_title(_, ax, **kwargs):
+def plot_title(ax, **kwargs):
     """Function that defines the title options of a matplotlib plot.
 
     Parameters:
-        fig: matplotlib figure
         ax: matplotlib axes
         pretitle(Optional[str]) : \
             String to include before the general title of the figure. \
@@ -420,11 +419,10 @@ def plot_title(_, ax, **kwargs):
                  fontsize=title_fontsize, **title_arg)
 
 
-def plot_labels(_, ax, **kwargs):
+def plot_labels(ax, **kwargs):
     """ Function that defines the labels options of a matplotlib plot.
 
     Parameters:
-        fig: matplotlib figure
         ax: matplotlib axes
         xlabel (Optional[str]): \
             The xlabel for the figure. \
@@ -480,14 +478,13 @@ def plot_labels(_, ax, **kwargs):
         ax.set_zlabel(zlabel, fontsize=label_fontsize, **zlabel_arg)
 
 
-def plot_ticks(_, ax, **kwargs):
+def plot_ticks(ax, **kwargs):
 
     """
     Function that defines the labels options
     of a matplotlib plot.
 
     Parameters:
-        fig: matplotlib figure
         ax: matplotlib axes
         xticks (Optional[list of ticks]): \
             Defines the values of x ticks in the figure. \
@@ -545,11 +542,10 @@ def plot_ticks(_, ax, **kwargs):
         ax.zaxis.set_tick_params(labelsize=tick_fontsize, **zticks_arg)
 
 
-def plot_limits(_, ax, **kwargs):
+def plot_limits(ax, **kwargs):
     """Sets the limit options of a matplotlib plot.
 
     Parameters:
-        fig: matplotlib figure
         ax: matplotlib axes
         xlim (Optional[list of two floats]): \
             Defines the min and the max values in x-axis. \
@@ -572,14 +568,13 @@ def plot_limits(_, ax, **kwargs):
         ax.set_zlim(zlim)
 
 
-def plot_legend(_, ax, **kwargs):
+def plot_legend(ax, **kwargs):
 
     """
     Function that defines the legend options
     of a matplotlib plot.
 
     Parameters:
-        fig: matplotlib figure
         ax: matplotlib axes
         no_legend (Optional[boolean]): \
             Defines the presence of a legend in the figure. \

--- a/neurom/view/tests/test_common.py
+++ b/neurom/view/tests/test_common.py
@@ -26,181 +26,240 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 from nose import tools as nt
-from neurom.view.common import plt
-from neurom.view.common import figure_naming
-from neurom.view.common import get_figure
-from neurom.view.common import save_plot
-from neurom.view.common import plot_style
-from neurom.view.common import plot_title
-from neurom.view.common import plot_labels
-from neurom.view.common import plot_legend
-from neurom.view.common import plot_limits
-from neurom.view.common import plot_ticks
-from neurom.view.common import plot_sphere
-from neurom.view.common import get_color
+
+from neurom.view.common import (plt, figure_naming, get_figure, save_plot, plot_style,
+                                plot_title, plot_labels, plot_legend, plot_limits, plot_ticks,
+                                plot_sphere, get_color)
+
 from neurom.core.types import NeuriteType
 
-import os
+import shutil
+import tempfile
+
+from contextlib import contextmanager
+
 import numpy as np
 
-fig_name = 'Figure.png'
-fig_dir  = './Testing_save_in_directory/'
 
 def test_figure_naming():
     pretitle, posttitle, prefile, postfile = figure_naming(pretitle='Test', posttitle=None, prefile="", postfile=3)
-    nt.ok_(pretitle == 'Test -- ')
-    nt.ok_(posttitle == "")
-    nt.ok_(prefile == "")
-    nt.ok_(postfile == "_3")
+    nt.eq_(pretitle, 'Test -- ')
+    nt.eq_(posttitle, "")
+    nt.eq_(prefile, "")
+    nt.eq_(postfile, "_3")
+
     pretitle, posttitle, prefile, postfile = figure_naming(pretitle='', posttitle="Test", prefile="test", postfile="")
-    nt.ok_(pretitle == "")
-    nt.ok_(posttitle == " -- Test")
-    nt.ok_(prefile == "test_")
-    nt.ok_(postfile == "")
+    nt.eq_(pretitle, "")
+    nt.eq_(posttitle, " -- Test")
+    nt.eq_(prefile, "test_")
+    nt.eq_(postfile, "")
+
 
 def test_get_figure():
     fig_old = plt.figure()
     fig, ax = get_figure(new_fig=False, subplot=False)
-    nt.ok_(fig == fig_old)
-    nt.ok_(ax.colNum == 0)
-    nt.ok_(ax.rowNum == 0)
+    nt.eq_(fig, fig_old)
+    nt.eq_(ax.colNum, 0)
+    nt.eq_(ax.rowNum, 0)
+
     fig1, ax1 = get_figure(new_fig=True, subplot=224)
     nt.ok_(fig1 != fig_old)
-    nt.ok_(ax1.colNum == 1)
-    nt.ok_(ax1.rowNum == 1)
+    nt.eq_(ax1.colNum, 1)
+    nt.eq_(ax1.rowNum, 1)
+
     fig = get_figure(new_fig=True, no_axes=True)
-    nt.ok_(type(fig) == plt.Figure)
-    fig2, ax2 = get_figure(new_fig=True, subplot=[1,1,1])
-    nt.ok_(ax2.colNum == 0)
-    nt.ok_(ax2.rowNum == 0)
+    nt.eq_(type(fig), plt.Figure)
+
+    fig2, ax2 = get_figure(new_fig=True, subplot=[1, 1, 1])
+    nt.eq_(ax2.colNum, 0)
+    nt.eq_(ax2.rowNum, 0)
     plt.close('all')
+
     fig = plt.figure()
     ax  = fig.add_subplot(111)
     fig2, ax2 = get_figure(new_fig=False, new_axes=False)
-    nt.ok_(fig2 == plt.gcf())
-    nt.ok_(ax2 == plt.gca())
+    nt.eq_(fig2, plt.gcf())
+    nt.eq_(ax2, plt.gca())
     plt.close('all')
+
 
 def test_save_plot():
-    if os.path.isfile(fig_name):
+    fig_name = 'Figure.png'
+
+    tempdir = tempfile.mkdtemp('test_common')
+    try:
+        old_dir = os.getcwd()
+        os.chdir(tempdir)
+
+        fig_old = plt.figure()
+        fig = save_plot(fig_old)
+        nt.ok_(os.path.isfile(fig_name))
+
         os.remove(fig_name)
-    fig_old = plt.figure()
-    fig = save_plot(fig_old)
-    nt.ok_(os.path.isfile(fig_name)==True)
-    os.remove(fig_name)
-    if os.path.isdir(fig_dir):
-        for data in os.listdir(fig_dir):
-            os.remove(fig_dir + data)
-        os.rmdir(fig_dir)
-    fig = save_plot(fig_old, output_path=fig_dir)
-    nt.ok_(os.path.isfile(fig_dir + fig_name)==True)
-    os.remove(fig_dir + fig_name)
-    os.rmdir(fig_dir)
-    plt.close('all')
 
-fig = plt.figure()
-ax  = fig.add_subplot(111)
-ax.plot([0,0], [1,2], label='test')
-xlim = ax.get_xlim()
-ylim = ax.get_ylim()
+        fig = save_plot(fig_old, output_path='subdir')
+        nt.ok_(os.path.isfile(os.path.join(tempdir, 'subdir', fig_name)))
+    finally:
+        os.chdir(old_dir)
+        shutil.rmtree(tempdir)
+        plt.close('all')
 
-fig0 = plt.figure()
-ax0  = fig0.add_subplot((111), projection='3d')
-ax0.plot([0,0], [1,2], [2,1])
-xlim0 = ax0.get_xlim()
-ylim0 = ax0.get_ylim()
-zlim0 = ax0.get_zlim()
+
+@contextmanager
+def get_fig_2d():
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.plot([0, 0], [1, 2], label='test')
+    yield fig, ax
+    plt.close(fig)
+
+
+@contextmanager
+def get_fig_3d():
+    fig0 = plt.figure()
+    ax0 = fig0.add_subplot((111), projection='3d')
+    ax0.plot([0, 0], [1, 2], [2, 1])
+    yield fig0, ax0
+    plt.close(fig0)
+
 
 def test_plot_title():
-    fig1, ax1 = plot_title(fig, ax)
-    nt.ok_(ax1.get_title() == 'Figure')
-    fig1, ax1 = plot_title(fig, ax, title='Test')
-    nt.ok_(ax1.get_title() == 'Test')
+    with get_fig_2d() as (fig, ax):
+        plot_title(fig, ax)
+        nt.eq_(ax.get_title(), 'Figure')
+
+    with get_fig_2d() as (fig, ax):
+        plot_title(fig, ax, title='Test')
+        nt.eq_(ax.get_title(), 'Test')
+
 
 def test_plot_labels():
-    fig1, ax1 = plot_labels(fig, ax)
-    nt.ok_(ax1.get_xlabel() == 'X')
-    nt.ok_(ax1.get_ylabel() == 'Y')
-    fig1, ax1 = plot_labels(fig, ax, xlabel='T', ylabel='R')
-    nt.ok_(ax1.get_xlabel() == 'T')
-    nt.ok_(ax1.get_ylabel() == 'R')
-    fig2, ax2 = plot_labels(fig0, ax0)
-    nt.ok_(ax2.get_zlabel() == 'Z')
-    fig2, ax2 = plot_labels(fig0, ax0, zlabel='T')
-    nt.ok_(ax2.get_zlabel() == 'T')
+    with get_fig_2d() as (fig, ax):
+        plot_labels(fig, ax)
+        nt.eq_(ax.get_xlabel(), 'X')
+        nt.eq_(ax.get_ylabel(), 'Y')
+
+    with get_fig_2d() as (fig, ax):
+        plot_labels(fig, ax, xlabel='T', ylabel='R')
+        nt.eq_(ax.get_xlabel(), 'T')
+        nt.eq_(ax.get_ylabel(), 'R')
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_labels(fig0, ax0)
+        nt.eq_(ax0.get_zlabel(), 'Z')
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_labels(fig0, ax0, zlabel='T')
+        nt.eq_(ax0.get_zlabel(), 'T')
+
 
 def test_plot_legend():
-    fig1, ax1 = plot_legend(fig, ax)
-    legend = ax1.get_legend()
-    nt.ok_(legend is None)
-    fig1, ax1 = plot_legend(fig, ax, no_legend=False)
-    legend = ax1.get_legend()
-    nt.ok_(legend.get_texts()[0].get_text() == 'test')
+    with get_fig_2d() as (fig, ax):
+        plot_legend(fig, ax)
+        legend = ax.get_legend()
+        nt.ok_(legend is None)
+
+    with get_fig_2d() as (fig, ax):
+        plot_legend(fig, ax, no_legend=False)
+        legend = ax.get_legend()
+        nt.eq_(legend.get_texts()[0].get_text(), 'test')
+
 
 def test_plot_limits():
-    fig1, ax1 = plot_limits(fig, ax)
-    nt.ok_(ax1.get_xlim() == xlim)
-    nt.ok_(ax1.get_ylim() == ylim)
-    fig1, ax1 = plot_limits(fig, ax, xlim=(0,100), ylim=(-100,0))
-    nt.ok_(ax1.get_xlim() == (0,100))
-    nt.ok_(ax1.get_ylim() == (-100,0))
-    fig2, ax2 = plot_limits(fig0, ax0)
-    nt.ok_(np.allclose(ax2.get_zlim(), zlim0))
-    fig2, ax2 = plot_limits(fig0, ax0, zlim=(0,100))
-    nt.ok_(np.allclose(ax2.get_zlim(), (0,100)))
+    with get_fig_2d() as (fig, ax):
+        plot_limits(fig, ax)
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
+        nt.eq_(ax.get_xlim(), xlim)
+        nt.eq_(ax.get_ylim(), ylim)
+
+    with get_fig_2d() as (fig, ax):
+        plot_limits(fig, ax, xlim=(0, 100), ylim=(-100, 0))
+        nt.eq_(ax.get_xlim(), (0, 100))
+        nt.eq_(ax.get_ylim(), (-100, 0))
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_limits(fig0, ax0)
+        zlim0 = ax0.get_zlim()
+        nt.ok_(np.allclose(ax0.get_zlim(), zlim0))
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_limits(fig0, ax0, zlim=(0, 100))
+        nt.ok_(np.allclose(ax0.get_zlim(), (0, 100)))
+
 
 def test_plot_ticks():
-    fig1, ax1 = plot_ticks(fig, ax)
-    nt.ok_(len(ax1.get_xticks()) != 0 )
-    nt.ok_(len(ax1.get_yticks()) != 0 )
-    fig1, ax1 = plot_ticks(fig, ax, xticks=[], yticks=[])
-    nt.ok_(len(ax1.get_xticks()) == 0 )
-    nt.ok_(len(ax1.get_yticks()) == 0 )
-    fig1, ax1 = plot_ticks(fig, ax, xticks=np.arange(3), yticks=np.arange(4))
-    nt.ok_(len(ax1.get_xticks()) == 3 )
-    nt.ok_(len(ax1.get_yticks()) == 4 )
-    fig2, ax2 = plot_ticks(fig0, ax0)
-    nt.ok_(len(ax2.get_zticks()) != 0 )
-    fig2, ax2 = plot_ticks(fig0, ax0, zticks=[])
-    nt.ok_(len(ax2.get_zticks()) == 0 )
-    fig2, ax2 = plot_ticks(fig0, ax0, zticks=np.arange(3))
-    nt.ok_(len(ax2.get_zticks()) == 3 )
+    with get_fig_2d() as (fig, ax):
+        plot_ticks(fig, ax)
+        nt.ok_(len(ax.get_xticks()))
+        nt.ok_(len(ax.get_yticks()))
+
+    with get_fig_2d() as (fig, ax):
+        plot_ticks(fig, ax, xticks=[], yticks=[])
+        nt.eq_(len(ax.get_xticks()), 0)
+        nt.eq_(len(ax.get_yticks()), 0)
+
+    with get_fig_2d() as (fig, ax):
+        plot_ticks(fig, ax, xticks=np.arange(3), yticks=np.arange(4))
+        nt.eq_(len(ax.get_xticks()), 3)
+        nt.eq_(len(ax.get_yticks()), 4)
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_ticks(fig0, ax0)
+        nt.ok_(len(ax0.get_zticks()))
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_ticks(fig0, ax0, zticks=[])
+        nt.eq_(len(ax0.get_zticks()), 0)
+
+    with get_fig_3d() as (fig0, ax0):
+        plot_ticks(fig0, ax0, zticks=np.arange(3))
+        nt.eq_(len(ax0.get_zticks()), 3)
+
 
 def test_plot_style():
-    fig1, ax1 = plot_style(fig, ax)
-    nt.ok_(ax1.get_title() == 'Figure')
-    nt.ok_(ax1.get_xlabel() == 'X')
-    nt.ok_(ax1.get_ylabel() == 'Y')
-    fig1, ax1 = plot_style(fig, ax, no_axes=True)
-    nt.ok_(ax1.get_frame_on() == False)
-    nt.ok_(ax1.xaxis.get_visible() == False)
-    nt.ok_(ax1.yaxis.get_visible() == False)
-    fig1, ax1 = plot_style(fig, ax, tight=True)
-    nt.ok_(fig1.get_tight_layout() == True)
-    fig1, ax1 = plot_style(fig, ax, show_plot=False)
-    nt.ok_(fig1 is None)
-    nt.ok_(ax1 is None)
-    if os.path.isdir(fig_dir):
-        for data in os.listdir(fig_dir):
-            os.remove(fig_dir + data)
-        os.rmdir(fig_dir)
-    fig1, ax1 = plot_style(fig, ax, output_path=fig_dir, output_name='Figure')
-    nt.ok_(os.path.isfile(fig_dir + fig_name)==True)
-    os.remove(fig_dir + fig_name)
-    os.rmdir(fig_dir)
+    with get_fig_2d() as (fig, ax):
+        plot_style(fig, ax)
+        nt.eq_(ax.get_title(), 'Figure')
+        nt.eq_(ax.get_xlabel(), 'X')
+        nt.eq_(ax.get_ylabel(), 'Y')
+
+    with get_fig_2d() as (fig, ax):
+        plot_style(fig, ax, no_axes=True)
+        nt.ok_(not ax.get_frame_on())
+        nt.ok_(not ax.xaxis.get_visible())
+        nt.ok_(not ax.yaxis.get_visible())
+
+    with get_fig_2d() as (fig, ax):
+        plot_style(fig, ax, tight=True)
+        nt.ok_(fig.get_tight_layout())
+
+    with get_fig_2d() as (fig, ax):
+        plot_style(fig, ax, show_plot=False)
+
+    try:
+        tempdir = tempfile.mkdtemp('test_common')
+        with get_fig_2d() as (fig, ax):
+            plot_style(fig, ax, output_path=tempdir, output_name='Figure')
+        nt.ok_(os.path.isfile(os.path.join(tempdir, 'Figure.png')))
+    finally:
+        shutil.rmtree(tempdir)
+
 
 def test_get_color():
-    nt.ok_(get_color(None, NeuriteType.basal_dendrite) == "red")
-    nt.ok_(get_color(None, NeuriteType.axon) == "blue")
-    nt.ok_(get_color(None, NeuriteType.apical_dendrite) == "purple")
-    nt.ok_(get_color(None, NeuriteType.soma) == "black")
-    nt.ok_(get_color(None, NeuriteType.undefined) == "green")
-    nt.ok_(get_color(None, 'wrong') == "green")
-    nt.ok_(get_color('blue', 'wrong') == "blue")
-    nt.ok_(get_color('yellow', NeuriteType.axon) == "yellow")
+    nt.eq_(get_color(None, NeuriteType.basal_dendrite), "red")
+    nt.eq_(get_color(None, NeuriteType.axon), "blue")
+    nt.eq_(get_color(None, NeuriteType.apical_dendrite), "purple")
+    nt.eq_(get_color(None, NeuriteType.soma), "black")
+    nt.eq_(get_color(None, NeuriteType.undefined), "green")
+    nt.eq_(get_color(None, 'wrong'), "green")
+    nt.eq_(get_color('blue', 'wrong'), "blue")
+    nt.eq_(get_color('yellow', NeuriteType.axon), "yellow")
+
 
 def test_plot_sphere():
-    fig0, ax0 = get_figure(params={'projection':'3d'})
-    fig1, ax1 = plot_sphere(fig0, ax0, [0,0,0], 10., color='black', alpha=1.)
-    nt.ok_(ax1.has_data() == True)
+    fig0, ax0 = get_figure(params={'projection': '3d'})
+    plot_sphere(fig0, ax0, [0, 0, 0], 10., color='black', alpha=1.)
+    nt.ok_(ax0.has_data())

--- a/neurom/view/tests/test_common.py
+++ b/neurom/view/tests/test_common.py
@@ -127,95 +127,95 @@ def get_fig_3d():
 
 def test_plot_title():
     with get_fig_2d() as (fig, ax):
-        plot_title(fig, ax)
+        plot_title(ax)
         nt.eq_(ax.get_title(), 'Figure')
 
     with get_fig_2d() as (fig, ax):
-        plot_title(fig, ax, title='Test')
+        plot_title(ax, title='Test')
         nt.eq_(ax.get_title(), 'Test')
 
 
 def test_plot_labels():
     with get_fig_2d() as (fig, ax):
-        plot_labels(fig, ax)
+        plot_labels(ax)
         nt.eq_(ax.get_xlabel(), 'X')
         nt.eq_(ax.get_ylabel(), 'Y')
 
     with get_fig_2d() as (fig, ax):
-        plot_labels(fig, ax, xlabel='T', ylabel='R')
+        plot_labels(ax, xlabel='T', ylabel='R')
         nt.eq_(ax.get_xlabel(), 'T')
         nt.eq_(ax.get_ylabel(), 'R')
 
     with get_fig_3d() as (fig0, ax0):
-        plot_labels(fig0, ax0)
+        plot_labels(ax0)
         nt.eq_(ax0.get_zlabel(), 'Z')
 
     with get_fig_3d() as (fig0, ax0):
-        plot_labels(fig0, ax0, zlabel='T')
+        plot_labels(ax0, zlabel='T')
         nt.eq_(ax0.get_zlabel(), 'T')
 
 
 def test_plot_legend():
     with get_fig_2d() as (fig, ax):
-        plot_legend(fig, ax)
+        plot_legend(ax)
         legend = ax.get_legend()
         nt.ok_(legend is None)
 
     with get_fig_2d() as (fig, ax):
-        plot_legend(fig, ax, no_legend=False)
+        plot_legend(ax, no_legend=False)
         legend = ax.get_legend()
         nt.eq_(legend.get_texts()[0].get_text(), 'test')
 
 
 def test_plot_limits():
     with get_fig_2d() as (fig, ax):
-        plot_limits(fig, ax)
+        plot_limits(ax)
         xlim = ax.get_xlim()
         ylim = ax.get_ylim()
         nt.eq_(ax.get_xlim(), xlim)
         nt.eq_(ax.get_ylim(), ylim)
 
     with get_fig_2d() as (fig, ax):
-        plot_limits(fig, ax, xlim=(0, 100), ylim=(-100, 0))
+        plot_limits(ax, xlim=(0, 100), ylim=(-100, 0))
         nt.eq_(ax.get_xlim(), (0, 100))
         nt.eq_(ax.get_ylim(), (-100, 0))
 
     with get_fig_3d() as (fig0, ax0):
-        plot_limits(fig0, ax0)
+        plot_limits(ax0)
         zlim0 = ax0.get_zlim()
         nt.ok_(np.allclose(ax0.get_zlim(), zlim0))
 
     with get_fig_3d() as (fig0, ax0):
-        plot_limits(fig0, ax0, zlim=(0, 100))
+        plot_limits(ax0, zlim=(0, 100))
         nt.ok_(np.allclose(ax0.get_zlim(), (0, 100)))
 
 
 def test_plot_ticks():
     with get_fig_2d() as (fig, ax):
-        plot_ticks(fig, ax)
+        plot_ticks(ax)
         nt.ok_(len(ax.get_xticks()))
         nt.ok_(len(ax.get_yticks()))
 
     with get_fig_2d() as (fig, ax):
-        plot_ticks(fig, ax, xticks=[], yticks=[])
+        plot_ticks(ax, xticks=[], yticks=[])
         nt.eq_(len(ax.get_xticks()), 0)
         nt.eq_(len(ax.get_yticks()), 0)
 
     with get_fig_2d() as (fig, ax):
-        plot_ticks(fig, ax, xticks=np.arange(3), yticks=np.arange(4))
+        plot_ticks(ax, xticks=np.arange(3), yticks=np.arange(4))
         nt.eq_(len(ax.get_xticks()), 3)
         nt.eq_(len(ax.get_yticks()), 4)
 
     with get_fig_3d() as (fig0, ax0):
-        plot_ticks(fig0, ax0)
+        plot_ticks(ax0)
         nt.ok_(len(ax0.get_zticks()))
 
     with get_fig_3d() as (fig0, ax0):
-        plot_ticks(fig0, ax0, zticks=[])
+        plot_ticks(ax0, zticks=[])
         nt.eq_(len(ax0.get_zticks()), 0)
 
     with get_fig_3d() as (fig0, ax0):
-        plot_ticks(fig0, ax0, zticks=np.arange(3))
+        plot_ticks(ax0, zticks=np.arange(3))
         nt.eq_(len(ax0.get_zticks()), 3)
 
 

--- a/neurom/view/tests/test_view.py
+++ b/neurom/view/tests/test_view.py
@@ -28,11 +28,10 @@
 import os
 import itertools as it
 import numpy as np
-import pylab as plt
 
 from nose import tools as nt
 from neurom import load_neuron
-from neurom.view import view
+from neurom.view import view, common
 from neurom.core import Section
 
 DATA_PATH = './test_data'
@@ -58,7 +57,7 @@ def test_tree():
 
     nt.assert_raises(AssertionError, view.tree, tree0, plane='wrong')
 
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_soma():
@@ -67,22 +66,23 @@ def test_soma():
 
     nt.assert_raises(AssertionError, view.tree, soma0, plane='wrong')
 
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_neuron():
     fig, ax = view.neuron(fst_neuron)
-    nt.ok_(np.allclose(ax.get_xlim(), (-70.328535157399998, 94.7472627179)) )
-    nt.ok_(np.allclose(ax.get_ylim(), (-87.600171997199993, 78.51626225230001)) )
+    np.testing.assert_allclose(ax.get_xlim(), (-70.328535157399998, 94.7472627179))
+    np.testing.assert_allclose(ax.get_ylim(), (-87.600171997199993, 78.51626225230001))
     nt.ok_(ax.get_title() == fst_neuron.name)
-    fig, ax = view.neuron(fst_neuron, xlim=(0,100), ylim=(0,100))
-    nt.ok_(np.allclose(ax.get_xlim(), (0, 100)) )
-    nt.ok_(np.allclose(ax.get_ylim(), (0, 100)) )
+
+    fig, ax = view.neuron(fst_neuron, xlim=(0, 100), ylim=(0, 100))
+    np.testing.assert_allclose(ax.get_xlim(), (0, 100))
+    np.testing.assert_allclose(ax.get_ylim(), (0, 100))
     nt.ok_(ax.get_title() == fst_neuron.name)
 
     nt.assert_raises(AssertionError, view.tree, fst_neuron, plane='wrong')
 
-    plt.close('all')
+    common.plt.close('all')
 
 
 def test_tree3d():

--- a/neurom/view/view.py
+++ b/neurom/view/view.py
@@ -28,10 +28,11 @@
 '''
 Python module of NeuroM to visualize morphologies
 '''
+from . import common
+
 import numpy as np
 from matplotlib.collections import LineCollection
 
-from . import common
 from neurom import NeuriteType, geom
 
 from neurom.core import iter_segments
@@ -155,7 +156,8 @@ def tree(tr, plane='xy', new_fig=True, subplot=False, **kwargs):
     kwargs.setdefault('ylim', [min_bounding_box[plane1] - white_space,
                                max_bounding_box[plane1] + white_space])
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def soma(sm, plane='xy', new_fig=True, subplot=False, **kwargs):
@@ -205,7 +207,8 @@ def soma(sm, plane='xy', new_fig=True, subplot=False, **kwargs):
     kwargs.setdefault('xlabel', plane[0])
     kwargs.setdefault('ylabel', plane[1])
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def neuron(nrn, plane='xy', new_fig=True, subplot=False, **kwargs):
@@ -260,7 +263,8 @@ def neuron(nrn, plane='xy', new_fig=True, subplot=False, **kwargs):
         kwargs.setdefault('ylim', [min_bounding_box[plane1] - white_space,
                                    max_bounding_box[plane1] + white_space])
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def tree3d(tr, new_fig=True, new_axes=True, subplot=False, **kwargs):
@@ -314,7 +318,8 @@ def tree3d(tr, new_fig=True, new_axes=True, subplot=False, **kwargs):
     kwargs.setdefault('zlim', [min_bounding_box[COLS.Z] - white_space,
                                max_bounding_box[COLS.Z] + white_space])
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def soma3d(sm, new_fig=True, new_axes=True, subplot=False, **kwargs):
@@ -334,12 +339,13 @@ def soma3d(sm, new_fig=True, new_axes=True, subplot=False, **kwargs):
     treecolor = common.get_color(treecolor, tree_type=NeuriteType.soma)
 
     # Plot the soma as a circle.
-    fig, ax = common.plot_sphere(fig, ax, center=sm.center[COLS.XYZ], radius=sm.radius,
-                                 color=treecolor, alpha=get_default('alpha', kwargs))
+    common.plot_sphere(fig, ax, center=sm.center[COLS.XYZ], radius=sm.radius,
+                       color=treecolor, alpha=get_default('alpha', kwargs))
 
     kwargs.setdefault('title', 'Soma view')
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def neuron3d(nrn, new_fig=True, new_axes=True, subplot=False, **kwargs):
@@ -392,7 +398,8 @@ def neuron3d(nrn, new_fig=True, new_axes=True, subplot=False, **kwargs):
         kwargs.setdefault('zlim', [min_bounding_box[COLS.Z] - white_space,
                                    max_bounding_box[COLS.Z] + white_space])
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 
 def _format_str(string):
@@ -499,7 +506,8 @@ def dendrogram(obj, show_diameters=True, new_fig=True, new_axes=True, subplot=Fa
     kwargs['no_legend'] = False
     kwargs.setdefault('aspect_ratio', 'auto')
 
-    return common.plot_style(fig=fig, ax=ax, **kwargs)
+    common.plot_style(fig=fig, ax=ax, **kwargs)
+    return fig, ax
 
 neuron.__doc__ += DEFAULT_PARAMS  # pylint: disable=no-member
 tree.__doc__ += DEFAULT_PARAMS  # pylint: disable=no-member

--- a/neurom/viewer.py
+++ b/neurom/viewer.py
@@ -40,27 +40,21 @@ Examples:
 
 '''
 
-from .view.view import neuron as draw_neuron
-from .view.view import neuron3d as draw_neuron3d
-from .view.view import tree as draw_tree
-from .view.view import tree3d as draw_tree3d
-from .view.view import soma as draw_soma
-from .view.view import soma3d as draw_soma3d
-from .view.view import dendrogram as draw_dendrogram
+from .view.view import (neuron, neuron3d, tree, tree3d, soma, soma3d, dendrogram)
 from .core import Tree, Neurite, Soma, Neuron
 
 
 MODES = ('2d', '3d', 'dendrogram')
 
 _VIEWERS = {
-    'neuron_3d': draw_neuron3d,
-    'neuron_2d': draw_neuron,
-    'neuron_dendrogram': draw_dendrogram,
-    'tree_3d': draw_tree3d,
-    'tree_2d': draw_tree,
-    'tree_dendrogram': draw_dendrogram,
-    'soma_3d': draw_soma3d,
-    'soma_2d': draw_soma
+    'neuron_3d': neuron3d,
+    'neuron_2d': neuron,
+    'neuron_dendrogram': dendrogram,
+    'tree_3d': tree3d,
+    'tree_2d': tree,
+    'tree_dendrogram': dendrogram,
+    'soma_3d': soma3d,
+    'soma_2d': soma
 }
 
 


### PR DESCRIPTION
* most plot_* functions don't return the same (figure, axis)
  that they received, since this suggests it's a copy, not the same one

* fix tests to not use a global fig/ax, because the order of the test
  means it's hard to find regressions

* tests don't create directories that would be lost if there's
  an exception

* make coverage rest itself on each nosetest runs, so things aren't
  cumulative

* reduce locations of matplotlib import, so there are fewer places to
  fix once the backend handling is done properly