### PR TITLE
faster path_distance computation (~2x)

### DIFF
--- a/neurom/morphmath.py
+++ b/neurom/morphmath.py
@@ -257,9 +257,7 @@ def path_distance(points):
     """
     Compute the path distance from given set of points
     """
-    vecs = np.diff(points, axis=0)[:, :3]
-    d2 = [np.dot(p, p) for p in vecs]
-    return np.sum(np.sqrt(d2))
+    return interval_lengths(points).sum()
 
 
 def segment_length(seg):


### PR DESCRIPTION
Just noticed that using np.linalg.norm instead of np.dot product was faster for this function. 