### PR TITLE
Stop supporting python 2.6 and bump h5py version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   - pip install 'matplotlib==1.5.2'
   - pip install .
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install  'scipy==0.18.1' 'Sphinx==1.5.5'; make -f Makefile run_tests PIP_INSTALL_OPTIONS=; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then make -f Makefile test; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then make -f Makefile run_tests; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then make -f Makefile run_tests; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,6 @@ enum34>=1.0.4
 pyyaml>=3.10
 tqdm>=4.8.4
 matplotlib>=1.3.1
-h5py==2.2.1
+h5py==2.7.1
 future>=0.16.0
 pylru>=1.0


### PR DESCRIPTION
The install of h5py version 2.2.1 fails so bumping to a more recent one