### PR TITLE
graft_neuron functionality

### DIFF
--- a/neurom/__init__.py
+++ b/neurom/__init__.py
@@ -59,7 +59,7 @@ Examples:
 '''
 
 from .version import VERSION as __version__
-from .core import iter_neurites, iter_sections, iter_segments, NeuriteType
+from .core import iter_neurites, iter_sections, graft_neuron, iter_segments, NeuriteType
 from .core.types import NEURITES as NEURITE_TYPES
 from .io.utils import load_neuron, load_neurons, NeuronLoader
 from .fst import get

--- a/neurom/core/__init__.py
+++ b/neurom/core/__init__.py
@@ -31,5 +31,6 @@
 from .tree import Tree
 from .types import NeuriteType
 from ._soma import Soma, make_soma, SomaError
-from ._neuron import Section, Neurite, Neuron, iter_neurites, iter_sections, iter_segments
+from ._neuron import (Section, Neurite, Neuron, iter_neurites,
+                      iter_sections, iter_segments, graft_neuron)
 from .population import Population

--- a/neurom/core/_neuron.py
+++ b/neurom/core/_neuron.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 import numpy as np
 
 from neurom import morphmath
+from neurom.core._soma import Soma
 from neurom.core.dataformat import COLS
 from neurom.utils import memoize
 from neurom._compat import filter, map, zip
@@ -114,6 +115,12 @@ def iter_segments(obj, neurite_filter=None):
                                for sec in sections)
 
 
+def graft_neuron(root_section):
+    '''Returns a neuron starting at root_section'''
+    assert isinstance(root_section, Section)
+    return Neuron(soma=Soma(root_section.points[:1]), neurites=[Neurite(root_section)])
+
+
 class Section(Tree):
     '''Class representing a neurite section'''
 
@@ -161,7 +168,8 @@ class Neurite(object):
 
     def __init__(self, root_node):
         self.root_node = root_node
-        self.type = root_node.type if hasattr(root_node, 'type') else NeuriteType.undefined
+        self.type = root_node.type if hasattr(
+            root_node, 'type') else NeuriteType.undefined
 
     @property
     @memoize
@@ -220,6 +228,12 @@ class Neurite(object):
     def __nonzero__(self):
         return bool(self.root_node)
 
+    def __eq__(self, other):
+        return self.type == other.type and self.root_node == other.root_node
+
+    def __hash__(self):
+        return hash((self.type, self.root_node))
+
     __bool__ = __nonzero__
 
     def __str__(self):
@@ -231,8 +245,9 @@ class Neurite(object):
 class Neuron(object):
     '''Class representing a simple neuron'''
 
-    def __init__(self, soma=None, neurites=None, sections=None):
+    def __init__(self, soma=None, neurites=None, sections=None, name='Neuron'):
         self.soma = soma
+        self.name = name
         self.neurites = neurites
         self.sections = sections
 

--- a/neurom/core/_soma.py
+++ b/neurom/core/_soma.py
@@ -44,8 +44,10 @@ class Soma(object):
     Holds a list of raw data rows corresponding to soma points
     and provides iterator access to them.
     '''
+
     def __init__(self, points):
         self._points = points
+        self.radius = 0
 
     @property
     def center(self):
@@ -67,6 +69,7 @@ class SomaSinglePoint(Soma):
     Type A: 1point soma
     Represented by a single point.
     '''
+
     def __init__(self, points):
         super(SomaSinglePoint, self).__init__(points)
         self.radius = points[0][COLS.R]
@@ -99,6 +102,7 @@ class SomaCylinders(Soma):
   in a line, then the overlap between cylinders isn't taken into account for
   the area calculation
   '''
+
     def __init__(self, points):
         super(SomaCylinders, self).__init__(points)
         self.area = sum(morphmath.segment_area((p0, p1))
@@ -134,6 +138,7 @@ class SomaNeuromorphoThreePointCylinders(SomaCylinders):
         and +rs, respectively (Figure 2). The surface area of this soma cylinder equals
         the surface area of a sphere of radius rs.
     '''
+
     def __init__(self, points):
         super(SomaNeuromorphoThreePointCylinders, self).__init__(points)
 
@@ -173,6 +178,7 @@ class SomaThreePoint(Soma):
         An equivalent radius (rs) is computed as the average distance
         of the other two points.'
     '''
+
     def __init__(self, points):
         super(SomaThreePoint, self).__init__(points)
         self.radius = morphmath.average_points_dist(points[0], (points[1],
@@ -193,6 +199,7 @@ class SomaSimpleContour(Soma):
     Note: This doesn't currently check to see if the contour is in a plane. Also
     the radii of the points are not taken into account.
     '''
+
     def __init__(self, points):
         super(SomaSimpleContour, self).__init__(points)
         points = np.array(self._points)

--- a/neurom/core/tests/test_neuron.py
+++ b/neurom/core/tests/test_neuron.py
@@ -31,7 +31,7 @@ from nose import tools as nt
 from copy import deepcopy
 
 import neurom as nm
-from neurom.core import iter_segments
+from neurom.core import iter_segments, graft_neuron
 from neurom._compat import zip
 
 import numpy as np
@@ -39,10 +39,19 @@ import numpy as np
 _path = os.path.dirname(os.path.abspath(__file__))
 SWC_PATH = os.path.join(_path, '../../../test_data/swc/')
 
+
 def test_deep_copy():
     nrn1 = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
     nrn2 = deepcopy(nrn1)
     check_cloned_neuron(nrn1, nrn2)
+
+
+def test_graft_neuron():
+    nrn1 = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+    basal_dendrite = nrn1.neurites[0]
+    nrn2 = graft_neuron(basal_dendrite.root_node)
+    nt.assert_equal(len(nrn2.neurites), 1)
+    nt.assert_equal(basal_dendrite, nrn2.neurites[0])
 
 
 def check_cloned_neuron(nrn1, nrn2):

--- a/neurom/fst/_core.py
+++ b/neurom/fst/_core.py
@@ -39,13 +39,13 @@ from neurom.core._soma import make_soma, SOMA_CONTOUR, SOMA_CYLINDER
 
 class FstNeuron(Neuron):
     '''Class representing a neuron'''
+
     def __init__(self, data_wrapper, name='Neuron'):
         self._data = data_wrapper
         neurites, sections = make_neurites(self._data)
         soma_check, soma_class = _SOMA_CONFIG[self._data.fmt]
         soma = make_soma(self._data.soma_points(), soma_check, soma_class)
-        super(FstNeuron, self).__init__(soma, neurites, sections)
-        self.name = name
+        super(FstNeuron, self).__init__(soma, neurites, sections, name)
         self._points = None
 
     @property


### PR DESCRIPTION
Returns a neuron with a single neurite starting at the given section.
Note that this is not a deep copy: the data points in the grafted neurite
are the same as in the original neuron

This PR will allow Lida (and others!) to use already existing neuromorpho features but on specific neuron parts (such as starting from the apical point for example)