### PR TITLE
3-points contours are no longer interpreted as SomaThreePoint

### DIFF
--- a/neurom/core/_soma.py
+++ b/neurom/core/_soma.py
@@ -167,28 +167,6 @@ class SomaNeuromorphoThreePointCylinders(SomaCylinders):
                 (repr(self._points), self.center, self.radius))
 
 
-class SomaThreePoint(Soma):
-    '''
-    Type B: 3point soma
-    Represented by 3 points.
-
-    Reference:
-        http://neuromorpho.org/SomaFormat.html
-        'The first point constitutes the center of the soma.
-        An equivalent radius (rs) is computed as the average distance
-        of the other two points.'
-    '''
-
-    def __init__(self, points):
-        super(SomaThreePoint, self).__init__(points)
-        self.radius = morphmath.average_points_dist(points[0], (points[1],
-                                                                points[2]))
-
-    def __str__(self):
-        return ('SomaThreePoint(%s) <center: %s, radius: %s>' %
-                (repr(self._points), self.center, self.radius))
-
-
 class SomaSimpleContour(Soma):
     '''
     Type C: multiple points soma
@@ -235,7 +213,6 @@ def _get_type(points, soma_class):
     if soma_class == SOMA_CONTOUR:
         return {0: None,
                 1: SomaSinglePoint,
-                3: SomaThreePoint,
                 2: None}.get(npoints, SomaSimpleContour)
     elif soma_class == SOMA_CYLINDER:
         if(npoints == 3 and

--- a/neurom/core/tests/test_soma.py
+++ b/neurom/core/tests/test_soma.py
@@ -88,12 +88,12 @@ def test_make_Soma_SinglePoint():
     nt.ok_(sm.radius == 44)
 
 
-def test_make_Soma_ThreePoint():
+def test_make_Soma_contour():
     sm = _soma.make_soma(SOMA_THREEPOINTS_PTS, soma_class=_soma.SOMA_CONTOUR)
-    nt.ok_('SomaThreePoint' in str(sm))
-    nt.ok_(isinstance(sm, _soma.SomaThreePoint))
+    nt.ok_('SomaSimpleContour' in str(sm))
+    nt.ok_(isinstance(sm, _soma.SomaSimpleContour))
     nt.eq_(list(sm.center), [0, 0, 0])
-    nt.eq_(sm.radius, 44)
+    nt.assert_almost_equal(sm.radius, 29.33333333, places=5)
 
 
 def test_make_Soma_ThreePointCylinder():

--- a/neurom/fst/tests/test_feature_compat.py
+++ b/neurom/fst/tests/test_feature_compat.py
@@ -192,6 +192,14 @@ class TestH5V1(SectionTreeBase):
         self.sec_nrn = nm.load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
 
+    # Overriding soma values as the same soma points in SWC and ASC have different
+    # meanings. Hence leading to different values
+    def test_get_soma_radius(self):
+        nt.assert_equal(self.sec_nrn.soma.radius, 0.09249506049313666)
+
+    def test_get_soma_surface_area(self):
+        nt.assert_equal(fst._nrn.soma_surface_area(self.sec_nrn),
+                        0.1075095256160432)
 
 class TestH5V2(SectionTreeBase):
 
@@ -199,6 +207,15 @@ class TestH5V2(SectionTreeBase):
         super(TestH5V2, self).setUp()
         self.sec_nrn = nm.load_neuron(os.path.join(H5V2_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
+
+    # Overriding soma values as the same soma points in SWC and ASC have different
+    # meanings. Hence leading to different values
+    def test_get_soma_radius(self):
+        nt.assert_equal(self.sec_nrn.soma.radius, 0.09249506049313666)
+
+    def test_get_soma_surface_area(self):
+        nt.assert_equal(fst._nrn.soma_surface_area(self.sec_nrn),
+                        0.1075095256160432)
 
 
 class TestSWC(SectionTreeBase):

--- a/neurom/fst/tests/test_get_features.py
+++ b/neurom/fst/tests/test_get_features.py
@@ -66,8 +66,6 @@ def assert_items_equal(a, b):
 
 def assert_features_for_neurite(feat, neurons, expected, exact=True):
     for neurite_type, expected_values in expected.items():
-        # print('neurite_type: %s' % neurite_type)
-
         if neurite_type is None:
             res_pop = fst_get(feat, neurons)
             res = fst_get(feat, neurons[0])
@@ -854,82 +852,3 @@ def test_section_strahler_orders():
     n = nm.load_neuron(path)
     assert_allclose(fst_get('section_strahler_orders', n),
                     [4, 1, 4, 3, 2, 1, 1, 2, 1, 1, 3, 1, 3, 2, 1, 1, 2, 1, 1])
-
-#class MockNeuron:
-#    pass
-#
-#
-#def test_trunk_origin_elevations():
-#    n0 = MockNeuron()
-#    n1 = MockNeuron()
-#
-#    s = make_soma([[0, 0, 0, 4]])
-#    t0 = PointTree((1, 0, 0, 2))
-#    t0.type = NeuriteType.basal_dendrite
-#    t1 = PointTree((0, 1, 0, 2))
-#    t1.type = NeuriteType.basal_dendrite
-#    n0.neurites = [t0, t1]
-#    n0.soma = s
-#
-#    t2 = PointTree((0, -1, 0, 2))
-#    t2.type = NeuriteType.basal_dendrite
-#    n1.neurites = [t2]
-#    n1.soma = s
-#
-#    pop = [n0, n1]
-#    nt.ok_(np.all(fst_get('trunk_origin_elevations', pop) ==
-#                          [0.0, np.pi/2., -np.pi/2.]))
-#    nt.eq_(len(fst_get('trunk_origin_elevations', pop, neurite_type=NeuriteType.axon)), 0)
-#
-#def test_trunk_origin_azimuths():
-#    n0 = MockNeuron()
-#    n1 = MockNeuron()
-#    n2 = MockNeuron()
-#    n3 = MockNeuron()
-#    n4 = MockNeuron()
-#    n5 = MockNeuron()
-#
-#    t = PointTree((0, 0, 0, 2))
-#    t.type = NeuriteType.basal_dendrite
-#    n0.neurites = [t]
-#    n1.neurites = [t]
-#    n2.neurites = [t]
-#    n3.neurites = [t]
-#    n4.neurites = [t]
-#    n5.neurites = [t]
-#    pop = [n0, n1, n2, n3, n4, n5]
-#    s0 = make_soma([[0, 0, 1, 4]])
-#    s1 = make_soma([[0, 0, -1, 4]])
-#    s2 = make_soma([[0, 0, 0, 4]])
-#    s3 = make_soma([[-1, 0, -1, 4]])
-#    s4 = make_soma([[-1, 0, 0, 4]])
-#    s5 = make_soma([[1, 0, 0, 4]])
-#
-#    pop[0].soma = s0
-#    pop[1].soma = s1
-#    pop[2].soma = s2
-#    pop[3].soma = s3
-#    pop[4].soma = s4
-#    pop[5].soma = s5
-#    nt.ok_(np.all(fst_get('trunk_origin_azimuths', pop) ==
-#                          [-np.pi/2., np.pi/2., 0.0, np.pi/4., 0.0, np.pi]))
-#    nt.eq_(len(fst_get('trunk_origin_azimuths', pop, neurite_type=NeuriteType.axon)), 0)
-
-#def test_principal_directions_extents():
-#    points = np.array([[-10., 0., 0.],
-#                       [-9., 0., 0.],
-#                       [9., 0., 0.],
-#                       [10., 0., 0.]])
-#
-#    tree = PointTree(np.array([points[0][0], points[0][1], points[0][2], 1., 0., 0.]))
-#    tree.add_child(PointTree(np.array([points[1][0], points[1][1], points[1][2], 1., 0., 0.])))
-#    tree.children[0].add_child(PointTree(np.array([points[2][0], points[2][1], points[2][2], 1., 0., 0.])))
-#    tree.children[0].add_child(PointTree(np.array([points[3][0], points[3][1], points[3][2], 1., 0., 0.])))
-#
-#    neurites = [tree, tree, tree]
-#    extents0 = fst_get('principal_direction_extents', neurites, direction='first')
-#    nt.ok_(np.allclose(extents0, [20., 20., 20.]))
-#    extents1 = fst_get('principal_direction_extents', neurites, direction='second')
-#    nt.ok_(np.allclose(extents1, [0., 0., 0.]))
-#    extents2 = fst_get('principal_direction_extents', neurites, direction='third')
-#    nt.ok_(np.allclose(extents2, [0., 0., 0.]))

--- a/neurom/fst/tests/test_neuronfunc.py
+++ b/neurom/fst/tests/test_neuronfunc.py
@@ -50,6 +50,7 @@ NRN = load_neuron(os.path.join(H5_PATH, 'Neuron.h5'))
 SWC_PATH = os.path.join(_PWD, '../../../test_data/swc')
 SIMPLE = load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
 SIMPLE_TRUNK = load_neuron(os.path.join(SWC_PATH, 'simple_trunk.swc'))
+SWC_NRN = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
 
 
 def test_soma_surface_area():
@@ -134,7 +135,7 @@ def test_trunk_origin_elevations():
 
 @nt.raises(Exception)
 def test_trunk_elevation_zero_norm_vector_raises():
-    _nf.trunk_origin_elevations(NRN)
+    _nf.trunk_origin_elevations(SWC_NRN)
 
 
 def test_sholl_crossings_simple():

--- a/neurom/view/tests/test_dendrogram.py
+++ b/neurom/view/tests/test_dendrogram.py
@@ -1,4 +1,5 @@
 import os
+from numpy.testing import assert_array_almost_equal
 import numpy as np
 from nose import tools as nt
 from neurom.core.types import NeuriteType
@@ -98,11 +99,11 @@ class TestDendrogram(object):
     def test_generate_soma(self):
 
         vrec = self.dnrn.soma
-        trec = np.array([[-0.17071068, -0.34142136],
-                         [-0.17071068,  0.        ],
-                         [ 0.17071068,  0.        ],
-                         [ 0.17071068, -0.34142136]])
-        nt.assert_true(np.allclose(vrec, trec))
+        assert_array_almost_equal(vrec,
+                                  np.array([[-0.092495, -0.18499],
+                                            [-0.092495,  0.],
+                                            [0.092495,  0.],
+                                            [0.092495, -0.18499]]))
 
         vrec = self.dtr.soma
 


### PR DESCRIPTION
In NeuroM a soma made of 3 points could be of type:
- SomaThreePoint if the soma_class was SOMA_CONTOUR

And if soma_class is SOMA_CYLINDER, there was 2 options:
- SomaNeuromorphoThreePointCylinders if it follows the spec of the soma 3pt
cylinder (http://neuromorpho.org/SomaFormat.html)
- SomaCylinders else

The change is that now, in the case of a soma_class == SOMA_CONTOUR:
It is of type SomaSimpleContour instead of SomaThreePoint