### PR TITLE
memoize at instance scope, no more at global scope

### DIFF
--- a/neurom/core/tests/test_neurite.py
+++ b/neurom/core/tests/test_neurite.py
@@ -27,28 +27,29 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+
+import numpy as np
 from nose import tools as nt
+
 import neurom as nm
 from neurom.core import Neurite, Section
-import numpy as np
-
 
 RADIUS = 4.
 POINTS0 = np.array([[0., 0., 0., RADIUS],
-                   [0., 0., 1., RADIUS],
-                   [0., 0., 2., RADIUS],
-                   [0., 0., 3., RADIUS],
-                   [1., 0., 3., RADIUS],
-                   [2., 0., 3., RADIUS],
-                   [3., 0., 3., RADIUS]])
+                    [0., 0., 1., RADIUS],
+                    [0., 0., 2., RADIUS],
+                    [0., 0., 3., RADIUS],
+                    [1., 0., 3., RADIUS],
+                    [2., 0., 3., RADIUS],
+                    [3., 0., 3., RADIUS]])
 
 POINTS1 = np.array([[3., 0., 3., RADIUS],
-                   [3., 0., 4., RADIUS],
-                   [3., 0., 5., RADIUS],
-                   [3., 0., 6., RADIUS],
-                   [4., 0., 6., RADIUS],
-                   [5., 0., 6., RADIUS],
-                   [6., 0., 6., RADIUS]])
+                    [3., 0., 4., RADIUS],
+                    [3., 0., 5., RADIUS],
+                    [3., 0., 6., RADIUS],
+                    [4., 0., 6., RADIUS],
+                    [5., 0., 6., RADIUS],
+                    [6., 0., 6., RADIUS]])
 
 REF_LEN = 12
 
@@ -89,6 +90,12 @@ def test_neurite_volume():
     volume = math.pi * RADIUS * RADIUS * REF_LEN
     nt.assert_almost_equal(nrt.volume, volume)
 
+
 def test_str():
     nrt = Neurite(ROOT_NODE)
     nt.ok_('Neurite' in str(nrt))
+
+
+def test_neurite_hash():
+    nrt = Neurite(ROOT_NODE)
+    nt.eq_(hash(nrt), hash((nrt.type, nrt.root_node)))

--- a/neurom/core/tests/test_neuron.py
+++ b/neurom/core/tests/test_neuron.py
@@ -27,14 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from nose import tools as nt
 from copy import deepcopy
 
-import neurom as nm
-from neurom.core import iter_segments, graft_neuron
-from neurom._compat import zip
-
 import numpy as np
+from nose import tools as nt
+
+import neurom as nm
+from neurom._compat import zip
+from neurom.core import graft_neuron, iter_segments
 
 _path = os.path.dirname(os.path.abspath(__file__))
 SWC_PATH = os.path.join(_path, '../../../test_data/swc/')

--- a/neurom/tests/test_utils.py
+++ b/neurom/tests/test_utils.py
@@ -28,41 +28,33 @@
 
 '''Test neurom.utils'''
 import json
-import numpy as np
-
-from neurom import utils as nu
-from nose import tools as nt
 import random
 import warnings
 
+import numpy as np
+from nose import tools as nt
 
-def test_memoize_caches_args():
+from neurom import utils as nu
 
-    @nu.memoize
-    def dummy(x, y=42):
-        return random.random()
 
-    ref1 = dummy(42)
-    ref2 = dummy(42, 43)
+def test_memoize_caches():
+    class A(object):
+        @nu.memoize
+        def dummy(self, x, y=42):
+            return random.random()
+
+    a = A()
+    ref1 = a.dummy(42)
+    ref2 = a.dummy(42, 43)
+    ref3 = a.dummy(42, y=43)
 
     for _ in range(10):
-        nt.assert_equal(dummy(42), ref1)
-        nt.assert_equal(dummy(42, 43), ref2)
-
-
-def test_memoize_does_not_cache_kwargs():
-
-    global ctr
-    ctr = 0
-
-    @nu.memoize
-    def dummy(x, y=42):
-        global ctr
-        ctr += 1
-        return ctr
-
-    for i in range(10):
-        nt.assert_equal(dummy(42, y=43), i + 1)
+        nt.assert_equal(a.dummy(42), ref1)
+        nt.assert_not_equal(A().dummy(42), ref1)
+        nt.assert_equal(a.dummy(42, 43), ref2)
+        nt.assert_not_equal(A().dummy(42, 43), ref2)
+        nt.assert_equal(a.dummy(42, y=43), ref3)
+        nt.assert_not_equal(A().dummy(42, y=43), ref3)
 
 
 def test_deprecated():

--- a/neurom/utils.py
+++ b/neurom/utils.py
@@ -28,31 +28,48 @@
 
 '''NeuroM helper utilities'''
 import json
-import functools
 import warnings
+from functools import partial, wraps
+
 import numpy as np
 
 
-def memoize(fun):
-    '''Memoize a function
+class memoize(object):
+    """cache the return value of a method
 
-    Caches return values based on function arguments.
+    This class is meant to be used as a decorator of methods. The return value
+    from a given method invocation will be cached on the instance whose method
+    was invoked. All arguments passed to a method decorated with memoize must
+    be hashable.
 
-    Note:
-        Does not cache calls with keyword arguments.
-    '''
-    _cache = {}
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method:
+    class Obj(object):
+        @memoize
+        def add_to(self, arg):
+            return self + arg
+    Obj.add_to(1) # not enough arguments
+    Obj.add_to(1, 2) # returns 3, result is not cached
+    """
 
-    @functools.wraps(fun)
-    def memoizer(*args, **kwargs):
-        '''Return cahced value
+    def __init__(self, func):
+        self.func = func
 
-        Calculate and store if args not in cache.
-        '''
-        if args not in _cache or kwargs:
-            _cache[args] = fun(*args, **kwargs)
-        return _cache[args]
-    return memoizer
+    def __get__(self, obj, objtype=None):
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        obj = args[0]
+        try:
+            cache = obj.__cache  # pylint: disable=protected-access
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
 
 
 def _warn_deprecated(msg):
@@ -66,7 +83,7 @@ def deprecated(fun_name=None, msg=""):
     '''Issue a deprecation warning for a function'''
     def _deprecated(fun):
         '''Issue a deprecation warning for a function'''
-        @functools.wraps(fun)
+        @wraps(fun)
         def _wrapper(*args, **kwargs):
             '''Issue deprecation warning and forward arguments to fun'''
             name = fun_name if fun_name is not None else fun.__name__


### PR DESCRIPTION
Memoizing in global scope causes a memory leak as when Neuron instance
are deleted their memoized values are not deleted.