### PR TITLE
Widespread the use of pathlib.Path

### DIFF
--- a/apps/morph_check
+++ b/apps/morph_check
@@ -32,11 +32,10 @@
 import argparse
 import json
 import logging
-import os
 import sys
+from pathlib import Path
 
 import pkg_resources
-
 from neurom.apps import get_config
 from neurom.check.runner import CheckRunner
 from neurom.exceptions import ConfigError
@@ -164,7 +163,7 @@ def main(args):
     _setup_logging(args.debug, args.log_file)
 
     try:
-        config = get_config(args.config, os.path.join(CONFIG_PATH, 'morph_check.yaml'))
+        config = get_config(args.config, Path(CONFIG_PATH, 'morph_check.yaml'))
         checker = CheckRunner(config)
     except ConfigError as e:
         L.error(str(e))

--- a/apps/raw_data_check
+++ b/apps/raw_data_check
@@ -30,7 +30,7 @@
 
 """Examples of basic data checks."""
 import argparse
-import os
+from pathlib import Path
 import sys
 
 from neurom.check import structural_checks as st_chk
@@ -81,10 +81,10 @@ def parse_args():
 
 def run(args):
     """Check if all files have a soma points and sequential ids."""
-    data_path = args.datapath
-    if os.path.isfile(data_path):
+    data_path = Path(args.datapath)
+    if data_path.is_file():
         files = [data_path]
-    elif os.path.isdir(data_path):
+    elif data_path.is_dir():
         print('Checking files in directory', data_path)
         files = get_morph_files(data_path)
     else:

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import neurom as nm
 import neurom.io
@@ -6,27 +6,26 @@ import neurom.fst._core
 from neurom.check import neuron_checks as nc
 from neurom.check import structural_checks as sc
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                        '../test_data/')
+DATA_DIR = Path(__file__).parent.parent / 'test_data/'
 
 
 class TimeLoadMorphology(object):
     def time_swc(self):
-        path = os.path.join(DATA_DIR, 'swc/Neuron.swc')
+        path = Path(DATA_DIR, 'swc/Neuron.swc')
         nm.load_neuron(path)
 
     def time_neurolucida_asc(self):
-        path = os.path.join(DATA_DIR, 'neurolucida/bio_neuron-000.asc')
+        path = Path(DATA_DIR, 'neurolucida/bio_neuron-000.asc')
         nm.load_neuron(path)
 
     def time_h5(self):
-        path = os.path.join(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
+        path = Path(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
         nm.load_neuron(path)
 
 
 class TimeFeatures(object):
     def setup(self):
-        path = os.path.join(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
+        path = Path(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
         self.neuron = nm.load_neuron(path)
 
     def time_total_length(self):
@@ -113,7 +112,7 @@ class TimeFeatures(object):
 
 class TimeChecks:
     def setup(self):
-        path = os.path.join(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
+        path = Path(DATA_DIR, 'h5/v1/bio_neuron-000.h5')
         self.data_wrapper = neurom.io.load_data(path)
         self.neuron = neurom.fst._core.FstNeuron(self.data_wrapper)
 

--- a/examples/features_graph_table.py
+++ b/examples/features_graph_table.py
@@ -29,6 +29,7 @@
 
 """Example for comparison of the same feature of multiple cells."""
 import argparse
+from pathlib import Path
 
 import pylab as pl
 import neurom as nm
@@ -106,8 +107,6 @@ def plot_feature(feature, cell):
 
 
 if __name__ == '__main__':
-    import os
-
     args = parse_args()
 
     for morph_file in get_morph_files(args.datapath):
@@ -116,5 +115,5 @@ if __name__ == '__main__':
         for _feature in args.features:
             f = plot_feature(_feature, nrn)
             figname = "{0}_{1}.eps".format(_feature, nrn.name)
-            f.savefig(os.path.join(args.odir, figname))
+            f.savefig(Path(args.odir, figname))
             pl.close(f)

--- a/examples/plot_somas.py
+++ b/examples/plot_somas.py
@@ -29,15 +29,15 @@
 
 """Load and view multiple somas."""
 
-import os
+from pathlib import Path
+
 from neurom import load_neuron
 import neurom.view.common as common
 import matplotlib.pyplot as plt
 import numpy as np
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
+DATA_PATH = Path(__file__).parent.parent / 'test_data'
+SWC_PATH = Path(DATA_PATH, 'swc')
 
 
 def random_color():
@@ -56,7 +56,7 @@ def plot_somas(somas):
 
 if __name__ == '__main__':
     #  define set of files containing relevant neurons
-    file_nms = [os.path.join(SWC_PATH, file_nm) for file_nm in ['Soma_origin.swc',
+    file_nms = [Path(SWC_PATH, file_nm) for file_nm in ['Soma_origin.swc',
                                                                 'Soma_translated_1.swc',
                                                                 'Soma_translated_2.swc']]
 

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -30,21 +30,20 @@
 import logging
 from collections import defaultdict
 from itertools import product
-import os
-import pkg_resources
-
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pkg_resources
 
 import neurom as nm
-from neurom.fst._core import FstNeuron
-from neurom.features import NEURONFEATURES, NEURITEFEATURES
 from neurom.exceptions import ConfigError
+from neurom.features import NEURITEFEATURES, NEURONFEATURES
+from neurom.fst._core import FstNeuron
 
 L = logging.getLogger(__name__)
 
-EXAMPLE_CONFIG = os.path.join(pkg_resources.resource_filename(
+EXAMPLE_CONFIG = Path(pkg_resources.resource_filename(
     'neurom', 'config'), 'morph_stats.yaml')
 
 

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 
 import numpy as np
 from nose.tools import (assert_almost_equal, assert_equal,
@@ -40,9 +40,8 @@ from neurom.exceptions import ConfigError
 from neurom.features import NEURITEFEATURES, NEURONFEATURES
 
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_PATH = DATA_PATH / 'swc'
 
 
 REF_CONFIG = {
@@ -131,7 +130,7 @@ def test_eval_stats_applies_numpy_function():
 
 
 def test_extract_stats_single_neuron():
-    nrn = nm.load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    nrn = nm.load_neuron(Path(SWC_PATH, 'Neuron.swc'))
     res = ms.extract_stats(nrn, REF_CONFIG)
     assert_equal(set(res.keys()), set(REF_OUT.keys()))
     # Note: soma radius is calculated from the sphere that gives the area
@@ -146,19 +145,19 @@ def test_extract_stats_single_neuron():
 
 def test_extract_dataframe():
     # Vanilla test
-    nrns = nm.load_neurons([os.path.join(SWC_PATH, name)
+    nrns = nm.load_neurons([Path(SWC_PATH, name)
                             for name in ['Neuron.swc', 'simple.swc']])
     actual = ms.extract_dataframe(nrns, REF_CONFIG)
-    expected = pd.read_csv(os.path.join(DATA_PATH, 'extracted-stats.csv'), index_col=0)
+    expected = pd.read_csv(Path(DATA_PATH, 'extracted-stats.csv'), index_col=0)
     assert_frame_equal(actual, expected)
 
     # Test with a single neuron in the population
-    nrns = nm.load_neurons(os.path.join(SWC_PATH, 'Neuron.swc'))
+    nrns = nm.load_neurons(Path(SWC_PATH, 'Neuron.swc'))
     actual = ms.extract_dataframe(nrns, REF_CONFIG)
     assert_frame_equal(actual, expected[expected.name == 'Neuron'], check_dtype=False)
 
     # Test with a config without the 'neuron' key
-    nrns = nm.load_neurons([os.path.join(SWC_PATH, name)
+    nrns = nm.load_neurons([Path(SWC_PATH, name)
                             for name in ['Neuron.swc', 'simple.swc']])
     config = {'neurite': {'section_lengths': ['total']},
               'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL']}
@@ -167,12 +166,12 @@ def test_extract_dataframe():
     assert_frame_equal(actual, expected)
 
     # Test with a FstNeuron argument
-    nrn = nm.load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    nrn = nm.load_neuron(Path(SWC_PATH, 'Neuron.swc'))
     actual = ms.extract_dataframe(nrn, config)
     assert_frame_equal(actual, expected[expected.name == 'Neuron'], check_dtype=False)
 
     # Test with a List[FstNeuron] argument
-    nrns = [nm.load_neuron(os.path.join(SWC_PATH, name))
+    nrns = [nm.load_neuron(Path(SWC_PATH, name))
             for name in ['Neuron.swc', 'simple.swc']]
     actual = ms.extract_dataframe(nrns, config)
     assert_frame_equal(actual, expected)

--- a/neurom/apps/tests/tests.py
+++ b/neurom/apps/tests/tests.py
@@ -26,19 +26,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-
-from nose import tools as nt
+from pathlib import Path
 
 from neurom.apps import get_config
 from neurom.exceptions import ConfigError
+from nose import tools as nt
 
 
 def test_get_config():
     # get the default
 
-    test_yaml = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             '../../config/morph_stats.yaml'))
+    test_yaml = Path(__file__).parent.parent.parent / 'config/morph_stats.yaml'
 
     expected = {'neurite': {'section_lengths': ['max', 'total'], 'section_volumes': ['total'], 'section_branch_orders': ['max']}, 'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'], 'neuron': {'soma_radii': ['mean']}}
 

--- a/neurom/check/runner.py
+++ b/neurom/check/runner.py
@@ -58,7 +58,7 @@ class CheckRunner(object):
 
         for _f in utils.get_files_by_path(path):
             L.info(SEPARATOR)
-            status, summ = self._check_file(_f)
+            status, summ = self._check_file(str(_f))
             res &= status
             if summ is not None:
                 summary.update(summ)

--- a/neurom/check/runner.py
+++ b/neurom/check/runner.py
@@ -58,7 +58,7 @@ class CheckRunner(object):
 
         for _f in utils.get_files_by_path(path):
             L.info(SEPARATOR)
-            status, summ = self._check_file(str(_f))
+            status, summ = self._check_file(_f)
             res &= status
             if summ is not None:
                 summary.update(summ)
@@ -134,7 +134,7 @@ class CheckRunner(object):
         for m, s in full_summary.items():
             self._log_msg(m, s)
 
-        return full_result, {f: full_summary}
+        return full_result, {str(f): full_summary}
 
     def _log_msg(self, msg, ok):
         """Helper to log message to the right level."""

--- a/neurom/check/tests/test_morphtree.py
+++ b/neurom/check/tests/test_morphtree.py
@@ -26,19 +26,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from copy import deepcopy
 from io import StringIO
+from pathlib import Path
+
+import numpy as np
 from neurom import load_neuron
 from neurom.check import morphtree as mt
 from neurom.core import Neurite, NeuriteType, Section
 from neurom.core.dataformat import COLS
 from nose import tools as nt
-import numpy as np
-import os
-from copy import deepcopy
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_PATH = DATA_PATH / 'swc'
 
 
 def _make_flat(neuron):
@@ -158,7 +158,7 @@ def test_is_monotonic():
 
 def test_is_flat():
 
-    neu_tree = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc')).neurites[0]
+    neu_tree = load_neuron(Path(SWC_PATH, 'Neuron.swc')).neurites[0]
 
     nt.assert_false(mt.is_flat(neu_tree, 1e-6, method='tolerance'))
     nt.assert_false(mt.is_flat(neu_tree, 0.1, method='ratio'))
@@ -191,7 +191,7 @@ def test_is_back_tracking():
 
 def test_get_flat_neurites():
 
-    n = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    n = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
 
     nt.assert_equal(len(mt.get_flat_neurites(n, 1e-6, method='tolerance')), 0)
     nt.assert_equal(len(mt.get_flat_neurites(n, 0.1, method='ratio')), 0)
@@ -204,7 +204,7 @@ def test_get_flat_neurites():
 
 def test_get_nonmonotonic_neurites():
 
-    n = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    n = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
 
     nt.assert_equal(len(mt.get_nonmonotonic_neurites(n)), 4)
 
@@ -215,5 +215,5 @@ def test_get_nonmonotonic_neurites():
 
 def test_get_back_tracking_neurites():
 
-    n = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    n = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
     nt.assert_equal(len(mt.get_back_tracking_neurites(n)), 4)

--- a/neurom/check/tests/test_neuron_checks.py
+++ b/neurom/check/tests/test_neuron_checks.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 from copy import deepcopy
 from io import StringIO
 
@@ -39,20 +39,19 @@ from neurom.check import neuron_checks as nrn_chk
 from neurom.core.dataformat import COLS
 from neurom.core.types import dendrite_filter
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
-ASC_PATH = os.path.join(DATA_PATH, 'neurolucida')
-H5V1_PATH = os.path.join(DATA_PATH, 'h5/v1')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_PATH = Path(DATA_PATH, 'swc')
+ASC_PATH = Path(DATA_PATH, 'neurolucida')
+H5V1_PATH = Path(DATA_PATH, 'h5/v1')
 
 
 def _load_neuron(name):
     if name.endswith('.swc'):
-        path = os.path.join(SWC_PATH, name)
+        path = Path(SWC_PATH, name)
     elif name.endswith('.h5'):
-        path = os.path.join(H5V1_PATH, name)
+        path = Path(H5V1_PATH, name)
     else:
-        path = os.path.join(ASC_PATH, name)
+        path = Path(ASC_PATH, name)
     return name, load_neuron(path)
 
 
@@ -281,13 +280,13 @@ def test_nonzero_section_lengths_threshold():
 
 def test_has_nonzero_soma_radius():
 
-    nrn = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+    nrn = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
     nt.assert_true(nrn_chk.has_nonzero_soma_radius(nrn))
 
 
 def test_has_nonzero_soma_radius_bad_data():
 
-    nrn = load_neuron(os.path.join(SWC_PATH, 'Single_basal.swc'))
+    nrn = load_neuron(Path(SWC_PATH, 'Single_basal.swc'))
     nt.assert_false(nrn_chk.has_nonzero_soma_radius(nrn).status)
 
 

--- a/neurom/check/tests/test_runner.py
+++ b/neurom/check/tests/test_runner.py
@@ -33,15 +33,16 @@ from nose import tools as nt
 
 from neurom.check.runner import CheckRunner
 from neurom.exceptions import ConfigError
+from pathlib import Path
 
-_path = os.path.dirname(os.path.abspath(__file__))
-SWC_PATH = os.path.join(_path, '../../../test_data/swc/')
-NRN_PATH_0 = os.path.join(SWC_PATH, 'Neuron.swc')
-NRN_PATH_1 = os.path.join(SWC_PATH, 'Neuron_zero_length_sections.swc')
-NRN_PATH_2 = os.path.join(SWC_PATH, 'Single_apical.swc')
-NRN_PATH_3 = os.path.join(SWC_PATH, 'Single_basal.swc')
-NRN_PATH_4 = os.path.join(SWC_PATH, 'Single_axon.swc')
-NRN_PATH_5 = os.path.join(SWC_PATH, 'Single_apical_no_soma.swc')
+
+SWC_PATH = Path(__file__).parent.parent.parent.parent / 'test_data/swc/'
+NRN_PATH_0 = Path(SWC_PATH, 'Neuron.swc')
+NRN_PATH_1 = Path(SWC_PATH, 'Neuron_zero_length_sections.swc')
+NRN_PATH_2 = Path(SWC_PATH, 'Single_apical.swc')
+NRN_PATH_3 = Path(SWC_PATH, 'Single_basal.swc')
+NRN_PATH_4 = Path(SWC_PATH, 'Single_axon.swc')
+NRN_PATH_5 = Path(SWC_PATH, 'Single_apical_no_soma.swc')
 
 CONFIG = {
     'checks': {
@@ -76,7 +77,7 @@ CONFIG_COLOR['color'] = True
 
 REF_0 = {
     'files': {
-        NRN_PATH_0: {
+        str(NRN_PATH_0): {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -98,7 +99,7 @@ REF_0 = {
 
 REF_1 = {
     'files': {
-        NRN_PATH_1: {
+        str(NRN_PATH_1): {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -120,7 +121,7 @@ REF_1 = {
 
 REF_2 = {
     'files': {
-        NRN_PATH_2: {
+        str(NRN_PATH_2): {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -142,7 +143,7 @@ REF_2 = {
 
 REF_3 = {
     'files': {
-        NRN_PATH_3: {
+        str(NRN_PATH_3): {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -164,7 +165,7 @@ REF_3 = {
 
 REF_4 = {
     'files': {
-        NRN_PATH_4: {
+        str(NRN_PATH_4): {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -187,7 +188,7 @@ REF_4 = {
 
 REF_5 = {
     'files': {
-        NRN_PATH_5: {
+        str(NRN_PATH_5): {
             "Is single tree": True,
             "Has soma points": False,
             "Has sequential ids": True,
@@ -246,8 +247,8 @@ def test_single_apical_no_soma():
 def test_directory_input():
     checker = CheckRunner(CONFIG)
     summ = checker.run(SWC_PATH)
-    nt.eq_(summ['files'][NRN_PATH_0]['Has axon'], True)
-    nt.eq_(summ['files'][NRN_PATH_2]['Has axon'], False)
+    nt.eq_(summ['files'][str(NRN_PATH_0)]['Has axon'], True)
+    nt.eq_(summ['files'][str(NRN_PATH_2)]['Has axon'], False)
 
 
 @nt.raises(IOError)

--- a/neurom/check/tests/test_runner.py
+++ b/neurom/check/tests/test_runner.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 from copy import copy
 
 from nose import tools as nt

--- a/neurom/check/tests/test_runner.py
+++ b/neurom/check/tests/test_runner.py
@@ -37,12 +37,12 @@ from pathlib import Path
 
 
 SWC_PATH = Path(__file__).parent.parent.parent.parent / 'test_data/swc/'
-NRN_PATH_0 = Path(SWC_PATH, 'Neuron.swc')
-NRN_PATH_1 = Path(SWC_PATH, 'Neuron_zero_length_sections.swc')
-NRN_PATH_2 = Path(SWC_PATH, 'Single_apical.swc')
-NRN_PATH_3 = Path(SWC_PATH, 'Single_basal.swc')
-NRN_PATH_4 = Path(SWC_PATH, 'Single_axon.swc')
-NRN_PATH_5 = Path(SWC_PATH, 'Single_apical_no_soma.swc')
+NRN_PATH_0 = str(Path(SWC_PATH, 'Neuron.swc'))
+NRN_PATH_1 = str(Path(SWC_PATH, 'Neuron_zero_length_sections.swc'))
+NRN_PATH_2 = str(Path(SWC_PATH, 'Single_apical.swc'))
+NRN_PATH_3 = str(Path(SWC_PATH, 'Single_basal.swc'))
+NRN_PATH_4 = str(Path(SWC_PATH, 'Single_axon.swc'))
+NRN_PATH_5 = str(Path(SWC_PATH, 'Single_apical_no_soma.swc'))
 
 CONFIG = {
     'checks': {
@@ -77,7 +77,7 @@ CONFIG_COLOR['color'] = True
 
 REF_0 = {
     'files': {
-        str(NRN_PATH_0): {
+        NRN_PATH_0: {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -99,7 +99,7 @@ REF_0 = {
 
 REF_1 = {
     'files': {
-        str(NRN_PATH_1): {
+        NRN_PATH_1: {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -121,7 +121,7 @@ REF_1 = {
 
 REF_2 = {
     'files': {
-        str(NRN_PATH_2): {
+        NRN_PATH_2: {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -143,7 +143,7 @@ REF_2 = {
 
 REF_3 = {
     'files': {
-        str(NRN_PATH_3): {
+        NRN_PATH_3: {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -165,7 +165,7 @@ REF_3 = {
 
 REF_4 = {
     'files': {
-        str(NRN_PATH_4): {
+        NRN_PATH_4: {
             "Is single tree": True,
             "Has soma points": True,
             "Has sequential ids": True,
@@ -188,7 +188,7 @@ REF_4 = {
 
 REF_5 = {
     'files': {
-        str(NRN_PATH_5): {
+        NRN_PATH_5: {
             "Is single tree": True,
             "Has soma points": False,
             "Has sequential ids": True,
@@ -247,8 +247,8 @@ def test_single_apical_no_soma():
 def test_directory_input():
     checker = CheckRunner(CONFIG)
     summ = checker.run(SWC_PATH)
-    nt.eq_(summ['files'][str(NRN_PATH_0)]['Has axon'], True)
-    nt.eq_(summ['files'][str(NRN_PATH_2)]['Has axon'], False)
+    nt.eq_(summ['files'][NRN_PATH_0]['Has axon'], True)
+    nt.eq_(summ['files'][NRN_PATH_2]['Has axon'], False)
 
 
 @nt.raises(IOError)

--- a/neurom/check/tests/test_structural_checks.py
+++ b/neurom/check/tests/test_structural_checks.py
@@ -26,16 +26,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-from neurom.check import structural_checks as chk
+from pathlib import Path
+
 from neurom import io
+from neurom.check import structural_checks as chk
 from nose import tools as nt
 
-
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
-H5V1_PATH = os.path.join(DATA_PATH, 'h5/v1')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_PATH = Path(DATA_PATH, 'swc')
+H5V1_PATH = Path(DATA_PATH, 'h5/v1')
 
 
 class TestIOCheckFST(object):
@@ -44,7 +43,7 @@ class TestIOCheckFST(object):
 
     def test_has_sequential_ids_good_data(self):
 
-        files = [os.path.join(SWC_PATH, f)
+        files = [Path(SWC_PATH, f)
                  for f in ['Neuron.swc',
                            'Single_apical_no_soma.swc',
                            'Single_apical.swc',
@@ -64,7 +63,7 @@ class TestIOCheckFST(object):
 
     def test_has_sequential_ids_bad_data(self):
 
-        f = os.path.join(SWC_PATH, 'Neuron_missing_ids.swc')
+        f = Path(SWC_PATH, 'Neuron_missing_ids.swc')
 
         ok = chk.has_sequential_ids(self.load_data(f))
         nt.ok_(not ok)
@@ -72,7 +71,7 @@ class TestIOCheckFST(object):
 
     def test_has_increasing_ids_good_data(self):
 
-        files = [os.path.join(SWC_PATH, f)
+        files = [Path(SWC_PATH, f)
                  for f in ['Neuron.swc',
                            'Single_apical_no_soma.swc',
                            'Single_apical.swc',
@@ -92,7 +91,7 @@ class TestIOCheckFST(object):
 
     def test_has_increasing_ids_bad_data(self):
 
-        f = os.path.join(SWC_PATH, 'non_increasing_trunk_off_1_16pt.swc')
+        f = Path(SWC_PATH, 'non_increasing_trunk_off_1_16pt.swc')
 
         ok = chk.has_increasing_ids(self.load_data(f))
         nt.ok_(not ok)
@@ -100,7 +99,7 @@ class TestIOCheckFST(object):
 
     def test_is_single_tree_bad_data(self):
 
-        f = os.path.join(SWC_PATH, 'Neuron_disconnected_components.swc')
+        f = Path(SWC_PATH, 'Neuron_disconnected_components.swc')
 
         ok = chk.is_single_tree(self.load_data(f))
         nt.ok_(not ok)
@@ -108,7 +107,7 @@ class TestIOCheckFST(object):
 
     def test_is_single_tree_good_data(self):
 
-        f = os.path.join(SWC_PATH, 'Neuron.swc')
+        f = Path(SWC_PATH, 'Neuron.swc')
 
         ok = chk.is_single_tree(self.load_data(f))
         nt.ok_(ok)
@@ -116,7 +115,7 @@ class TestIOCheckFST(object):
 
     def test_has_no_missing_parents_bad_data(self):
 
-        f = os.path.join(SWC_PATH, 'Neuron_missing_parents.swc')
+        f = Path(SWC_PATH, 'Neuron_missing_parents.swc')
 
         ok = chk.no_missing_parents(self.load_data(f))
         nt.ok_(not ok)
@@ -124,46 +123,46 @@ class TestIOCheckFST(object):
 
     def test_has_no_missing_parents_good_data(self):
 
-        f = os.path.join(SWC_PATH, 'Neuron.swc')
+        f = Path(SWC_PATH, 'Neuron.swc')
 
         ok = chk.no_missing_parents(self.load_data(f))
         nt.ok_(ok)
         nt.eq_(len(ok.info), 0)
 
     def test_has_soma_points_good_data(self):
-        files = [os.path.join(SWC_PATH, f)
+        files = [Path(SWC_PATH, f)
                  for f in ['Neuron.swc',
                            'Single_apical.swc',
                            'Single_basal.swc',
                            'Single_axon.swc']]
 
-        files.append(os.path.join(H5V1_PATH, 'Neuron_2_branch.h5'))
+        files.append(Path(H5V1_PATH, 'Neuron_2_branch.h5'))
 
         for f in files:
             nt.ok_(chk.has_soma_points(self.load_data(f)))
 
     def test_has_soma_points_bad_data(self):
-        f = os.path.join(SWC_PATH, 'Single_apical_no_soma.swc')
+        f = Path(SWC_PATH, 'Single_apical_no_soma.swc')
         nt.ok_(not chk.has_soma_points(self.load_data(f)))
 
     def test_has_valid_soma_good_data(self):
-        dw = self.load_data(os.path.join(SWC_PATH, 'Neuron.swc'))
+        dw = self.load_data(Path(SWC_PATH, 'Neuron.swc'))
         nt.ok_(chk.has_valid_soma(dw))
-        dw = self.load_data(os.path.join(H5V1_PATH, 'Neuron.h5'))
+        dw = self.load_data(Path(H5V1_PATH, 'Neuron.h5'))
         nt.ok_(chk.has_valid_soma(dw))
 
     def test_has_valid_soma_bad_data(self):
-        dw = self.load_data(os.path.join(SWC_PATH, 'Single_apical_no_soma.swc'))
+        dw = self.load_data(Path(SWC_PATH, 'Single_apical_no_soma.swc'))
         nt.ok_(not chk.has_valid_soma(dw))
 
     def test_has_finite_radius_neurites_good_data(self):
-        files = [os.path.join(SWC_PATH, f)
+        files = [Path(SWC_PATH, f)
                  for f in ['Neuron.swc',
                            'Single_apical.swc',
                            'Single_basal.swc',
                            'Single_axon.swc']]
 
-        files.append(os.path.join(H5V1_PATH, 'Neuron_2_branch.h5'))
+        files.append(Path(H5V1_PATH, 'Neuron_2_branch.h5'))
 
         for f in files:
             ok = chk.has_all_finite_radius_neurites(self.load_data(f))
@@ -171,7 +170,7 @@ class TestIOCheckFST(object):
             nt.ok_(len(ok.info) == 0)
 
     def test_has_finite_radius_neurites_bad_data(self):
-        f = os.path.join(SWC_PATH, 'Neuron_zero_radius.swc')
+        f = Path(SWC_PATH, 'Neuron_zero_radius.swc')
         ok = chk.has_all_finite_radius_neurites(self.load_data(f))
         nt.ok_(not ok)
         nt.ok_(list(ok.info) == [194, 210, 246, 304, 493])
@@ -189,11 +188,11 @@ class TestIOCheckFST(object):
             return False
 
     def test_has_valid_neurites_good_data(self):
-        dw = self.load_data(os.path.join(SWC_PATH, 'Neuron.swc'))
+        dw = self.load_data(Path(SWC_PATH, 'Neuron.swc'))
         nt.ok_(chk.has_valid_neurites(dw))
-        dw = self.load_data(os.path.join(H5V1_PATH, 'Neuron.h5'))
+        dw = self.load_data(Path(H5V1_PATH, 'Neuron.h5'))
         nt.ok_(chk.has_valid_neurites(dw))
 
     def test_has_valid_neurites_bad_data(self):
-        dw = self.load_data(os.path.join(SWC_PATH, 'Soma_origin.swc'))
+        dw = self.load_data(Path(SWC_PATH, 'Soma_origin.swc'))
         nt.ok_(not chk.has_valid_neurites(dw))

--- a/neurom/core/tests/test_iter.py
+++ b/neurom/core/tests/test_iter.py
@@ -26,9 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 from io import StringIO
-from os.path import join as joinp
 
 from nose import tools as nt
 from numpy.testing import assert_array_equal
@@ -37,19 +36,18 @@ import neurom as nm
 from neurom import COLS, core, load_neuron
 from neurom.core import NeuriteIter, Tree
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = joinp(_path, '../../../test_data')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
 
-NRN1 = load_neuron(joinp(DATA_PATH, 'swc/Neuron.swc'))
+NRN1 = load_neuron(Path(DATA_PATH, 'swc/Neuron.swc'))
 
 NEURONS = [NRN1,
-           load_neuron(joinp(DATA_PATH, 'swc/Single_basal.swc')),
-           load_neuron(joinp(DATA_PATH, 'swc/Neuron_small_radius.swc')),
-           load_neuron(joinp(DATA_PATH, 'swc/Neuron_3_random_walker_branches.swc')),
+           load_neuron(Path(DATA_PATH, 'swc/Single_basal.swc')),
+           load_neuron(Path(DATA_PATH, 'swc/Neuron_small_radius.swc')),
+           load_neuron(Path(DATA_PATH, 'swc/Neuron_3_random_walker_branches.swc')),
            ]
 TOT_NEURITES = sum(len(N.neurites) for N in NEURONS)
 
-REVERSED_NEURITES = load_neuron(joinp(DATA_PATH, 'swc/ordering/reversed_NRN_neurite_order.swc'))
+REVERSED_NEURITES = load_neuron(Path(DATA_PATH, 'swc/ordering/reversed_NRN_neurite_order.swc'))
 
 POP = core.Population(NEURONS, name='foo')
 

--- a/neurom/core/tests/test_neuron.py
+++ b/neurom/core/tests/test_neuron.py
@@ -26,31 +26,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 from copy import deepcopy
 from pathlib import Path
 
+import neurom as nm
 import numpy as np
+from neurom.core import graft_neuron, iter_segments
 from nose import tools as nt
 
-import neurom as nm
-from neurom.core import graft_neuron, iter_segments
-
-_path = os.path.dirname(os.path.abspath(__file__))
-SWC_PATH = os.path.join(_path, '../../../test_data/swc/')
+SWC_PATH = Path(__file__).parent.parent.parent.parent / 'test_data/swc/'
 
 
 def test_load_neuron_pathlib():
     nrn1 = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
 
 def test_deep_copy():
-    nrn1 = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+    nrn1 = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
     nrn2 = deepcopy(nrn1)
     check_cloned_neuron(nrn1, nrn2)
 
 
 def test_graft_neuron():
-    nrn1 = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+    nrn1 = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
     basal_dendrite = nrn1.neurites[0]
     nrn2 = graft_neuron(basal_dendrite.root_node)
     nt.assert_equal(len(nrn2.neurites), 1)
@@ -91,6 +88,6 @@ def check_cloned_neuron(nrn1, nrn2):
 
 
 def test_str():
-    n = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+    n = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
     nt.ok_('Neuron' in str(n))
     nt.ok_('Section' in str(n.neurites[0].root_node))

--- a/neurom/core/tests/test_population.py
+++ b/neurom/core/tests/test_population.py
@@ -26,19 +26,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 from os.path import join as joinp
 
 from nose import tools as nt
 from neurom.core.population import Population
 from neurom import load_neuron
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = joinp(_path, '../../../test_data')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
 
-NRN1 = load_neuron(joinp(DATA_PATH, 'swc/Neuron.swc'))
-NRN2 = load_neuron(joinp(DATA_PATH, 'swc/Single_basal.swc'))
-NRN3 = load_neuron(joinp(DATA_PATH, 'swc/Neuron_small_radius.swc'))
+NRN1 = load_neuron(Path(DATA_PATH, 'swc/Neuron.swc'))
+NRN2 = load_neuron(Path(DATA_PATH, 'swc/Single_basal.swc'))
+NRN3 = load_neuron(Path(DATA_PATH, 'swc/Neuron_small_radius.swc'))
 
 NEURONS = [NRN1, NRN2, NRN3]
 TOT_NEURITES = sum(len(N.neurites) for N in NEURONS)

--- a/neurom/core/tests/test_population.py
+++ b/neurom/core/tests/test_population.py
@@ -27,7 +27,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from pathlib import Path
-from os.path import join as joinp
 
 from nose import tools as nt
 from neurom.core.population import Population

--- a/neurom/features/tests/test_bifurcationfunc.py
+++ b/neurom/features/tests/test_bifurcationfunc.py
@@ -28,7 +28,7 @@
 
 """Test neurom._bifurcationfunc functionality."""
 
-import os
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -46,13 +46,12 @@ from neurom.exceptions import NeuroMError
 # the should use the aliasing used in fst/tests module files
 from neurom.features import bifurcationfunc as bf
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_PWD, '../../../test_data/')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
-SIMPLE = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+DATA_PATH = Path(__file__).parent / '../../../test_data/'
+SWC_PATH = Path(DATA_PATH, 'swc')
+SIMPLE = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
 with warnings.catch_warnings(record=True):
-    SIMPLE2 = load_neuron(os.path.join(DATA_PATH, 'neurolucida', 'not_too_complex.asc'))
-    MULTIFURCATION = load_neuron(os.path.join(DATA_PATH, 'neurolucida', 'multifurcation.asc'))
+    SIMPLE2 = load_neuron(Path(DATA_PATH, 'neurolucida', 'not_too_complex.asc'))
+    MULTIFURCATION = load_neuron(Path(DATA_PATH, 'neurolucida', 'multifurcation.asc'))
 
 
 def test_local_bifurcation_angle():
@@ -60,10 +59,12 @@ def test_local_bifurcation_angle():
     nt.ok_(bf.local_bifurcation_angle(SIMPLE.sections[4]) == np.pi)
     assert_raises(NeuroMError, bf.local_bifurcation_angle, SIMPLE.sections[0])
 
+
 def test_remote_bifurcation_angle():
     nt.ok_(bf.remote_bifurcation_angle(SIMPLE.sections[1]) == np.pi)
     nt.ok_(bf.remote_bifurcation_angle(SIMPLE.sections[4]) == np.pi)
     assert_raises(NeuroMError, bf.local_bifurcation_angle, SIMPLE.sections[0])
+
 
 def test_bifurcation_partition():
     root = SIMPLE2.neurites[0].root_node
@@ -75,6 +76,7 @@ def test_bifurcation_partition():
 
     multifurcation_section = MULTIFURCATION.neurites[0].root_node.children[0]
     assert_raises(NeuroMError, bf.bifurcation_partition, multifurcation_section)
+
 
 def test_partition_asymmetry():
     root = SIMPLE2.neurites[0].root_node
@@ -104,6 +106,7 @@ def test_sibling_ratio():
     assert_raises(NeuroMError, bf.sibling_ratio, multifurcation_section)
 
     assert_raises(ValueError, bf.sibling_ratio, root, method='unvalid-method')
+
 
 def test_diameter_power_relation():
     root = SIMPLE2.neurites[0].root_node

--- a/neurom/features/tests/test_core.py
+++ b/neurom/features/tests/test_core.py
@@ -28,7 +28,7 @@
 
 """Test neurom.features._core module."""
 
-import os
+from pathlib import Path
 from copy import deepcopy
 
 import numpy as np
@@ -37,10 +37,9 @@ from nose import tools as nt
 from neurom import io as _io
 from neurom.fst import _core
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_ROOT = os.path.join(_path, '../../../test_data')
-DATA_PATH = os.path.join(_path, '../../../test_data/valid_set')
-FILENAMES = [os.path.join(DATA_PATH, f)
+DATA_ROOT = Path(__file__).parent / '../../../test_data'
+DATA_PATH = DATA_ROOT / 'valid_set'
+FILENAMES = [Path(DATA_PATH, f)
              for f in ['Neuron.swc', 'Neuron_h5v1.h5', 'Neuron_h5v2.h5']]
 
 

--- a/neurom/features/tests/test_feature_compat.py
+++ b/neurom/features/tests/test_feature_compat.py
@@ -29,8 +29,8 @@
 neurom._point_neurite.features"""
 
 import json
-import os
 import warnings
+from pathlib import Path
 from itertools import chain
 
 from nose import tools as nt
@@ -49,18 +49,17 @@ from neurom.features import neuronfunc as _nrn
 from neurom.features import sectionfunc as _sec
 from neurom.features.tests.utils import _close, _equal
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-SWC_DATA_PATH = os.path.join(_PWD, '../../../test_data/swc')
-H5V1_DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v1')
-H5V2_DATA_PATH = os.path.join(_PWD, '../../../test_data/h5/v2')
+DATA_PATH =  Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_DATA_PATH = DATA_PATH / 'swc'
+H5V1_DATA_PATH = DATA_PATH / 'h5/v1'
+H5V2_DATA_PATH = DATA_PATH / 'h5/v2'
 MORPH_FILENAME = 'Neuron.h5'
 SWC_MORPH_FILENAME = 'Neuron.swc'
 
 REF_NEURITE_TYPES = [NeuriteType.apical_dendrite, NeuriteType.basal_dendrite,
                      NeuriteType.basal_dendrite, NeuriteType.axon]
 
-json_data = json.load(open(
-    os.path.join(_PWD, '../../../test_data/dataset/point_neuron_feature_values.json')))
+json_data = json.load(open(Path(DATA_PATH, 'dataset/point_neuron_feature_values.json')))
 
 
 def get(feat, neurite_format, **kwargs):
@@ -195,7 +194,7 @@ class TestH5V1(SectionTreeBase):
 
     def setUp(self):
         super(TestH5V1, self).setUp()
-        self.sec_nrn = nm.load_neuron(os.path.join(H5V1_DATA_PATH, MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(Path(H5V1_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
 
     # Overriding soma values as the same soma points in SWC and ASC have different
@@ -216,7 +215,7 @@ class TestH5V2(SectionTreeBase):
 
     def setUp(self):
         super(TestH5V2, self).setUp()
-        self.sec_nrn = nm.load_neuron(os.path.join(H5V2_DATA_PATH, MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(Path(H5V2_DATA_PATH, MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
 
     # Overriding soma values as the same soma points in SWC and ASC have different
@@ -237,7 +236,7 @@ class TestSWC(SectionTreeBase):
 
     def setUp(self):
         self.ref_nrn = 'swc'
-        self.sec_nrn = nm.load_neuron(os.path.join(SWC_DATA_PATH, SWC_MORPH_FILENAME))
+        self.sec_nrn = nm.load_neuron(Path(SWC_DATA_PATH, SWC_MORPH_FILENAME))
         self.sec_nrn_trees = [n.root_node for n in self.sec_nrn.neurites]
         self.ref_types = [NeuriteType.axon,
                           NeuriteType.basal_dendrite,

--- a/neurom/features/tests/test_get_features.py
+++ b/neurom/features/tests/test_get_features.py
@@ -28,32 +28,35 @@
 
 """Test neurom.features_get features."""
 
-import os
 import math
-import numpy as np
 from io import StringIO
-from numpy.testing import assert_allclose
-from nose import tools as nt
+from pathlib import Path
+
 import neurom as nm
-from neurom.core.types import NeuriteType
+import numpy as np
+from neurom import (core, features, iter_neurites, iter_sections, load_neuron,
+                    load_neurons)
 from neurom.core.population import Population
-from neurom import (core, load_neurons, iter_neurites, iter_sections,
-                    load_neuron, features)
-from neurom.features import get as get_feature
-from neurom.features import NEURITEFEATURES
-from neurom.features import neuritefunc as nf
+from neurom.core.types import NeuriteType
 from neurom.core.types import tree_type_checker as _is_type
 from neurom.exceptions import NeuroMError
+from neurom.features import NEURITEFEATURES
+from neurom.features import get as get_feature
+from neurom.features import neuritefunc as nf
+from nose import tools as nt
+from numpy.testing import assert_allclose
 
-
-_PWD = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_PWD, '../../../test_data')
-NRN_FILES = [os.path.join(DATA_PATH, 'h5/v1', f)
+DATA_PATH = Path(__file__).parent / '../../../test_data'
+NRN_FILES = [Path(DATA_PATH, 'h5/v1', f)
              for f in ('Neuron.h5', 'Neuron_2_branch.h5', 'bio_neuron-001.h5')]
 
 NRNS = load_neurons(NRN_FILES)
 NRN = NRNS[0]
 POP = Population(NRNS)
+
+SWC_PATH = Path(DATA_PATH, 'swc')
+NEURON_PATH = Path(SWC_PATH, 'Neuron.swc')
+NEURON = load_neuron(NEURON_PATH)
 
 NEURITES = (NeuriteType.axon,
             NeuriteType.apical_dendrite,
@@ -232,30 +235,31 @@ def test_total_length_pop():
                 }
     assert_features_for_neurite(feat, POP, expected, exact=False)
 
+
 def test_segment_radii_pop():
 
     feat = 'segment_radii'
 
     assert_allclose(_stats(get_feature(feat, POP)),
-                       (0.079999998211860657,
+                    (0.079999998211860657,
                         1.2150000333786011,
                         1301.9191725363567,
                         0.20222416473071708))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.all)),
-                       (0.079999998211860657,
+                    (0.079999998211860657,
                         1.2150000333786011,
                         1301.9191725363567,
                         0.20222416473071708))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.13142434507608414,
+                    (0.13142434507608414,
                         1.0343990325927734,
                         123.41135908663273,
                         0.58767313850777492))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.079999998211860657,
+                    (0.079999998211860657,
                         1.2150000333786011,
                         547.43900821779164,
                         0.42078324997524336))
@@ -266,25 +270,25 @@ def test_segment_radii_nrn():
     feat = 'segment_radii'
 
     assert_allclose(_stats(get_feature(feat, NRN)),
-                       (0.12087134271860123,
+                    (0.12087134271860123,
                         1.0343990325927734,
                         507.01994501426816,
                         0.60359517263603357))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.all)),
-                       (0.12087134271860123,
+                    (0.12087134271860123,
                         1.0343990325927734,
                         507.01994501426816,
                         0.60359517263603357))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.13142434507608414,
+                    (0.13142434507608414,
                         1.0343990325927734,
                         123.41135908663273,
                         0.58767313850777492))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.14712842553853989,
+                    (0.14712842553853989,
                         1.0215770602226257,
                         256.71241207793355,
                         0.61122002875698467))
@@ -295,16 +299,16 @@ def test_segment_meander_angles_pop():
     feat = 'segment_meander_angles'
 
     assert_allclose(_stats(get_feature(feat, POP)),
-                       (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395))
+                    (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.all)),
-                       (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395))
+                    (0.0, 3.1415926535897931, 14637.977670710961, 2.3957410263029395))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884))
+                    (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.0, 3.1415926535897931, 2926.2411975307768, 2.4084289691611334))
+                    (0.0, 3.1415926535897931, 2926.2411975307768, 2.4084289691611334))
 
 
 def test_segment_meander_angles_nrn():
@@ -312,16 +316,16 @@ def test_segment_meander_angles_nrn():
     feat = 'segment_meander_angles'
 
     assert_allclose(_stats(get_feature(feat, NRN)),
-                       (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562))
+                    (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.all)),
-                       (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562))
+                    (0.326101999292573, 3.129961675751181, 1842.351779156608, 2.4369732528526562))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884))
+                    (0.326101999292573, 3.0939261437163492, 461.98168732359414, 2.4443475519766884))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.47318725279312024, 3.129961675751181, 926.33847274926438, 2.4506308802890593))
+                    (0.47318725279312024, 3.129961675751181, 926.33847274926438, 2.4506308802890593))
 
 
 def test_neurite_volumes_nrn():
@@ -329,43 +333,39 @@ def test_neurite_volumes_nrn():
     feat = 'neurite_volumes'
 
     assert_allclose(_stats(get_feature(feat, NRN)),
-                       (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552))
+                    (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.all)),
-                       (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552))
+                    (271.94122143951864, 281.24754646913954, 1104.9077698137021, 276.22694245342552))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.axon)),
-                       (276.73860261723024, 276.73860261723024, 276.73860261723024, 276.73860261723024))
-
+                    (276.73860261723024, 276.73860261723024, 276.73860261723024, 276.73860261723024))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
-                       (274.98039928781355, 281.24754646913954, 556.22794575695309, 278.11397287847655))
-
+                    (274.98039928781355, 281.24754646913954, 556.22794575695309, 278.11397287847655))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
-                       (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864))
+                    (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864))
 
 
 def test_neurite_volumes_pop():
 
     feat = 'neurite_volumes'
 
-
     assert_allclose(_stats(get_feature(feat, POP)),
-                       (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839))
+                    (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.all)),
-                       (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839))
+                    (28.356406629821159, 281.24754646913954, 2249.4613918388391, 224.9461391838839))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.axon)),
-                       (276.58135508666612, 277.5357232437392, 830.85568094763551, 276.95189364921185))
-
+                    (276.58135508666612, 277.5357232437392, 830.85568094763551, 276.95189364921185))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
-                       (28.356406629821159, 281.24754646913954, 1146.6644894516851, 191.1107482419475))
+                    (28.356406629821159, 281.24754646913954, 1146.6644894516851, 191.1107482419475))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
-                       (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864))
+                    (271.94122143951864, 271.94122143951864, 271.94122143951864, 271.94122143951864))
 
 
 def test_neurite_density_nrn():
@@ -373,19 +373,19 @@ def test_neurite_density_nrn():
     feat = 'neurite_volume_density'
 
     assert_allclose(_stats(get_feature(feat, NRN)),
-                       (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704))
+                    (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.all)),
-                       (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704))
+                    (0.24068543213643726, 0.52464681266899216, 1.4657913638494682, 0.36644784096236704))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.axon)),
-                       (0.26289304906104355, 0.26289304906104355, 0.26289304906104355, 0.26289304906104355))
+                    (0.26289304906104355, 0.26289304906104355, 0.26289304906104355, 0.26289304906104355))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.24068543213643726, 0.52464681266899216, 0.76533224480542938, 0.38266612240271469))
+                    (0.24068543213643726, 0.52464681266899216, 0.76533224480542938, 0.38266612240271469))
 
     assert_allclose(_stats(get_feature(feat, NRN, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519))
+                    (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519))
 
 
 def test_neurite_density_pop():
@@ -393,19 +393,19 @@ def test_neurite_density_pop():
     feat = 'neurite_volume_density'
 
     assert_allclose(_stats(get_feature(feat, POP)),
-                       (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539))
+                    (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.all)),
-                       (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539))
+                    (6.1847539631150784e-06, 0.52464681266899216, 1.9767794901940539, 0.19767794901940539))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.axon)),
-                       (6.1847539631150784e-06, 0.26465213325053372, 0.5275513670655404, 0.17585045568851346))
+                    (6.1847539631150784e-06, 0.26465213325053372, 0.5275513670655404, 0.17585045568851346))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.basal_dendrite)),
-                       (0.00034968816544949771, 0.52464681266899216, 1.0116620531455183, 0.16861034219091972))
+                    (0.00034968816544949771, 0.52464681266899216, 1.0116620531455183, 0.16861034219091972))
 
     assert_allclose(_stats(get_feature(feat, POP, neurite_type=NeuriteType.apical_dendrite)),
-                       (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519))
+                    (0.43756606998299519, 0.43756606998299519, 0.43756606998299519, 0.43756606998299519))
 
 
 def test_segment_meander_angles_single_section():
@@ -436,7 +436,7 @@ def test_neurite_features_accept_single_tree():
     for f in features:
         ret = get_feature(f, NRN.neurites[0])
         nt.ok_(ret.dtype.kind in ('i', 'f'))
-        nt.ok_(len(ret) or len(ret) == 0) #  make sure that len() resolves
+        nt.ok_(len(ret) or len(ret) == 0)  # make sure that len() resolves
 
 
 def test_register_neurite_feature_nrns():
@@ -505,14 +505,6 @@ def test_register_neurite_feature_pop():
 @nt.raises(NeuroMError)
 def test_register_existing_feature_raises():
     features.register_neurite_feature('total_length', lambda n: None)
-
-
-_PWD = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_PWD, '../../../test_data')
-
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
-NEURON_PATH = os.path.join(SWC_PATH, 'Neuron.swc')
-NEURON = load_neuron(NEURON_PATH)
 
 
 def test_section_lengths():
@@ -628,7 +620,8 @@ def test_remote_bifurcation_angles():
     remote_bifangles = get_feature('remote_bifurcation_angles', NEURON)
     nt.eq_(len(remote_bifangles), 40)
     assert_allclose(remote_bifangles, ref_remote_bifangles)
-    remote_bifangles = get_feature('remote_bifurcation_angles', NEURON, neurite_type=NeuriteType.all)
+    remote_bifangles = get_feature('remote_bifurcation_angles',
+                                   NEURON, neurite_type=NeuriteType.all)
     nt.eq_(len(remote_bifangles), 40)
     assert_allclose(remote_bifangles, ref_remote_bifangles)
 
@@ -661,7 +654,7 @@ def test_segment_radial_distances_origin():
     nt.ok_(np.all(rad_dists_origin == ref_segs_origin))
     nt.ok_(np.all(rad_dists_origin != ref_segs))
 
-    nrns = [nm.load_neuron(os.path.join(SWC_PATH, f)) for
+    nrns = [nm.load_neuron(Path(SWC_PATH, f)) for
             f in ('point_soma_single_neurite.swc', 'point_soma_single_neurite2.swc')]
     pop = Population(nrns)
     rad_dist_nrns = []
@@ -681,7 +674,7 @@ def test_section_radial_distances_endpoint():
     nt.eq_(len(rad_dists), 84)
     nt.ok_(np.all(rad_dists == ref_sec_rad_dist))
 
-    nrns = [nm.load_neuron(os.path.join(SWC_PATH, f)) for
+    nrns = [nm.load_neuron(Path(SWC_PATH, f)) for
             f in ('point_soma_single_neurite.swc', 'point_soma_single_neurite2.swc')]
     pop = Population(nrns)
     rad_dist_nrns = [nm.get('section_radial_distances', nrn) for nrn in nrns]
@@ -712,11 +705,13 @@ def test_number_of_sections_axon():
 
 
 def test_number_of_sections_basal():
-    nt.eq_(get_feature('number_of_sections', NEURON, neurite_type=NeuriteType.basal_dendrite)[0], 42)
+    nt.eq_(get_feature('number_of_sections', NEURON,
+                       neurite_type=NeuriteType.basal_dendrite)[0], 42)
 
 
 def test_n_sections_apical():
-    nt.eq_(get_feature('number_of_sections', NEURON, neurite_type=NeuriteType.apical_dendrite)[0], 21)
+    nt.eq_(get_feature('number_of_sections', NEURON,
+                       neurite_type=NeuriteType.apical_dendrite)[0], 21)
 
 
 def test_section_number_invalid():
@@ -737,13 +732,15 @@ def test_per_neurite_number_of_sections_axon():
 
 
 def test_n_sections_per_neurite_basal():
-    nsecs = get_feature('number_of_sections_per_neurite', NEURON, neurite_type=NeuriteType.basal_dendrite)
+    nsecs = get_feature('number_of_sections_per_neurite', NEURON,
+                        neurite_type=NeuriteType.basal_dendrite)
     nt.eq_(len(nsecs), 2)
     nt.ok_(np.all(nsecs == [21, 21]))
 
 
 def test_n_sections_per_neurite_apical():
-    nsecs = get_feature('number_of_sections_per_neurite', NEURON, neurite_type=NeuriteType.apical_dendrite)
+    nsecs = get_feature('number_of_sections_per_neurite', NEURON,
+                        neurite_type=NeuriteType.apical_dendrite)
     nt.eq_(len(nsecs), 1)
     nt.ok_(np.all(nsecs == [21]))
 
@@ -753,7 +750,8 @@ def test_neurite_number():
     nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.all)[0], 4)
     nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.axon)[0], 1)
     nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.basal_dendrite)[0], 2)
-    nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.apical_dendrite)[0], 1)
+    nt.eq_(get_feature('number_of_neurites', NEURON,
+                       neurite_type=NeuriteType.apical_dendrite)[0], 1)
     nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.soma)[0], 0)
     nt.eq_(get_feature('number_of_neurites', NEURON, neurite_type=NeuriteType.undefined)[0], 0)
 
@@ -824,6 +822,7 @@ def test_section_path_distances_endpoint():
     nt.eq_(len(path_lengths), 84)
     nt.ok_(np.all(path_lengths == ref_sec_path_len))
 
+
 @nt.nottest  # test_get_segment_lengths is disabled in test_get_features
 def test_section_path_distances_start_point():
 
@@ -832,19 +831,22 @@ def test_section_path_distances_start_point():
     nt.eq_(len(path_lengths), 84)
     nt.ok_(np.all(path_lengths == ref_sec_path_len_start))
 
+
 def test_partition():
-    nt.ok_(np.all(get_feature('partition', NRNS)[:10] == np.array([ 19.,  17.,  15.,  13.,  11.,   9.,   7.,   5.,   3.,   1.])))
+    nt.ok_(np.all(get_feature('partition', NRNS)[:10] == np.array(
+        [19.,  17.,  15.,  13.,  11.,   9.,   7.,   5.,   3.,   1.])))
+
 
 def test_partition_asymmetry():
     assert_allclose(get_feature('partition_asymmetry', NRNS)[:10], np.array([0.9, 0.88888889, 0.875,
-                                                                            0.85714286, 0.83333333,
+                                                                             0.85714286, 0.83333333,
 
-                                                                            0.8, 0.75,  0.66666667,
-                                                                            0.5,  0.]))
+                                                                             0.8, 0.75,  0.66666667,
+                                                                             0.5,  0.]))
 
 
 def test_section_strahler_orders():
-    path = os.path.join(SWC_PATH, 'strahler.swc')
+    path = Path(SWC_PATH, 'strahler.swc')
     n = nm.load_neuron(path)
     assert_allclose(get_feature('section_strahler_orders', n),
                     [4, 1, 4, 3, 2, 1, 1, 2, 1, 1, 3, 1, 3, 2, 1, 1, 2, 1, 1])

--- a/neurom/features/tests/test_neuritefunc.py
+++ b/neurom/features/tests/test_neuritefunc.py
@@ -28,7 +28,7 @@
 
 """Test neurom._neuritefunc functionality."""
 
-import os
+from pathlib import Path
 from math import pi, sqrt
 
 import numpy as np
@@ -46,11 +46,11 @@ from neurom.features import sectionfunc as sectionfunc
 from neurom.geom import convex_hull
 from neurom.features.tests.utils import _close
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
-SWC_PATH = os.path.join(_PWD, '../../../test_data/swc')
-SIMPLE = nm.load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
-NRN = nm.load_neuron(os.path.join(H5_PATH, 'Neuron.h5'))
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+H5_PATH = DATA_PATH / 'h5/v1'
+SWC_PATH = DATA_PATH / 'swc'
+SIMPLE = nm.load_neuron(Path(SWC_PATH, 'simple.swc'))
+NRN = nm.load_neuron(Path(H5_PATH, 'Neuron.h5'))
 
 
 def test_principal_direction_extents():
@@ -59,7 +59,7 @@ def test_principal_direction_extents():
                     (14.736052694538641, 12.105102672688004))
 
     # test with a realistic neuron
-    nrn = nm.load_neuron(os.path.join(H5_PATH, 'bio_neuron-000.h5'))
+    nrn = nm.load_neuron(Path(H5_PATH, 'bio_neuron-000.h5'))
 
     p_ref = [1672.9694359427331, 142.43704397865031, 226.45895382204986,
              415.50612748523838, 429.83008974193206, 165.95410536922873,

--- a/neurom/features/tests/test_neuronfunc.py
+++ b/neurom/features/tests/test_neuronfunc.py
@@ -27,7 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Test neurom._neuronfunc functionality."""
-import os
+from pathlib import Path
 import tempfile
 import warnings
 from io import StringIO
@@ -46,17 +46,16 @@ from neurom.core.population import Population
 # the should use the aliasing used in fst/tests module files
 from neurom.features import neuronfunc as _nf
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+H5_PATH = DATA_PATH / 'h5/v1'
+NRN = load_neuron(Path(H5_PATH, 'Neuron.h5'))
 
-H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
-NRN = load_neuron(os.path.join(H5_PATH, 'Neuron.h5'))
-
-SWC_PATH = os.path.join(_PWD, '../../../test_data/swc')
-SIMPLE = load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
-SIMPLE_TRUNK = load_neuron(os.path.join(SWC_PATH, 'simple_trunk.swc'))
-SWC_NRN = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
+SWC_PATH = DATA_PATH / 'swc'
+SIMPLE = load_neuron(Path(SWC_PATH, 'simple.swc'))
+SIMPLE_TRUNK = load_neuron(Path(SWC_PATH, 'simple_trunk.swc'))
+SWC_NRN = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
 with warnings.catch_warnings(record=True):
-    SWC_NRN_3PT = load_neuron(os.path.join(SWC_PATH, 'soma', 'three_pt_soma.swc'))
+    SWC_NRN_3PT = load_neuron(Path(SWC_PATH, 'soma', 'three_pt_soma.swc'))
 
 
 def test_soma_volume():
@@ -74,34 +73,42 @@ def test_soma_volume():
         ret = _nf.soma_volume(SWC_NRN_3PT)
         assert_almost_equal(ret, 50.26548245743669)
 
+
 def test_soma_volumes():
     with warnings.catch_warnings(record=True):
         ret = _nf.soma_volumes(SIMPLE)
         nt.eq_(ret, [4.1887902047863905, ])
 
+
 def test_soma_surface_area():
     ret = _nf.soma_surface_area(SIMPLE)
     nt.eq_(ret, 12.566370614359172)
+
 
 def test_soma_surface_areas():
     ret = _nf.soma_surface_areas(SIMPLE)
     nt.eq_(ret, [12.566370614359172, ])
 
+
 def test_soma_radii():
     ret = _nf.soma_radii(SIMPLE)
     nt.eq_(ret, [1., ])
+
 
 def test_trunk_section_lengths():
     ret = _nf.trunk_section_lengths(SIMPLE)
     nt.eq_(ret, [5.0, 4.0])
 
+
 def test_trunk_origin_radii():
     ret = _nf.trunk_origin_radii(SIMPLE)
     nt.eq_(ret, [1.0, 1.0])
 
+
 def test_trunk_origin_azimuths():
     ret = _nf.trunk_origin_azimuths(SIMPLE)
     nt.eq_(ret, [0.0, 0.0])
+
 
 def test_trunk_angles():
     ret = _nf.trunk_angles(SIMPLE_TRUNK)
@@ -150,7 +157,7 @@ def test_trunk_origin_elevations():
                        [])
 
     assert_array_equal(_nf.trunk_origin_elevations(pop, neurite_type=NeuriteType.apical_dendrite),
-[])
+                       [])
 
 
 @nt.raises(Exception)
@@ -185,8 +192,8 @@ def load_swc(string):
 
 
 def test_sholl_analysis_custom():
-    #recreate morphs from Fig 2 of
-    #http://dx.doi.org/10.1016/j.jneumeth.2014.01.016
+    # recreate morphs from Fig 2 of
+    # http://dx.doi.org/10.1016/j.jneumeth.2014.01.016
     radii = np.arange(10, 81, 10)
     center = 0, 0, 0
     morph_A = load_swc("""\
@@ -235,4 +242,4 @@ def test_sholl_analysis_custom():
                        """)
     nt.eq_(list(_nf.sholl_crossings(morph_C, center, radii=radii)),
            [2, 2, 2, 2, 2, 2, 10, 10])
-    #view.neuron(morph_C)[0].savefig('foo.png')
+    # view.neuron(morph_C)[0].savefig('foo.png')

--- a/neurom/features/tests/test_sectionfunc.py
+++ b/neurom/features/tests/test_sectionfunc.py
@@ -29,7 +29,7 @@
 """Test neurom.sectionfunc functionality."""
 
 from nose import tools as nt
-import os
+from pathlib import Path
 import math
 import numpy as np
 import warnings
@@ -45,12 +45,11 @@ from neurom.features import sectionfunc as _sf
 from neurom.features import neuritefunc as _nf
 from neurom import morphmath as mmth
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-H5_PATH = os.path.join(_PWD, '../../../test_data/h5/v1/')
-DATA_PATH = os.path.join(H5_PATH, 'Neuron.h5')
-SWC_PATH = os.path.join(_PWD, '../../../test_data/swc/')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+H5_PATH = Path(DATA_PATH, 'h5/v1/')
+SWC_PATH = Path(DATA_PATH, 'swc/')
 
-NRN = load_neuron(DATA_PATH)
+NRN = load_neuron(H5_PATH / 'Neuron.h5')
 
 
 def test_total_volume_per_neurite():
@@ -165,7 +164,7 @@ def test_section_meander_angles_single_segment():
 
 
 def test_strahler_order():
-    path = os.path.join(SWC_PATH, 'strahler.swc')
+    path = Path(SWC_PATH, 'strahler.swc')
     n = load_neuron(path)
     strahler_order = _sf.strahler_order(n.neurites[0].root_node)
     nt.eq_(strahler_order, 4)

--- a/neurom/fst/tests/test_core.py
+++ b/neurom/fst/tests/test_core.py
@@ -28,7 +28,7 @@
 
 """Test neurom.fst._core module."""
 
-import os
+from pathlib import Path
 from copy import deepcopy
 
 import numpy as np
@@ -37,10 +37,9 @@ from nose import tools as nt
 from neurom import io as _io
 from neurom.fst import _core
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_ROOT = os.path.join(_path, '../../../test_data')
-DATA_PATH = os.path.join(_path, '../../../test_data/valid_set')
-FILENAMES = [os.path.join(DATA_PATH, f)
+DATA_ROOT = Path(__file__).parent.parent.parent.parent / 'test_data'
+DATA_PATH = Path(DATA_ROOT, 'valid_set')
+FILENAMES = [Path(DATA_PATH, f)
              for f in ['Neuron.swc', 'Neuron_h5v1.h5', 'Neuron_h5v2.h5']]
 
 

--- a/neurom/geom/tests/test_geom.py
+++ b/neurom/geom/tests/test_geom.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 import numpy as np
 import neurom as nm
 from neurom import fst
@@ -34,9 +34,8 @@ from neurom import geom
 
 from nose import tools as nt
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-SWC_DATA_PATH = os.path.join(_PWD, '../../../test_data/swc')
-NRN = nm.load_neuron(os.path.join(SWC_DATA_PATH, 'Neuron.swc'))
+SWC_DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data/swc'
+NRN = nm.load_neuron(Path(SWC_DATA_PATH, 'Neuron.swc'))
 
 
 class PointObj(object):
@@ -58,8 +57,8 @@ def test_bounding_box():
 
 def test_bounding_box_neuron():
 
-    ref = np.array([[-40.32853516, -57.600172  , 0.],
-                    [ 64.74726272, 48.51626225, 54.20408797]])
+    ref = np.array([[-40.32853516, -57.600172, 0.],
+                    [64.74726272, 48.51626225, 54.20408797]])
 
     nt.assert_true(np.allclose(geom.bounding_box(NRN), ref))
 

--- a/neurom/geom/tests/test_transform.py
+++ b/neurom/geom/tests/test_transform.py
@@ -27,22 +27,21 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+from pathlib import Path
+
 import neurom.geom.transform as gtr
+import numpy as np
 from neurom import load_neuron
 from neurom.fst import _neuritefunc as _nf
 from nose import tools as nt
 
-import numpy as np
-import os
-
-
-TEST_UVEC =  np.array([ 0.01856633,  0.37132666,  0.92831665])
+TEST_UVEC = np.array([0.01856633,  0.37132666,  0.92831665])
 
 TEST_ANGLE = np.pi / 3.
 
-_path = os.path.dirname(os.path.abspath(__file__))
-SWC_NRN_PATH = os.path.join(_path, '../../../test_data/swc/Neuron.swc')
-H5_NRN_PATH = os.path.join(_path, '../../../test_data/h5/v1/Neuron.h5')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+H5_NRN_PATH = DATA_PATH / 'h5/v1/Neuron.h5'
+SWC_NRN_PATH = DATA_PATH / 'swc/Neuron.swc'
 
 
 def _Rx(angle):
@@ -75,16 +74,17 @@ def test_not_implemented_transform_call_raises():
         pass
 
     d = Dummy()
-    d([1,2,3])
+    d([1, 2, 3])
+
 
 @nt.raises(NotImplementedError)
 def test_translate_bad_type_raises():
-    gtr.translate("hello", [1,2,3])
+    gtr.translate("hello", [1, 2, 3])
 
 
 @nt.raises(NotImplementedError)
 def test_rotate_bad_type_raises():
-    gtr.rotate("hello", [1,0,0], math.pi)
+    gtr.rotate("hello", [1, 0, 0], math.pi)
 
 
 def test_translate_point():
@@ -118,55 +118,54 @@ ROT_270 = np.array([[0, 1, 0],
 
 def test_rotate_point():
 
-
     rot = gtr.Rotation(ROT_90)
-    nt.assert_equal(rot([2,0,0]).tolist(), [0, 2, 0])
-    nt.assert_equal(rot([0,2,0]).tolist(), [-2, 0, 0])
-    nt.assert_equal(rot([0,0,2]).tolist(), [0, 0, 2])
+    nt.assert_equal(rot([2, 0, 0]).tolist(), [0, 2, 0])
+    nt.assert_equal(rot([0, 2, 0]).tolist(), [-2, 0, 0])
+    nt.assert_equal(rot([0, 0, 2]).tolist(), [0, 0, 2])
 
     rot = gtr.Rotation(ROT_180)
-    nt.assert_equal(rot([2,0,0]).tolist(), [-2, 0, 0])
-    nt.assert_equal(rot([0,2,0]).tolist(), [0, -2, 0])
-    nt.assert_equal(rot([0,0,2]).tolist(), [0, 0, 2])
+    nt.assert_equal(rot([2, 0, 0]).tolist(), [-2, 0, 0])
+    nt.assert_equal(rot([0, 2, 0]).tolist(), [0, -2, 0])
+    nt.assert_equal(rot([0, 0, 2]).tolist(), [0, 0, 2])
 
     rot = gtr.Rotation(ROT_270)
-    nt.assert_equal(rot([2,0,0]).tolist(), [0, -2, 0])
-    nt.assert_equal(rot([0,2,0]).tolist(), [2, 0, 0])
-    nt.assert_equal(rot([0,0,2]).tolist(), [0, 0, 2])
+    nt.assert_equal(rot([2, 0, 0]).tolist(), [0, -2, 0])
+    nt.assert_equal(rot([0, 2, 0]).tolist(), [2, 0, 0])
+    nt.assert_equal(rot([0, 0, 2]).tolist(), [0, 0, 2])
 
 
 def test_rotate_points():
 
     rot = gtr.Rotation(ROT_90)
 
-    points = np.array([[2, 0,0],
-                       [0,2,0],
-                       [0,0,2],
-                       [3,0,3]])
+    points = np.array([[2, 0, 0],
+                       [0, 2, 0],
+                       [0, 0, 2],
+                       [3, 0, 3]])
 
-    nt.assert_true(np.all(rot(points) == np.array([[0,2,0],
-                                                   [-2,0,0],
-                                                   [0,0,2],
-                                                   [0,3,3]])))
+    nt.assert_true(np.all(rot(points) == np.array([[0, 2, 0],
+                                                   [-2, 0, 0],
+                                                   [0, 0, 2],
+                                                   [0, 3, 3]])))
 
     rot = gtr.Rotation(ROT_180)
-    nt.assert_true(np.all(rot(points) == np.array([[-2,0,0],
-                                                   [0,-2,0],
-                                                   [0,0,2],
-                                                   [-3,0,3]])))
+    nt.assert_true(np.all(rot(points) == np.array([[-2, 0, 0],
+                                                   [0, -2, 0],
+                                                   [0, 0, 2],
+                                                   [-3, 0, 3]])))
 
     rot = gtr.Rotation(ROT_270)
-    nt.assert_true(np.all(rot(points) == np.array([[0,-2,0],
-                                                   [2,0,0],
-                                                   [0,0,2],
-                                                   [0,-3,3]])))
+    nt.assert_true(np.all(rot(points) == np.array([[0, -2, 0],
+                                                   [2, 0, 0],
+                                                   [0, 0, 2],
+                                                   [0, -3, 3]])))
 
 
 def test_pivot_rotate_point():
 
     point = [1, 2, 3]
 
-    new_orig = np.array([10. , 45., 50.])
+    new_orig = np.array([10., 45., 50.])
 
     t = gtr.Translation(new_orig)
     t_inv = gtr.Translation(new_orig * -1)
@@ -191,7 +190,7 @@ def test_pivot_rotate_points():
                        [7, 8, 9],
                        [10, 11, 12]])
 
-    new_orig = np.array([10. , 45., 50.])
+    new_orig = np.array([10., 45., 50.])
 
     t = gtr.Translation(new_orig)
     t_inv = gtr.Translation(new_orig * -1)
@@ -220,13 +219,13 @@ def _check_fst_nrn_translate(nrn_a, nrn_b, t):
 def _check_fst_neurite_translate(nrts_a, nrts_b, t):
     # neurite sections
     for sa, sb in zip(_nf.iter_sections(nrts_a),
-                       _nf.iter_sections(nrts_b)):
+                      _nf.iter_sections(nrts_b)):
         nt.assert_true(np.allclose((sb.points[:, 0:3] - sa.points[:, 0:3]), t))
 
 
 def test_translate_fst_neuron_swc():
 
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(SWC_NRN_PATH)
     tnrn = gtr.translate(nrn, t)
     _check_fst_nrn_translate(nrn, tnrn, t)
@@ -234,7 +233,7 @@ def test_translate_fst_neuron_swc():
 
 def test_translate_fst_neurite_swc():
 
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(SWC_NRN_PATH)
     nrt_a = nrn.neurites[0]
     nrt_b = gtr.translate(nrt_a, t)
@@ -242,7 +241,7 @@ def test_translate_fst_neurite_swc():
 
 
 def test_transform_translate_neuron_swc():
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(SWC_NRN_PATH)
     tnrn = nrn.transform(gtr.Translation(t))
     _check_fst_nrn_translate(nrn, tnrn, t)
@@ -250,7 +249,7 @@ def test_transform_translate_neuron_swc():
 
 def test_translate_fst_neuron_h5():
 
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(H5_NRN_PATH)
     tnrn = gtr.translate(nrn, t)
 
@@ -259,7 +258,7 @@ def test_translate_fst_neuron_h5():
 
 def test_translate_fst_neurite_h5():
 
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(H5_NRN_PATH)
     nrt_a = nrn.neurites[0]
     nrt_b = gtr.translate(nrt_a, t)
@@ -267,7 +266,7 @@ def test_translate_fst_neurite_h5():
 
 
 def test_transform_translate_neuron_h5():
-    t = np.array([100.,100.,100.])
+    t = np.array([100., 100., 100.])
     nrn = load_neuron(H5_NRN_PATH)
     tnrn = nrn.transform(gtr.Translation(t))
     _check_fst_nrn_translate(nrn, tnrn, t)
@@ -275,6 +274,7 @@ def test_transform_translate_neuron_h5():
 
 def _apply_rot(points, rot_mat):
     return np.dot(rot_mat, np.array(points).T).T
+
 
 def _check_fst_nrn_rotate(nrn_a, nrn_b, rot_mat):
 
@@ -288,23 +288,23 @@ def _check_fst_nrn_rotate(nrn_a, nrn_b, rot_mat):
 
 def _check_fst_neurite_rotate(nrt_a, nrt_b, rot_mat):
     for sa, sb in zip(_nf.iter_sections(nrt_a),
-                       _nf.iter_sections(nrt_b)):
+                      _nf.iter_sections(nrt_b)):
         nt.assert_true(np.allclose(sb.points[:, 0:3],
                                    _apply_rot(sa.points[:, 0:3], rot_mat)))
 
 
 def test_rotate_neuron_swc():
     nrn_a = load_neuron(SWC_NRN_PATH)
-    nrn_b = gtr.rotate(nrn_a, [0,0,1], math.pi/2.0)
-    rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
+    nrn_b = gtr.rotate(nrn_a, [0, 0, 1], math.pi/2.0)
+    rot = gtr._rodrigues_to_dcm([0, 0, 1], math.pi/2.0)
     _check_fst_nrn_rotate(nrn_a, nrn_b, rot)
 
 
 def test_rotate_neurite_swc():
     nrn_a = load_neuron(SWC_NRN_PATH)
     nrt_a = nrn_a.neurites[0]
-    nrt_b = gtr.rotate(nrt_a, [0,0,1], math.pi/2.0)
-    rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
+    nrt_b = gtr.rotate(nrt_a, [0, 0, 1], math.pi/2.0)
+    rot = gtr._rodrigues_to_dcm([0, 0, 1], math.pi/2.0)
     _check_fst_neurite_rotate(nrt_a, nrt_b, rot)
 
 
@@ -317,16 +317,16 @@ def test_transform_rotate_neuron_swc():
 
 def test_rotate_neuron_h5():
     nrn_a = load_neuron(H5_NRN_PATH)
-    nrn_b = gtr.rotate(nrn_a, [0,0,1], math.pi/2.0)
-    rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
+    nrn_b = gtr.rotate(nrn_a, [0, 0, 1], math.pi/2.0)
+    rot = gtr._rodrigues_to_dcm([0, 0, 1], math.pi/2.0)
     _check_fst_nrn_rotate(nrn_a, nrn_b, rot)
 
 
 def test_rotate_neurite_h5():
     nrn_a = load_neuron(H5_NRN_PATH)
     nrt_a = nrn_a.neurites[0]
-    nrt_b = gtr.rotate(nrt_a, [0,0,1], math.pi/2.0)
-    rot = gtr._rodrigues_to_dcm([0,0,1], math.pi/2.0)
+    nrt_b = gtr.rotate(nrt_a, [0, 0, 1], math.pi/2.0)
+    rot = gtr._rodrigues_to_dcm([0, 0, 1], math.pi/2.0)
     _check_fst_neurite_rotate(nrt_a, nrt_b, rot)
 
 

--- a/neurom/io/tests/test_datawrapper.py
+++ b/neurom/io/tests/test_datawrapper.py
@@ -1,5 +1,5 @@
 """Test neurom.io.utils."""
-import os
+from pathlib import Path
 import numpy as np
 from nose import tools as nt
 

--- a/neurom/io/tests/test_h5_reader.py
+++ b/neurom/io/tests/test_h5_reader.py
@@ -26,36 +26,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import numpy as np
+from pathlib import Path
+
 import h5py
-from neurom.io import hdf5, swc
+import numpy as np
 from neurom.core.dataformat import COLS
+from neurom.io import hdf5, swc
 from nose import tools as nt
 
-
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-H5_PATH = os.path.join(DATA_PATH, 'h5')
-H5V1_PATH = os.path.join(H5_PATH, 'v1')
-H5V2_PATH = os.path.join(H5_PATH, 'v2')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+H5_PATH = Path(DATA_PATH, 'h5')
+H5V1_PATH = Path(H5_PATH, 'v1')
+H5V2_PATH = Path(H5_PATH, 'v2')
+SWC_PATH = Path(DATA_PATH, 'swc')
 
 
 def test_get_version():
-    with h5py.File(os.path.join(H5V1_PATH, 'Neuron.h5'), mode='r') as v1:
+    with h5py.File(Path(H5V1_PATH, 'Neuron.h5'), mode='r') as v1:
         nt.assert_equal(hdf5.get_version(v1), 'H5V1')
 
-    with h5py.File(os.path.join(H5V2_PATH, 'Neuron.h5'), mode='r') as v2:
+    with h5py.File(Path(H5V2_PATH, 'Neuron.h5'), mode='r') as v2:
         nt.assert_equal(hdf5.get_version(v2), 'H5V2')
     nt.assert_equal(hdf5.get_version({}), None)
 
 
 def test_unpack_h5():
-    with h5py.File(os.path.join(H5V1_PATH, 'Neuron.h5'), mode='r') as v1:
+    with h5py.File(Path(H5V1_PATH, 'Neuron.h5'), mode='r') as v1:
         pts1, grp1 = hdf5._unpack_v1(v1)
 
-    with h5py.File(os.path.join(H5V2_PATH, 'Neuron.h5'), mode='r') as v2:
+    with h5py.File(Path(H5V2_PATH, 'Neuron.h5'), mode='r') as v2:
         pts2, grp2 = hdf5._unpack_v2(v2, stage='raw')
 
     nt.assert_true(np.all(pts1 == pts2))
@@ -63,14 +62,14 @@ def test_unpack_h5():
 
 
 def test_consistency_between_v1_v2():
-    v1_data = hdf5.read(os.path.join(H5V1_PATH, 'Neuron.h5'))
-    v2_data = hdf5.read(os.path.join(H5V2_PATH, 'Neuron.h5'))
+    v1_data = hdf5.read(Path(H5V1_PATH, 'Neuron.h5'))
+    v2_data = hdf5.read(Path(H5V2_PATH, 'Neuron.h5'))
     nt.ok_(np.allclose(v1_data.data_block, v2_data.data_block))
 
 
 def test_consistency_between_h5_swc():
-    h5_data = hdf5.read(os.path.join(H5V1_PATH, 'Neuron.h5'), remove_duplicates=True)
-    swc_data = swc.read(os.path.join(SWC_PATH, 'Neuron.swc'))
+    h5_data = hdf5.read(Path(H5V1_PATH, 'Neuron.h5'), remove_duplicates=True)
+    swc_data = swc.read(Path(SWC_PATH, 'Neuron.swc'))
     nt.ok_(np.allclose(h5_data.data_block.shape, swc_data.data_block.shape))
 
 
@@ -108,16 +107,18 @@ class DataWrapper_Neuron(object):
 
 class TestDataWrapper_Neuron_H5V1(DataWrapper_Neuron):
     """Test HDF5 v1 reading."""
+
     def setup(self):
-        self.data = hdf5.read(os.path.join(H5V1_PATH, 'Neuron.h5'))
+        self.data = hdf5.read(Path(H5V1_PATH, 'Neuron.h5'))
         self.first_id = int(self.data.data_block[0][COLS.ID])
         self.rows = len(self.data.data_block)
 
 
 class TestDataWrapper_Neuron_H5V2(DataWrapper_Neuron):
     """Test HDF5 v2 reading."""
+
     def setup(self):
-        self.data = hdf5.read(os.path.join(H5V2_PATH, 'Neuron.h5'))
+        self.data = hdf5.read(Path(H5V2_PATH, 'Neuron.h5'))
         self.first_id = int(self.data.data_block[0][COLS.ID])
         self.rows = len(self.data.data_block)
 

--- a/neurom/io/tests/test_neurolucida.py
+++ b/neurom/io/tests/test_neurolucida.py
@@ -1,24 +1,20 @@
-import os
-import warnings
 import textwrap
+import warnings
 from io import StringIO
-
-import numpy as np
-from mock import patch
-from nose.tools import eq_, ok_, assert_raises
+from pathlib import Path
 
 import neurom.io as io
 import neurom.io.neurolucida as nasc
-from neurom.core.dataformat import COLS
-from neurom.exceptions import RawDataError
-from neurom.io.datawrapper import DataWrapper
+import numpy as np
+from mock import patch
 from neurom import load_neuron
-
+from neurom.core.dataformat import COLS
+from neurom.io.datawrapper import DataWrapper
+from nose.tools import eq_, ok_
 from numpy.testing import assert_array_equal
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-NEUROLUCIDA_PATH = os.path.join(DATA_PATH, 'neurolucida')
+DATA_PATH = Path(Path(__file__).parent, '../../../test_data')
+NEUROLUCIDA_PATH = Path(DATA_PATH, 'neurolucida')
 
 
 def test__match_section():
@@ -260,7 +256,7 @@ def test_read():
 
 
 def test_load_neurolucida_ascii():
-    f = os.path.join(NEUROLUCIDA_PATH, 'sample.asc')
+    f = Path(NEUROLUCIDA_PATH, 'sample.asc')
     with warnings.catch_warnings(record=True):
         ascii = io.load_data(f)
     ok_(isinstance(ascii, DataWrapper))
@@ -268,7 +264,7 @@ def test_load_neurolucida_ascii():
 
 def test_spine():
     with warnings.catch_warnings(record=True):
-        n = load_neuron(os.path.join(NEUROLUCIDA_PATH, 'spine.asc'))
+        n = load_neuron(Path(NEUROLUCIDA_PATH, 'spine.asc'))
 
     assert_array_equal(n.neurites[0].points,
                        [[ 0. ,  5. ,  0. ,  1. ],
@@ -277,4 +273,4 @@ def test_spine():
 
     # with warnings.catch_warnings(record=True):
     #     assert_raises(RawDataError,
-    #                   load_neuron, os.path.join(NEUROLUCIDA_PATH, 'broken-spine.asc'))
+    #                   load_neuron, Path(NEUROLUCIDA_PATH, 'broken-spine.asc'))

--- a/neurom/io/tests/test_swc_reader.py
+++ b/neurom/io/tests/test_swc_reader.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -38,15 +38,14 @@ from nose import tools as nt
 from nose.tools import assert_equal
 
 
-_path = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_path, '../../../test_data')
-SWC_PATH = os.path.join(DATA_PATH, 'swc')
-SWC_SOMA_PATH = os.path.join(SWC_PATH, 'soma')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+SWC_PATH = Path(DATA_PATH, 'swc')
+SWC_SOMA_PATH = Path(SWC_PATH, 'soma')
 
 
 def test_read_swc_basic_with_offset_0():
     """first ID = 0, rare to find."""
-    rdw = swc.read(os.path.join(SWC_PATH, 'sequential_trunk_off_0_16pt.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'sequential_trunk_off_0_16pt.swc'))
     nt.eq_(rdw.fmt, 'SWC')
     nt.eq_(len(rdw.data_block), 16)
     nt.eq_(np.shape(rdw.data_block), (16, 7))
@@ -54,7 +53,7 @@ def test_read_swc_basic_with_offset_0():
 
 def test_read_swc_basic_with_offset_1():
     """More normal ID numbering, starting at 1."""
-    rdw = swc.read(os.path.join(SWC_PATH, 'sequential_trunk_off_1_16pt.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'sequential_trunk_off_1_16pt.swc'))
     nt.eq_(rdw.fmt, 'SWC')
     nt.eq_(len(rdw.data_block), 16)
     nt.eq_(np.shape(rdw.data_block), (16, 7))
@@ -62,21 +61,21 @@ def test_read_swc_basic_with_offset_1():
 
 def test_read_swc_basic_with_offset_42():
     """ID numbering starting at 42."""
-    rdw = swc.read(os.path.join(SWC_PATH, 'sequential_trunk_off_42_16pt.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'sequential_trunk_off_42_16pt.swc'))
     nt.eq_(rdw.fmt, 'SWC')
     nt.eq_(len(rdw.data_block), 16)
     nt.eq_(np.shape(rdw.data_block), (16, 7))
 
 
 def test_read_single_neurite():
-    rdw = swc.read(os.path.join(SWC_PATH, 'point_soma_single_neurite.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'point_soma_single_neurite.swc'))
     nt.eq_(rdw.neurite_root_section_ids(), [1])
     nt.eq_(len(rdw.soma_points()), 1)
     nt.eq_(len(rdw.sections), 2)
 
 
 def test_read_split_soma():
-    rdw = swc.read(os.path.join(SWC_PATH, 'split_soma_single_neurites.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'split_soma_single_neurites.swc'))
     nt.eq_(rdw.neurite_root_section_ids(), [1, 3])
     nt.eq_(len(rdw.soma_points()), 3)
     nt.eq_(len(rdw.sections), 4)
@@ -92,15 +91,15 @@ def test_read_split_soma():
 
 
 def test_simple_reversed():
-    rdw = swc.read(os.path.join(SWC_PATH, 'simple_reversed.swc'))
+    rdw = swc.read(Path(SWC_PATH, 'simple_reversed.swc'))
     nt.eq_(rdw.neurite_root_section_ids(), [5, 6])
     nt.eq_(len(rdw.soma_points()), 1)
     nt.eq_(len(rdw.sections), 7)
 
 def test_custom_type():
-    neuron = load_neuron(os.path.join(SWC_PATH, 'custom_type.swc'))
+    neuron = load_neuron(Path(SWC_PATH, 'custom_type.swc'))
     assert_equal(neuron.neurites[1].type, NeuriteType.custom)
 
 def test_undefined_type():
-    neuron = load_neuron(os.path.join(SWC_PATH, 'undefined_type.swc'))
+    neuron = load_neuron(Path(SWC_PATH, 'undefined_type.swc'))
     assert_equal(neuron.neurites[1].type, NeuriteType.undefined)

--- a/neurom/io/tests/test_utils.py
+++ b/neurom/io/tests/test_utils.py
@@ -27,7 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Test neurom.io.utils."""
-import os
+from pathlib import Path
 import sys
 from io import StringIO
 from pathlib import Path
@@ -333,7 +333,7 @@ def test_load_h5_trunk_points_regression():
 
 
 def test_load_unknown_type():
-    nt.assert_raises(NeuroMError, utils.load_data, 'fake.file')
+    nt.assert_raises(NeuroMError, utils.load_data, Path('fake.file'))
 
 
 def test_NeuronLoader():

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -95,7 +95,7 @@ def get_morph_files(directory):
         list with all files with extensions '.swc' , 'h5' or '.asc' (case insensitive)
     """
     directory = Path(directory)
-    return [Path(directory, m) for m in directory.iterdir() if _is_morphology_file(m)]
+    return list(filter(_is_morphology_file, directory.iterdir()))
 
 
 def get_files_by_path(path):

--- a/neurom/tests/test_viewer.py
+++ b/neurom/tests/test_viewer.py
@@ -27,6 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+from pathlib import Path
 import shutil
 import tempfile
 import mock
@@ -43,9 +44,8 @@ from neurom import load_neuron, viewer, NeuriteType
 from nose import tools as nt
 from numpy.testing import assert_allclose, assert_array_almost_equal
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_PWD, '../../test_data/swc')
-MORPH_FILENAME = os.path.join(DATA_PATH, 'Neuron.swc')
+DATA_PATH = Path(__file__).parent.parent.parent / 'test_data/swc'
+MORPH_FILENAME = Path(DATA_PATH, 'Neuron.swc')
 
 nrn = load_neuron(MORPH_FILENAME)
 
@@ -71,7 +71,7 @@ def test_plotly_draw_neuron3d():
     plotly.draw(nrn, plane='3d', auto_open=False)
     plotly.draw(nrn.neurites[0], plane='3d', auto_open=False)
 
-    fig = plotly.draw(load_neuron(os.path.join(DATA_PATH, 'simple-different-soma.swc')),
+    fig = plotly.draw(load_neuron(Path(DATA_PATH, 'simple-different-soma.swc')),
                       auto_open=False)
     x, y, z = [fig['data'][2][key] for key in str('xyz')]
     assert_allclose(x[0, 0], 2)
@@ -135,7 +135,7 @@ def test_draw_dendrogram():
     common.plt.close('all')
 
 def test_draw_dendrogram_empty_segment():
-    neuron = load_neuron(os.path.join(DATA_PATH, 'empty_segments.swc'))
+    neuron = load_neuron(Path(DATA_PATH, 'empty_segments.swc'))
     viewer.draw(neuron, mode='dendrogram')
     common.plt.close('all')
 
@@ -159,15 +159,8 @@ def test_invalid_combo_raises():
 
 
 def test_writing_output():
-    fig_name = 'Figure.png'
-
-    tempdir = tempfile.mkdtemp('test_viewer')
-    try:
-        old_dir = os.getcwd()
-        os.chdir(tempdir)
-        viewer.draw(nrn, mode='2d', output_path='subdir')
-        nt.ok_(os.path.isfile(os.path.join(tempdir, 'subdir', fig_name)))
-    finally:
-        os.chdir(old_dir)
-        shutil.rmtree(tempdir)
+    with tempfile.TemporaryDirectory() as folder:
+        output_dir = Path(folder, 'subdir')
+        viewer.draw(nrn, mode='2d', output_path=output_dir)
+        nt.ok_((output_dir / 'Figure.png').is_file())
         common.plt.close('all')

--- a/neurom/view/common.py
+++ b/neurom/view/common.py
@@ -27,7 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Functionality for styling plots."""
-import os
+from pathlib import Path
 
 import numpy as np
 from matplotlib.patches import Polygon
@@ -124,13 +124,11 @@ def save_plot(fig, prefile='', postfile='', output_path='./', output_name='Figur
         dpi(int): Define the DPI (Dots per Inch) of the figure
         transparent(bool): If True the saved figure will have a transparent background
     """
-    if not os.path.exists(output_path):
-        os.makedirs(output_path)  # Make output directory if non-exsiting
+    output_path = Path(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
-    output = os.path.join(output_path,
-                          prefile + output_name + postfile + "." + output_format)
-
-    fig.savefig(output, dpi=dpi, transparent=transparent)
+    fig.savefig(Path(output_path, prefile + output_name + postfile + "." + output_format),
+                dpi=dpi, transparent=transparent)
 
 
 def plot_style(fig, ax,  # pylint: disable=too-many-arguments, too-many-locals

--- a/neurom/view/tests/test_common.py
+++ b/neurom/view/tests/test_common.py
@@ -27,7 +27,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from .utils import get_fig_2d, get_fig_3d # needs to be at top to trigger matplotlib Agg backend
 
-import os
+from pathlib import Path
 from nose import tools as nt
 import shutil
 import tempfile
@@ -80,25 +80,13 @@ def test_get_figure():
 
 
 def test_save_plot():
-    fig_name = 'Figure.png'
-
-    tempdir = tempfile.mkdtemp('test_common')
-    try:
-        old_dir = os.getcwd()
-        os.chdir(tempdir)
-
+    with tempfile.TemporaryDirectory() as folder:
         fig_old = plt.figure()
-        fig = save_plot(fig_old)
-        nt.ok_(os.path.isfile(fig_name))
-
-        os.remove(fig_name)
-
-        fig = save_plot(fig_old, output_path='subdir')
-        nt.ok_(os.path.isfile(os.path.join(tempdir, 'subdir', fig_name)))
-    finally:
-        os.chdir(old_dir)
-        shutil.rmtree(tempdir)
+        output_path = Path(folder, 'subdir')
+        fig = save_plot(fig_old, output_path=output_path)
+        nt.ok_(Path(output_path, 'Figure.png').is_file())
         plt.close('all')
+
 
 
 def test_plot_title():

--- a/neurom/view/tests/test_dendrogram.py
+++ b/neurom/view/tests/test_dendrogram.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from collections import namedtuple
 
 import numpy as np
@@ -9,9 +9,8 @@ import neurom.view.dendrogram as dm
 from neurom import load_neuron, get
 from neurom.core.types import NeuriteType
 
-_PWD = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH = os.path.join(_PWD, '../../../test_data/')
-NEURON_PATH = os.path.join(DATA_PATH, 'h5', 'v1', 'Neuron.h5')
+DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'
+NEURON_PATH = Path(DATA_PATH, 'h5', 'v1', 'Neuron.h5')
 
 
 def test_create_dendrogram_neuron():

--- a/neurom/view/tests/test_view.py
+++ b/neurom/view/tests/test_view.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import itertools as it
-import os
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -44,13 +44,13 @@ from .utils import (  # needs to be at top to trigger matplotlib Agg backend
     get_fig_2d, get_fig_3d)
 
 DATA_PATH = './test_data'
-SWC_PATH = os.path.join(DATA_PATH, 'swc/')
-fst_neuron = load_neuron(os.path.join(SWC_PATH, 'Neuron.swc'))
-simple_neuron = load_neuron(os.path.join(SWC_PATH, 'simple.swc'))
+SWC_PATH = Path(DATA_PATH, 'swc/')
+fst_neuron = load_neuron(Path(SWC_PATH, 'Neuron.swc'))
+simple_neuron = load_neuron(Path(SWC_PATH, 'simple.swc'))
 
 
 def test_tree():
-    neuron = load_neuron(os.path.join(SWC_PATH, 'simple-different-section-types.swc'))
+    neuron = load_neuron(Path(SWC_PATH, 'simple-different-section-types.swc'))
     expected_colors = {'black': np.array([[0., 0., 0., 1.] for _ in range(3)]),
                        None: [[1.      , 0.      , 0.      , 1.],
                               [1.      , 0.      , 0.      , 1.],
@@ -116,13 +116,13 @@ def test_neuron3d():
 
 
 def test_neuron_no_neurites():
-    filename = os.path.join(SWC_PATH, 'point_soma.swc')
+    filename = Path(SWC_PATH, 'point_soma.swc')
     with get_fig_2d() as (fig, ax):
         view.plot_neuron(ax, load_neuron(filename))
 
 
 def test_neuron3d_no_neurites():
-    filename = os.path.join(SWC_PATH, 'point_soma.swc')
+    filename = Path(SWC_PATH, 'point_soma.swc')
     with get_fig_3d() as (fig, ax):
         view.plot_neuron3d(ax, load_neuron(filename))
 

--- a/tutorial/plotly.ipynb
+++ b/tutorial/plotly.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "from neurom.view.plotly import draw\n",
     "import neurom\n",
-    "import os\n",
+    "from pathlib import Path\n",
     "\n",
-    "path = os.path.join(os.path.dirname(neurom.__file__),'../test_data/valid_set/Neuron.swc')\n",
+    "path = Path(os.path.dirname(neurom.__file__),'../test_data/valid_set/Neuron.swc')\n",
     "neuron = neurom.load_neuron(path)"
    ]
   },


### PR DESCRIPTION
- neurom.io.utils `get_files_by_path` and `get_morph_files` returns pathlib objects
- fix name == None when calling load_neuron with a pathlib object
- all unit tests use pathlib instead of os.path