### PR TITLE
Add narrow dendrite check

### DIFF
--- a/neurom/check/neuron_checks.py
+++ b/neurom/check/neuron_checks.py
@@ -287,3 +287,26 @@ def has_no_dangling_branch(n):
     bad_ids = [(neurite.root_node.id, [neurite.root_node.points[1]])
                for neurite in iter_neurites(n) if is_dangling(neurite)]
     return CheckResult(len(bad_ids) == 0, bad_ids)
+
+
+def has_no_narrow_neurite_section(neuron,
+                                  neurite_filter,
+                                  radius_threshold=0.05,
+                                  considered_section_min_length=50):
+    '''Check if the neuron has dendrites with narrow sections
+        sections below 'considered_section_min_length' are not taken into account
+    Returns:
+        CheckResult with result. result.info contains the narrow section ids and their
+        first point
+    '''
+
+    considered_sections = (sec for sec in iter_sections(neuron, neurite_filter=neurite_filter)
+                           if sec.length > considered_section_min_length)
+
+    def narrow_section(section):
+        '''Select narrow sections'''
+        return section.points[:, COLS.R].mean() < radius_threshold
+
+    bad_ids = [(section.id, section.points[1])
+               for section in considered_sections if narrow_section(section)]
+    return CheckResult(len(bad_ids) == 0, bad_ids)

--- a/neurom/core/tests/test_types.py
+++ b/neurom/core/tests/test_types.py
@@ -27,30 +27,48 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from nose import tools as nt
 from mock import Mock
+from nose import tools as nt
 
-from neurom.core.types import NeuriteType, tree_type_checker, NEURITES
+from neurom.core.types import (NEURITES, NeuriteType, axon_filter,
+                               dendrite_filter, tree_type_checker)
 
 
 def test_tree_type_checker():
-    #check that when NeuriteType.all, we accept all trees, w/o checking type
+    # check that when NeuriteType.all, we accept all trees, w/o checking type
     tree_filter = tree_type_checker(NeuriteType.all)
     nt.ok_(tree_filter('fake_tree'))
 
     mock_tree = Mock()
     mock_tree.type = NeuriteType.axon
 
-    #single arg
+    # single arg
     tree_filter = tree_type_checker(NeuriteType.axon)
     nt.ok_(tree_filter(mock_tree))
 
     mock_tree.type = NeuriteType.basal_dendrite
     nt.ok_(not tree_filter(mock_tree))
 
-    #multiple args
+    # multiple args
     tree_filter = tree_type_checker(NeuriteType.axon, NeuriteType.basal_dendrite)
     nt.ok_(tree_filter(mock_tree))
 
     tree_filter = tree_type_checker(*NEURITES)
     nt.ok_(tree_filter('fake_tree'))
+
+
+def test_type_filters():
+    axon = Mock()
+    axon.type = NeuriteType.axon
+    nt.ok_(axon_filter(axon))
+    nt.ok_(not dendrite_filter(axon))
+
+    basal_dendrite = Mock()
+    basal_dendrite.type = NeuriteType.basal_dendrite
+    nt.ok_(not axon_filter(basal_dendrite))
+    nt.ok_(dendrite_filter(basal_dendrite))
+
+    apical_dendrite = Mock()
+    apical_dendrite.type = NeuriteType.apical_dendrite
+    nt.ok_(not axon_filter(apical_dendrite))
+    nt.ok_(dendrite_filter(apical_dendrite))

--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -42,6 +42,14 @@ class NeuriteType(IntEnum):
     all = 32
 
 
+NEURITES = (NeuriteType.all,
+            NeuriteType.axon,
+            NeuriteType.basal_dendrite,
+            NeuriteType.apical_dendrite)
+
+ROOT_ID = -1
+
+
 def tree_type_checker(*ref):
     '''Tree type checker functor
 
@@ -71,10 +79,11 @@ def tree_type_checker(*ref):
     return check_tree_type
 
 
-NEURITES = (NeuriteType.all,
-            NeuriteType.axon,
-            NeuriteType.basal_dendrite,
-            NeuriteType.apical_dendrite)
+def dendrite_filter(n):
+    '''Select only dendrites'''
+    return n.type == NeuriteType.basal_dendrite or n.type == NeuriteType.apical_dendrite
 
 
-ROOT_ID = -1
+def axon_filter(n):
+    '''Select only axons'''
+    return n.type == NeuriteType.axon


### PR DESCRIPTION
Add a function for checking that the neuron has no narrow dendrites.
Narrow dendrites are dendrites whose at least one segment greater than a given threshold has a mean radius smaller than a threshold radius.

See https://bbpteam.epfl.ch/project/issues/browse/NSETM-275