### PR TITLE
Fix: Section iterator strategies #690

### DIFF
--- a/neurom/core/__init__.py
+++ b/neurom/core/__init__.py
@@ -29,7 +29,7 @@
 ''' Core functionality and data types of NeuroM '''
 
 from .tree import Tree
-from .types import NeuriteType
+from .types import NeuriteType, NeuriteIter
 from ._soma import Soma, make_soma, SomaError
 from ._neuron import (Section, Neurite, Neuron, iter_neurites,
                       iter_sections, iter_segments, graft_neuron)

--- a/neurom/core/tests/test_iter.py
+++ b/neurom/core/tests/test_iter.py
@@ -33,48 +33,60 @@ from nose import tools as nt
 import neurom as nm
 from neurom import load_neuron
 from neurom import core
-from neurom.core import Tree
+from neurom.core import Tree, NeuriteIter
 from neurom._compat import filter
 
 _path = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = joinp(_path, '../../../test_data')
 
 NRN1 = load_neuron(joinp(DATA_PATH, 'swc/Neuron.swc'))
+
 NEURONS = [NRN1,
            load_neuron(joinp(DATA_PATH, 'swc/Single_basal.swc')),
            load_neuron(joinp(DATA_PATH, 'swc/Neuron_small_radius.swc')),
            load_neuron(joinp(DATA_PATH, 'swc/Neuron_3_random_walker_branches.swc')),
            ]
 TOT_NEURITES = sum(len(N.neurites) for N in NEURONS)
+
+REVERSED_NEURITES = load_neuron(joinp(DATA_PATH, 'swc/ordering/reversed_NRN_neurite_order.swc'))
+
 POP = core.Population(NEURONS, name='foo')
 
 
 def assert_sequence_equal(a, b):
     nt.eq_(tuple(a), tuple(b))
 
+
 def test_iter_neurites_default():
     assert_sequence_equal(POP.neurites,
                           [n for n in core.iter_neurites(POP)])
+
+
+def test_iter_neurites_nrn_order():
+    assert_sequence_equal(list(core.iter_neurites(REVERSED_NEURITES,
+                                                  neurite_order=NeuriteIter.NRN)),
+                          reversed(list(core.iter_neurites(REVERSED_NEURITES))))
+
 
 def test_iter_neurites_filter():
 
     for ntyp in nm.NEURITE_TYPES:
         a = [n for n in POP.neurites if n.type == ntyp]
-        b = [n for n in core.iter_neurites(POP, filt=lambda n : n.type == ntyp)]
+        b = [n for n in core.iter_neurites(POP, filt=lambda n: n.type == ntyp)]
         assert_sequence_equal(a, b)
 
 
 def test_iter_neurites_mapping():
 
-    n = [n for n in core.iter_neurites(POP, mapfun=lambda n : len(n.points))]
+    n = [n for n in core.iter_neurites(POP, mapfun=lambda n: len(n.points))]
     ref = [211, 211, 211, 211, 211, 211, 211, 211, 211, 500, 500, 500]
     assert_sequence_equal(n, ref)
 
 
 def test_iter_neurites_filter_mapping():
     n = [n for n in core.iter_neurites(POP,
-                                       mapfun=lambda n : len(n.points),
-                                       filt=lambda n : len(n.points) > 250)]
+                                       mapfun=lambda n: len(n.points),
+                                       filt=lambda n: len(n.points) > 250)]
 
     ref = [500, 500, 500]
     assert_sequence_equal(n, ref)
@@ -92,36 +104,36 @@ def test_iter_sections_filter():
     for ntyp in nm.NEURITE_TYPES:
         a = [s for n in filter(lambda nn: nn.type == ntyp, POP.neurites)
              for s in n.iter_sections()]
-        b = [n for n in core.iter_sections(POP, neurite_filter=lambda n : n.type == ntyp)]
+        b = [n for n in core.iter_sections(POP, neurite_filter=lambda n: n.type == ntyp)]
         assert_sequence_equal(a, b)
+
+def test_iter_sections_inrnorder():
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(neurite_order=NeuriteIter.NRN)],
+                          [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 2, 3, 4])
+
+def test_iter_sections_ipreorder():
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(Tree.ipreorder)],
+                          [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 2, 3, 4])
 
 
 def test_iter_sections_ipostorder():
-
-    ref = [s for n in POP.neurites for s in n.iter_sections(Tree.ipostorder)]
-    assert_sequence_equal(ref,
-                          [n for n in core.iter_sections(POP, iterator_type=Tree.ipostorder)])
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(Tree.ipostorder)],
+                          [3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 43, 41, 39, 37, 35, 33, 31, 29, 27, 25, 23, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 64, 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 85, 83, 81, 79, 77, 75, 73, 71, 69, 67, 65, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 43, 41, 39, 37, 35, 33, 31, 29, 27, 25, 23, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 64, 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 85, 83, 81, 79, 77, 75, 73, 71, 69, 67, 65, 2, 3, 4])
 
 
 def test_iter_sections_ibifurcation():
-
-    ref = [s for n in POP.neurites for s in n.iter_sections(Tree.ibifurcation_point)]
-    assert_sequence_equal(ref,
-                          [n for n in core.iter_sections(POP, iterator_type=Tree.ibifurcation_point)])
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(Tree.ibifurcation_point)],
+                          [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83],)
 
 
 def test_iter_sections_iforking():
-
-    ref = [s for n in POP.neurites for s in n.iter_sections(Tree.iforking_point)]
-    assert_sequence_equal(ref,
-                          [n for n in core.iter_sections(POP, iterator_type=Tree.iforking_point)])
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(Tree.iforking_point)],
+                          [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83])
 
 
 def test_iter_sections_ileaf():
-
-    ref = [s for n in POP.neurites for s in n.iter_sections(Tree.ileaf)]
-    assert_sequence_equal(ref,
-                          [n for n in core.iter_sections(POP, iterator_type=Tree.ileaf)])
+    assert_sequence_equal([s.id for n in POP.neurites for s in n.iter_sections(Tree.ileaf)],
+                          [3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 85, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 85, 2, 3, 4])
 
 
 def test_iter_segments_nrn():

--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -34,6 +34,17 @@ from neurom.utils import OrderedEnum
 
 
 @unique
+class NeuriteIter(OrderedEnum):
+    '''Neurite iteration orders'''
+    FileOrder = 1  # Order in which neurites appear in the file
+
+    # NRN simulator order: soma -> axon -> basal -> apical
+    # Coming from:
+    # https://github.com/neuronsimulator/nrn/blob/2dbf2ebf95f1f8e5a9f0565272c18b1c87b2e54c/share/lib/hoc/import3d/import3d_gui.hoc#L874
+    NRN = 2
+
+
+@unique
 class NeuriteType(OrderedEnum):
     '''Enum representing valid tree types'''
     undefined = 1

--- a/test_data/swc/ordering/reversed_NRN_neurite_order.swc
+++ b/test_data/swc/ordering/reversed_NRN_neurite_order.swc
@@ -1,0 +1,6 @@
+# NRN simulator neurite order is: soma -> axon -> basal -> apical
+# In this file the order is reversed
+ 1 1  0  0 0 1. -1
+ 2 5  0  0 0 1.  1 # apical
+ 6 4  0  0 0 1.  1 # basal
+ 6 3  0  0 0 1.  1 # axon


### PR DESCRIPTION
iter_neurites and iter_sections have new iteration modes:

1) iter_neurites has an optional argument iterator_type of type NeuriteIter.
iter_neurites(neuron, NeuriteIter.NRN) will iterate on the neurite in the same order as the simulator does

2) iter_sections can now be called with iterator_type==Tree.inrnorder
this will iterate on section the same way the NRN simulator would do