### PR TITLE
Use multiprocessing in morphs_stats

### DIFF
--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -27,12 +27,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Core code for morph_stats application."""
+import os
 import logging
 from collections import defaultdict
 from itertools import product
 from pathlib import Path
 import multiprocessing
 from functools import partial
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -126,6 +128,8 @@ def extract_dataframe(neurons, config, n_workers=1):
     if n_workers == 1:
         stats = dict(map(func, neurons))
     else:
+        if n_workers > os.cpu_count():
+            warnings.warn(f'n_workers ({n_workers}) > os.cpu_count() ({os.cpu_count()}))')
         with multiprocessing.Pool(n_workers) as pool:
             stats = dict(pool.imap_unordered(func, neurons))
 
@@ -159,9 +163,6 @@ def extract_stats(neurons, config):
 
     {config_path}
     """
-    if isinstance(neurons, (str, Path)) or (isinstance(neurons, list) and
-                                            all(isinstance(nrn, (str, Path)) for nrn in neurons)):
-        neurons = nm.load_neurons(neurons)
 
     def _fill_stats_dict(data, stat_name, stat):
         """Insert the stat data in the dict.

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -30,10 +30,10 @@
 import logging
 from collections import defaultdict
 from itertools import product
+from functools import partial
 from pathlib import Path
 import multiprocessing
 from tqdm import tqdm
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -98,6 +98,7 @@ def extract_dataframe(neurons, config, n_workers=1):
                 - mode is an aggregation operation provided as a string such as:
                   ['min', 'max', 'median', 'mean', 'std', 'raw', 'total']
         n_workers (int): number of workers for multiprocessing (on collection of neurons)
+
     Returns:
         The extracted statistics
 
@@ -120,9 +121,9 @@ def extract_dataframe(neurons, config, n_workers=1):
                  stat for nrn, stat in tqdm(zip(neurons,
                                                 pool.imap(partial(extract_stats, config=config),
                                                           neurons)
-                                                ), total=len(neurons)
-                                            )
-                 }
+                                               ), total=len(neurons)
+                                           )
+                }
     columns = list(next(iter(next(iter(stats.values())).values())).keys())
 
     rows = [[name, neurite_type] + list(features.values())

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -121,9 +121,9 @@ def extract_dataframe(neurons, config, n_workers=1):
                  stat for nrn, stat in tqdm(zip(neurons,
                                                 pool.imap(partial(extract_stats, config=config),
                                                           neurons)
-                                               ), total=len(neurons)
-                                           )
-                }
+                                                ), total=len(neurons)
+                                            )
+                 }
     columns = list(next(iter(next(iter(stats.values())).values())).keys())
 
     rows = [[name, neurite_type] + list(features.values())
@@ -154,10 +154,9 @@ def extract_stats(neurons, config):
 
     {config_path}
     """
-    from neurom import load_neurons
     if isinstance(neurons, (str, Path)) or (isinstance(neurons, list) and
                                             all(isinstance(nrn, (str, Path)) for nrn in neurons)):
-        neurons = load_neurons(neurons)
+        neurons = nm.load_neurons(neurons)
 
     def _fill_stats_dict(data, stat_name, stat):
         """Insert the stat data in the dict.

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -131,6 +131,20 @@ def test_eval_stats_applies_numpy_function():
             getattr(np, m)(ref_array))
 
 
+def test_extract_stats_single_neuron():
+    nrn = nm.load_neuron(Path(SWC_PATH, 'Neuron.swc'))
+    res = ms.extract_stats(nrn, REF_CONFIG)
+    assert_equal(set(res.keys()), set(REF_OUT.keys()))
+    # Note: soma radius is calculated from the sphere that gives the area
+    # of the cylinders described in Neuron.swc
+    assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
+
+    for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
+        assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
+        for kk in res[k].keys():
+            assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
+
+
 def test_extract_dataframe():
     # Vanilla test
     nrns = nm.load_neurons([Path(SWC_PATH, name)

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -177,6 +177,11 @@ def test_extract_dataframe():
     actual = ms.extract_dataframe(nrns, config)
     assert_frame_equal(actual, expected)
 
+    # Test with a List[Path] argument
+    nrns = [Path(SWC_PATH, name) for name in ['Neuron.swc', 'simple.swc']]
+    actual = ms.extract_dataframe(nrns, config)
+    assert_frame_equal(actual, expected)
+
     # Test without any neurite_type keys, it should pick the defaults
     config = {'neurite': {'total_length_per_neurite': ['total']}}
     actual = ms.extract_dataframe(nrns, config)
@@ -192,6 +197,16 @@ def test_extract_dataframe():
               ['simple', 'all', 31.000000]])
     assert_frame_equal(actual, expected)
 
+
+def test_extract_dataframe_multiproc():
+    nrns = nm.load_neurons([Path(SWC_PATH, name)
+                            for name in ['Neuron.swc', 'simple.swc']])
+    actual = ms.extract_dataframe(nrns, REF_CONFIG, n_workers=2)
+    expected = pd.read_csv(Path(DATA_PATH, 'extracted-stats.csv'), index_col=0)
+
+    # Compare sorted DataFrame since Pool.imap_unordered disrupted the order
+    assert_frame_equal(actual.sort_values(by=['name']).reset_index(drop=True),
+                       expected.sort_values(by=['name']).reset_index(drop=True))
 
 
 def test_get_header():

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -130,31 +130,18 @@ def test_eval_stats_applies_numpy_function():
 
 
 def test_extract_stats_single_neuron():
-    nrn = nm.load_neuron(Path(SWC_PATH, 'Neuron.swc'))
-    res = ms.extract_stats(nrn, REF_CONFIG)
-    assert_equal(set(res.keys()), set(REF_OUT.keys()))
-    # Note: soma radius is calculated from the sphere that gives the area
-    # of the cylinders described in Neuron.swc
-    assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
+    path = SWC_PATH / 'Neuron.swc'
+    for nrn in (nm.load_neuron(path), path, str(path)):
+        res = ms.extract_stats(nrn, REF_CONFIG)
+        assert_equal(set(res.keys()), set(REF_OUT.keys()))
+        # Note: soma radius is calculated from the sphere that gives the area
+        # of the cylinders described in Neuron.swc
+        assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
 
-    for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
-        assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
-        for kk in res[k].keys():
-            assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
-
-
-def test_extract_stats_single_neuron_path():
-    nrn = Path(SWC_PATH, 'Neuron.swc')
-    res = ms.extract_stats(nrn, REF_CONFIG)
-    assert_equal(set(res.keys()), set(REF_OUT.keys()))
-    # Note: soma radius is calculated from the sphere that gives the area
-    # of the cylinders described in Neuron.swc
-    assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
-
-    for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
-        assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
-        for kk in res[k].keys():
-            assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
+        for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
+            assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
+            for kk in res[k].keys():
+                assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
 
 
 def test_extract_dataframe():

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -143,6 +143,20 @@ def test_extract_stats_single_neuron():
             assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
 
 
+def test_extract_stats_single_neuron_path():
+    nrn = Path(SWC_PATH, 'Neuron.swc')
+    res = ms.extract_stats(nrn, REF_CONFIG)
+    assert_equal(set(res.keys()), set(REF_OUT.keys()))
+    # Note: soma radius is calculated from the sphere that gives the area
+    # of the cylinders described in Neuron.swc
+    assert_almost_equal(res['mean_soma_radius'], REF_OUT['mean_soma_radius'])
+
+    for k in ('all', 'axon', 'basal_dendrite', 'apical_dendrite'):
+        assert_equal(set(res[k].keys()), set(REF_OUT[k].keys()))
+        for kk in res[k].keys():
+            assert_almost_equal(res[k][kk], REF_OUT[k][kk], places=3)
+
+
 def test_extract_dataframe():
     # Vanilla test
     nrns = nm.load_neurons([Path(SWC_PATH, name)

--- a/neurom/features/tests/test_get_features.py
+++ b/neurom/features/tests/test_get_features.py
@@ -436,7 +436,7 @@ def test_neurite_features_accept_single_tree():
     for f in features:
         ret = get_feature(f, NRN.neurites[0])
         nt.ok_(ret.dtype.kind in ('i', 'f'))
-        nt.ok_(len(ret) or len(ret) == 0)  # make sure that len() resolves
+        nt.ok_(len(ret) > 0)
 
 
 def test_register_neurite_feature_nrns():


### PR DESCRIPTION
Small refactoring of morphs_stats module for computational speedup, with the following changes:

1. uses pool.imap_unordered in extract_dataframe in the loop overs neurons
2. allow giving a list of str/Path instead of neuron collection (so that the expansive loadine is done in parallel, see 1.)
3. moved neurom.get outside mode loop to avoid duplicate computations