### PR TITLE
Fix enum34 incompatibility with Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from setuptools import find_packages
 VERSION = "1.4.15.dev1"
 
 REQS = ['click>=7.0',
-        'enum34>=1.0.4',
+        'enum-compat>=0.0.2',
         'future>=0.16.0',
         'h5py>=2.7.1',
         'matplotlib>=1.3.1',
@@ -46,8 +46,7 @@ REQS = ['click>=7.0',
         'pyyaml>=3.10',
         'scipy>=1.2.0',
         'tqdm>=4.8.4',
-        'future>=0.16.0',
-        ]
+]
 
 # Hack to avoid installation of modules with C extensions
 # in readthedocs documentation building environment.


### PR DESCRIPTION
Uses the package enum-compat that only installs enum34 for python < 3.4

The error on python 3.6 was:
AttributeError: module 'enum' has no attribute 'IntFlag'

See:
https://stackoverflow.com/questions/43124775/why-python-3-6-1-throws-attributeerror-module-enum-has-no-attribute-intflag