### PR TITLE
Fix dendrogram plot called with a neurite

### DIFF
--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -121,6 +121,9 @@ def test_draw_dendrogram():
     viewer.draw(nrn, mode='dendrogram')
     common.plt.close('all')
 
+    viewer.draw(nrn.neurites[0], mode='dendrogram')
+    common.plt.close('all')
+
 
 @nt.raises(viewer.InvalidDrawModeError)
 def test_invalid_draw_mode_raises():

--- a/neurom/view/_dendrogram.py
+++ b/neurom/view/_dendrogram.py
@@ -184,7 +184,7 @@ class Dendrogram(object):
             dummy_section.add_child(self._obj.root_node)
             self._generate_dendro(dummy_section, (max_diameter, 0.), offsets)
 
-            self._groups.append((0., self._n))
+            self._groups.append((0, self._n))
 
             self._dims.append(self._max_dims)
 


### PR DESCRIPTION
A numpy index was set as a float