### PR TITLE
Fix incorrect summary information in checks w/ multiple files

### DIFF
--- a/neurom/check/tests/test_runner.py
+++ b/neurom/check/tests/test_runner.py
@@ -244,6 +244,8 @@ def test_single_apical_no_soma():
 def test_directory_input():
     checker = CheckRunner(CONFIG)
     summ = checker.run(SWC_PATH)
+    nt.eq_(summ['files'][NRN_PATH_0]['Has axon'], True)
+    nt.eq_(summ['files'][NRN_PATH_2]['Has axon'], False)
 
 
 @nt.raises(IOError)


### PR DESCRIPTION
* class member was used to store results, so the last result
  was being propagated to all the results

Fixes #622 