### PR TITLE
morph_stat can now extract all features with the '-f' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The build-time and runtime dependencies of NeuroM are:
 * [h5py](http://www.h5py.org/)
 * [scipy](http://www.scipy.org/)
 * [matplotlib](http://www.matplotlib.org/)
-* [enum34](https://pypi.python.org/pypi/enum34/)
+* [enum-compat](https://pypi.python.org/pypi/enum-compat/)
 * [pyyaml](http://www.pyyaml.org/)
 
 

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -40,7 +40,7 @@ import neurom as nm
 from neurom import exceptions
 from neurom.apps import get_config
 from neurom.apps.morph_stats import (extract_stats, generate_flattened_dict,
-                                     get_header, sanitize_config)
+                                     get_header, sanitize_config, full_config)
 from neurom.io.utils import get_files_by_path
 from neurom.utils import NeuromJSON
 
@@ -74,6 +74,9 @@ def get_parser():
                         help='If enabled the directory is treated as a population')
 
     parser.add_argument('-C', '--config', help='Configuration File')
+    parser.add_argument('-f', '--full-config', action='store_true', default=False,
+                        help='If passed, compute statistics for all neurite types,'
+                        ' all modes and all features')
 
     parser.add_argument('-o', '--output', dest='output_file',
                         help=('Summary output file name, if it ends in .json, '
@@ -88,12 +91,17 @@ def get_parser():
 
 def main(args):
     '''main function'''
-    try:
-        config = get_config(args.config, os.path.join(CONFIG_PATH, 'morph_stats.yaml'))
-        config = sanitize_config(config)
-    except exceptions.ConfigError as e:
-        L.error(str(e))
-        sys.exit(1)
+
+    if args.full_config:
+        config = full_config()
+        assert args.config is None, '-C, --config must NOT be specified with the -f, --full-config flag'
+    else:
+        try:
+            config = get_config(args.config, os.path.join(CONFIG_PATH, 'morph_stats.yaml'))
+            config = sanitize_config(config)
+        except exceptions.ConfigError as e:
+            L.error(str(e))
+            sys.exit(1)
 
     ignored_exceptions = tuple(IGNORABLE_EXCEPTIONS[k] for k in args.ignored_exceptions)
     neurons = nm.load_neurons(get_files_by_path(args.datapath),

--- a/apps/morph_stats
+++ b/apps/morph_stats
@@ -93,8 +93,9 @@ def main(args):
     '''main function'''
 
     if args.full_config:
+        assert args.config is None, (
+            '-C, --config must NOT be specified with the' ' -f, --full-config flag')
         config = full_config()
-        assert args.config is None, '-C, --config must NOT be specified with the -f, --full-config flag'
     else:
         try:
             config = get_config(args.config, os.path.join(CONFIG_PATH, 'morph_stats.yaml'))

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -140,7 +140,7 @@ _NEURITE_MAP = {
 
 def full_config():
     '''Returns a config with all features, all modes, all neurite types'''
-    modes = ['min', 'max', 'median', 'mean', 'std', 'raw']
+    modes = ['min', 'max', 'median', 'mean', 'std']
     return {
         'neurite': {feature: modes for feature in NEURITEFEATURES},
         'neuron': {feature: modes for feature in NEURONFEATURES},

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -29,6 +29,7 @@
 '''Core code for morph_stats application'''
 import logging
 from collections import defaultdict
+from itertools import product
 import numpy as np
 import neurom as nm
 from neurom.features import NEURONFEATURES, NEURITEFEATURES
@@ -85,13 +86,13 @@ def extract_stats(neurons, config):
                 compound_stat_name = stat_name + '_' + suffix
                 data[compound_stat_name] = stat[i]
 
-    for feature_name, modes in config['neurite'].items():
-        for n in config['neurite_type']:
-            n = _NEURITE_MAP[n]
-            for mode in modes:
-                stat_name = _stat_name(feature_name, mode)
-                stat = eval_stats(nm.get(feature_name, neurons, neurite_type=n), mode)
-                _fill_compoundified(stats[n.name], stat_name, stat)
+    for (feature_name, modes), neurite_type in product(config['neurite'].items(),
+                                                       config['neurite_type']):
+        neurite_type = _NEURITE_MAP[neurite_type]
+        for mode in modes:
+            stat_name = _stat_name(feature_name, mode)
+            stat = eval_stats(nm.get(feature_name, neurons, neurite_type=neurite_type), mode)
+            _fill_compoundified(stats[neurite_type.name], stat_name, stat)
 
     for feature_name, modes in config['neuron'].items():
         for mode in modes:

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -35,6 +35,7 @@ from nose.tools import (assert_almost_equal, assert_equal,
 import neurom as nm
 from neurom.apps import morph_stats as ms
 from neurom.exceptions import ConfigError
+from neurom.features import NEURITEFEATURES, NEURONFEATURES
 
 _path = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(_path, '../../../test_data/swc')
@@ -164,8 +165,9 @@ def test_generate_flattened_dict():
 def test_full_config():
     config = ms.full_config()
     assert_equal(set(config.keys()), {'neurite', 'neuron', 'neurite_type'})
-    assert_greater_equal(len(list(config['neurite'].keys())), 48)
-    assert_greater_equal(len(list(config['neuron'].keys())), 10)
+
+    assert_equal(config['neurite'].keys(), NEURITEFEATURES.keys())
+    assert_equal(config['neuron'].keys(), NEURONFEATURES.keys())
 
 
 def test_sanitize_config():

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -27,8 +27,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from nose.tools import assert_equal, ok_, assert_true, eq_, assert_almost_equal, assert_dict_equal, assert_raises, assert_greater_equal
+
 import numpy as np
+from nose.tools import (assert_almost_equal, assert_equal,
+                        assert_greater_equal, assert_raises, ok_)
+
 import neurom as nm
 from neurom.apps import morph_stats as ms
 from neurom.exceptions import ConfigError
@@ -101,15 +104,15 @@ def test_name_correction():
 
 
 def test_eval_stats_raw_returns_list():
-    assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'raw'), [1,2,3,4])
+    assert_equal(ms.eval_stats(np.array([1, 2, 3, 4]), 'raw'), [1, 2, 3, 4])
 
 
 def test_eval_stats_empty_input_returns_none():
-    assert_true(ms.eval_stats([], 'min') is None)
+    ok_(ms.eval_stats([], 'min') is None)
 
 
 def test_eval_stats_total_returns_sum():
-    assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'total'), 10)
+    assert_equal(ms.eval_stats(np.array([1, 2, 3, 4]), 'total'), 10)
 
 
 def test_eval_stats_applies_numpy_function():
@@ -118,20 +121,20 @@ def test_eval_stats_applies_numpy_function():
     ref_array = np.arange(1, 10)
 
     for m in modes:
-        eq_(ms.eval_stats(ref_array, m),
-               getattr(np, m)(ref_array))
+        assert_equal(ms.eval_stats(ref_array, m),
+            getattr(np, m)(ref_array))
 
 
 def test_extract_stats_single_neuron():
     nrn = nm.load_neuron(os.path.join(DATA_PATH, 'Neuron.swc'))
     res = ms.extract_stats(nrn, REF_CONFIG)
-    eq_(set(res.keys()), set(REF_OUT.keys()))
-    #Note: soma radius is calculated from the sphere that gives the area
+    assert_equal(set(res.keys()), set(REF_OUT.keys()))
+    # Note: soma radius is calculated from the sphere that gives the area
     # of the cylinders described in Neuron.swc
     assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
 
     for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
-        eq_(set(res[k].keys()), set(REF_OUT[k].keys()))
+        assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
         for kk in res[k].keys():
             assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
 
@@ -142,7 +145,7 @@ def test_get_header():
                     'fake_name2': REF_OUT,
                     }
     header = ms.get_header(fake_results)
-    eq_(1 + 1 + 4 * (4 + 3), len(header))  # name + everything in REF_OUT
+    assert_equal(1 + 1 + 4 * (4 + 3), len(header))  # name + everything in REF_OUT
     ok_('name' in header)
     ok_('mean_soma_radius' in header)
 
@@ -154,8 +157,8 @@ def test_generate_flattened_dict():
                     }
     header = ms.get_header(fake_results)
     rows = list(ms.generate_flattened_dict(header, fake_results))
-    eq_(3, len(rows))  # one for fake_name[0-2]
-    eq_(1 + 1 + 4 * (4 + 3), len(rows[0]))  # name + everything in REF_OUT
+    assert_equal(3, len(rows))  # one for fake_name[0-2]
+    assert_equal(1 + 1 + 4 * (4 + 3), len(rows[0]))  # name + everything in REF_OUT
 
 
 def test_full_config():
@@ -168,8 +171,8 @@ def test_full_config():
 def test_sanitize_config():
     assert_raises(ConfigError, ms.sanitize_config, {'neurite': []})
 
-    new_config = ms.sanitize_config({}) #empty
-    eq_(2, len(new_config)) #neurite & neuron created
+    new_config = ms.sanitize_config({})  # empty
+    assert_equal(2, len(new_config))  # neurite & neuron created
 
     full_config = {
         'neurite': {
@@ -183,4 +186,4 @@ def test_sanitize_config():
         }
     }
     new_config = ms.sanitize_config(full_config)
-    eq_(3, len(new_config)) #neurite, neurite_type & neuron
+    assert_equal(3, len(new_config))  # neurite, neurite_type & neuron

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -166,8 +166,8 @@ def test_full_config():
     config = ms.full_config()
     assert_equal(set(config.keys()), {'neurite', 'neuron', 'neurite_type'})
 
-    assert_equal(config['neurite'].keys(), NEURITEFEATURES.keys())
-    assert_equal(config['neuron'].keys(), NEURONFEATURES.keys())
+    assert_equal(set(config['neurite'].keys()), set(NEURITEFEATURES.keys()))
+    assert_equal(set(config['neuron'].keys()), set(NEURONFEATURES.keys()))
 
 
 def test_sanitize_config():

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -163,8 +163,6 @@ def test_full_config():
     assert_equal(set(config.keys()), {'neurite', 'neuron', 'neurite_type'})
     assert_greater_equal(len(list(config['neurite'].keys())), 48)
     assert_greater_equal(len(list(config['neuron'].keys())), 10)
-    print(config)
-    assert_true(False)
 
 
 def test_sanitize_config():

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -27,7 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from nose import tools as nt
+from nose.tools import assert_equal, ok_, assert_true, eq_, assert_almost_equal, assert_dict_equal, assert_raises, assert_greater_equal
 import numpy as np
 import neurom as nm
 from neurom.apps import morph_stats as ms
@@ -92,24 +92,24 @@ REF_OUT = {
 
 
 def test_name_correction():
-    nt.assert_equal(ms._stat_name('foo', 'raw'), 'foo')
-    nt.assert_equal(ms._stat_name('foos', 'raw'), 'foo')
-    nt.assert_equal(ms._stat_name('foos', 'bar'), 'bar_foo')
-    nt.assert_equal(ms._stat_name('foos', 'total'), 'total_foo')
-    nt.assert_equal(ms._stat_name('soma_radii', 'total'), 'total_soma_radius')
-    nt.assert_equal(ms._stat_name('soma_radii', 'raw'), 'soma_radius')
+    assert_equal(ms._stat_name('foo', 'raw'), 'foo')
+    assert_equal(ms._stat_name('foos', 'raw'), 'foo')
+    assert_equal(ms._stat_name('foos', 'bar'), 'bar_foo')
+    assert_equal(ms._stat_name('foos', 'total'), 'total_foo')
+    assert_equal(ms._stat_name('soma_radii', 'total'), 'total_soma_radius')
+    assert_equal(ms._stat_name('soma_radii', 'raw'), 'soma_radius')
 
 
 def test_eval_stats_raw_returns_list():
-    nt.assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'raw'), [1,2,3,4])
+    assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'raw'), [1,2,3,4])
 
 
 def test_eval_stats_empty_input_returns_none():
-    nt.assert_true(ms.eval_stats([], 'min') is None)
+    assert_true(ms.eval_stats([], 'min') is None)
 
 
 def test_eval_stats_total_returns_sum():
-    nt.assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'total'), 10)
+    assert_equal(ms.eval_stats(np.array([1,2,3,4]), 'total'), 10)
 
 
 def test_eval_stats_applies_numpy_function():
@@ -118,22 +118,22 @@ def test_eval_stats_applies_numpy_function():
     ref_array = np.arange(1, 10)
 
     for m in modes:
-        nt.eq_(ms.eval_stats(ref_array, m),
+        eq_(ms.eval_stats(ref_array, m),
                getattr(np, m)(ref_array))
 
 
 def test_extract_stats_single_neuron():
     nrn = nm.load_neuron(os.path.join(DATA_PATH, 'Neuron.swc'))
     res = ms.extract_stats(nrn, REF_CONFIG)
-    nt.eq_(set(res.keys()), set(REF_OUT.keys()))
+    eq_(set(res.keys()), set(REF_OUT.keys()))
     #Note: soma radius is calculated from the sphere that gives the area
     # of the cylinders described in Neuron.swc
-    nt.assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
+    assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
 
     for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
-        nt.eq_(set(res[k].keys()), set(REF_OUT[k].keys()))
+        eq_(set(res[k].keys()), set(REF_OUT[k].keys()))
         for kk in res[k].keys():
-            nt.assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
+            assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
 
 
 def test_get_header():
@@ -142,9 +142,9 @@ def test_get_header():
                     'fake_name2': REF_OUT,
                     }
     header = ms.get_header(fake_results)
-    nt.eq_(1 + 1 + 4 * (4 + 3), len(header))  # name + everything in REF_OUT
-    nt.ok_('name' in header)
-    nt.ok_('mean_soma_radius' in header)
+    eq_(1 + 1 + 4 * (4 + 3), len(header))  # name + everything in REF_OUT
+    ok_('name' in header)
+    ok_('mean_soma_radius' in header)
 
 
 def test_generate_flattened_dict():
@@ -154,15 +154,24 @@ def test_generate_flattened_dict():
                     }
     header = ms.get_header(fake_results)
     rows = list(ms.generate_flattened_dict(header, fake_results))
-    nt.eq_(3, len(rows))  # one for fake_name[0-2]
-    nt.eq_(1 + 1 + 4 * (4 + 3), len(rows[0]))  # name + everything in REF_OUT
+    eq_(3, len(rows))  # one for fake_name[0-2]
+    eq_(1 + 1 + 4 * (4 + 3), len(rows[0]))  # name + everything in REF_OUT
+
+
+def test_full_config():
+    config = ms.full_config()
+    assert_equal(set(config.keys()), {'neurite', 'neuron', 'neurite_type'})
+    assert_greater_equal(len(list(config['neurite'].keys())), 48)
+    assert_greater_equal(len(list(config['neuron'].keys())), 10)
+    print(config)
+    assert_true(False)
 
 
 def test_sanitize_config():
-    nt.assert_raises(ConfigError, ms.sanitize_config, {'neurite': []})
+    assert_raises(ConfigError, ms.sanitize_config, {'neurite': []})
 
     new_config = ms.sanitize_config({}) #empty
-    nt.eq_(2, len(new_config)) #neurite & neuron created
+    eq_(2, len(new_config)) #neurite & neuron created
 
     full_config = {
         'neurite': {
@@ -176,4 +185,4 @@ def test_sanitize_config():
         }
     }
     new_config = ms.sanitize_config(full_config)
-    nt.eq_(3, len(new_config)) #neurite, neurite_type & neuron
+    eq_(3, len(new_config)) #neurite, neurite_type & neuron

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -46,7 +46,7 @@ from neurom.morphmath import interval_lengths
 def total_length(nrn_pop, neurite_type=NeuriteType.all):
     '''Get the total length of all sections in the group of neurons or neurites'''
     nrns = neuronfunc.neuron_population(nrn_pop)
-    return list(sum(section_lengths(n, neurite_type=neurite_type)) for n in nrns)
+    return np.array([sum(section_lengths(n, neurite_type=neurite_type)) for n in nrns])
 
 
 def n_segments(neurites, neurite_type=NeuriteType.all):
@@ -291,8 +291,9 @@ def segment_path_lengths(neurites, neurite_type=NeuriteType.all):
                 pathlength[section.id] = 0
         return pathlength[section.id]
 
-    return np.hstack([_get_pathlength(section) + sectionfunc.segment_lengths(section)
-                      for section in iter_sections(neurites, neurite_filter=neurite_filter)])
+    result = [_get_pathlength(section) + sectionfunc.segment_lengths(section)
+              for section in iter_sections(neurites, neurite_filter=neurite_filter)]
+    return np.hstack(result) if result else np.array([])
 
 
 def segment_radial_distances(neurites, neurite_type=NeuriteType.all, origin=None):
@@ -375,7 +376,7 @@ def sibling_ratios(neurites, neurite_type=NeuriteType.all, method='first'):
 
 def partition_pairs(neurites, neurite_type=NeuriteType.all):
     '''Partition pairs at bifurcation points of a collection of neurites.
-    Partition pait is defined as the number of bifurcations at the two
+    Partition pair is defined as the number of bifurcations at the two
     daughters of the bifurcating section'''
     return map(bifurcationfunc.partition_pair,
                iter_sections(neurites,

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -46,7 +46,7 @@ from neurom.morphmath import interval_lengths
 def total_length(nrn_pop, neurite_type=NeuriteType.all):
     '''Get the total length of all sections in the group of neurons or neurites'''
     nrns = neuronfunc.neuron_population(nrn_pop)
-    return np.array([sum(section_lengths(n, neurite_type=neurite_type)) for n in nrns])
+    return list(sum(section_lengths(n, neurite_type=neurite_type)) for n in nrns)
 
 
 def n_segments(neurites, neurite_type=NeuriteType.all):


### PR DESCRIPTION
Calling 'morph_stats -f' or 'morph_stats --full-config' will call collect
statistics for all features, all mode and all neurite types.

Cf Issue #702