### PR TITLE
Introduced `locate_segment_position()` function

### DIFF
--- a/neurom/fst/sectionfunc.py
+++ b/neurom/fst/sectionfunc.py
@@ -123,3 +123,10 @@ def strahler_order(section):
             return max_so_children + 1
         return max_so_children
     return 1
+
+
+def locate_segment_position(section, fraction):
+    '''
+    Segment ID / offset corresponding to a given fraction of section length.
+    '''
+    return mm.path_fraction_id_offset(section.points, fraction)

--- a/neurom/fst/tests/test_sectionfunc.py
+++ b/neurom/fst/tests/test_sectionfunc.py
@@ -148,3 +148,31 @@ def test_strahler_order():
     n = load_neuron(path)
     strahler_order = _sf.strahler_order(n.neurites[0].root_node)
     nt.eq_(strahler_order, 4)
+
+
+def test_locate_segment_position():
+    s = Section(np.array([[0, 0, 0, 0], [3, 0, 4, 100], [6, 4, 4, 200]]))
+    nt.assert_equal(
+        _sf.locate_segment_position(s, 0.0),
+        (0, 0.0)
+    )
+    nt.assert_equal(
+        _sf.locate_segment_position(s, 0.25),
+        (0, 2.5)
+    )
+    nt.assert_equal(
+        _sf.locate_segment_position(s, 0.75),
+        (1, 2.5)
+    )
+    nt.assert_equal(
+        _sf.locate_segment_position(s, 1.0),
+        (1, 5.0)
+    )
+    nt.assert_raises(
+        ValueError,
+        _sf.locate_segment_position, s, 1.1
+    )
+    nt.assert_raises(
+        ValueError,
+        _sf.locate_segment_position, s, -0.1
+    )


### PR DESCRIPTION
Given that SONATA format stores synapse positions as section ID + relative distance along the section, the task of locating the corresponding segment might be something needed repeatedly.

Not sure if NeuroM is the appropriate place for it, though.