### PR TITLE
Issue #670: NeuriteType filter not available in viewer.draw

### DIFF
--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -37,8 +37,10 @@ if 'DISPLAY' not in os.environ:  # noqa
 from neurom.view import common
 from neurom import load_neuron
 from neurom import viewer
+from neurom import NeuriteType
 
 from nose import tools as nt
+from numpy.testing import assert_allclose
 
 _PWD = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_PWD, '../../test_data/swc')
@@ -49,6 +51,15 @@ nrn = load_neuron(MORPH_FILENAME)
 
 def test_draw_neuron():
     viewer.draw(nrn)
+    common.plt.close('all')
+
+
+def test_draw_filter_neurite():
+    for mode in ['2d', '3d']:
+        viewer.draw(nrn, mode=mode, neurite_type=NeuriteType.basal_dendrite)
+        assert_allclose(common.plt.gca().get_ylim(),
+                        [-30., 78], atol=5)
+
     common.plt.close('all')
 
 

--- a/neurom/view/view.py
+++ b/neurom/view/view.py
@@ -33,7 +33,8 @@ from matplotlib.patches import Circle
 
 from neurom import NeuriteType, geom
 from neurom._compat import zip
-from neurom.core import iter_segments
+from neurom.core.types import tree_type_checker
+from neurom.core import iter_segments, iter_neurites
 from neurom.core._soma import SomaCylinders
 from neurom.core.dataformat import COLS
 from neurom.morphmath import segment_radius
@@ -156,7 +157,10 @@ def plot_soma(ax, soma, plane='xy',
                                    ignore=False)
 
 
-def plot_neuron(ax, nrn, plane='xy',
+# pylint: disable=too-many-arguments
+def plot_neuron(ax, nrn,
+                neurite_type=NeuriteType.all,
+                plane='xy',
                 soma_outline=True,
                 diameter_scale=_DIAMETER_SCALE, linewidth=_LINEWIDTH,
                 color=None, alpha=_ALPHA):
@@ -164,6 +168,7 @@ def plot_neuron(ax, nrn, plane='xy',
 
     Args:
         ax(matplotlib axes): on what to plot
+        neurite_type(NeuriteType): an optional filter on the neurite type
         nrn(neuron): neuron to be plotted
         soma_outline(bool): should the soma be drawn as an outline
         plane(str): Any pair of 'xyz'
@@ -175,7 +180,7 @@ def plot_neuron(ax, nrn, plane='xy',
     plot_soma(ax, nrn.soma, plane=plane, soma_outline=soma_outline, linewidth=linewidth,
               color=color, alpha=alpha)
 
-    for neurite in nrn.neurites:
+    for neurite in iter_neurites(nrn, filt=tree_type_checker(neurite_type)):
         plot_tree(ax, neurite, plane=plane,
                   diameter_scale=diameter_scale, linewidth=linewidth,
                   color=color, alpha=alpha)
@@ -249,7 +254,7 @@ def plot_soma3d(ax, soma, color=None, alpha=_ALPHA):
     _update_3d_datalim(ax, soma)
 
 
-def plot_neuron3d(ax, nrn,
+def plot_neuron3d(ax, nrn, neurite_type=NeuriteType.all,
                   diameter_scale=_DIAMETER_SCALE, linewidth=_LINEWIDTH,
                   color=None, alpha=_ALPHA):
     '''
@@ -259,6 +264,7 @@ def plot_neuron3d(ax, nrn,
     Args:
         ax(matplotlib axes): on what to plot
         nrn(neuron): neuron to be plotted
+        neurite_type(NeuriteType): an optional filter on the neurite type
         diameter_scale(float): Scale factor multiplied with segment diameters before plotting
         linewidth(float): all segments are plotted with this width, but only if diameter_scale=None
         color(str or None): Color of plotted values, None corresponds to default choice
@@ -266,7 +272,7 @@ def plot_neuron3d(ax, nrn,
     '''
     plot_soma3d(ax, nrn.soma, color=color, alpha=alpha)
 
-    for neurite in nrn.neurites:
+    for neurite in iter_neurites(nrn, filt=tree_type_checker(neurite_type)):
         plot_tree3d(ax, neurite,
                     diameter_scale=diameter_scale, linewidth=linewidth,
                     color=color, alpha=alpha)


### PR DESCRIPTION
This adds a filter on neurite types when calling viewer.draw with a neuron
and with modes '2d' and '3d'.