### PR TITLE
Bump to version 1.4.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-VERSION = "1.4.8"
+VERSION = "1.4.9"
 
 REQS = ['enum34>=1.0.4;python_version<"3.4"',
         'future>=0.16.0',


### PR DESCRIPTION
Changes:
  - Require 'enum34' only for Python<3.4
  - Create plotly module
  - Specify morph_stats example config path in help
  - Fix: Section type constants are shown as integers #697
  - 3-points contours are not longer interpreted as SomaThreePoint