### PR TITLE
Deprecate COLS.TYPE, COLS.ID and COLS.P

### DIFF
--- a/neurom/check/structural_checks.py
+++ b/neurom/check/structural_checks.py
@@ -29,7 +29,7 @@
 """Module with consistency/validity checks for raw data  blocks."""
 import numpy as np
 from neurom.check import CheckResult
-from neurom.core.dataformat import COLS
+from neurom.core.dataformat import COLS, _COLS
 from neurom.core.dataformat import POINT_TYPE
 from neurom.core import make_soma
 from neurom.fst._core import make_neurites
@@ -43,7 +43,7 @@ def has_sequential_ids(data_wrapper):
     with their predecessor)
     """
     db = data_wrapper.data_block
-    ids = db[:, COLS.ID]
+    ids = db[:, _COLS.ID]
     steps = ids[np.where(np.diff(ids) != 1)[0] + 1].astype(int)
     return CheckResult(len(steps) == 0, steps)
 
@@ -58,7 +58,7 @@ def no_missing_parents(data_wrapper):
         CheckResult with result and list of IDs that have no parent
     """
     db = data_wrapper.data_block
-    ids = np.setdiff1d(db[:, COLS.P], db[:, COLS.ID])[1:]
+    ids = np.setdiff1d(db[:, _COLS.P], db[:, _COLS.ID])[1:]
     return CheckResult(len(ids) == 0, ids.astype(np.int) + 1)
 
 
@@ -74,7 +74,7 @@ def is_single_tree(data_wrapper):
         This assumes no_missing_parents passed.
     """
     db = data_wrapper.data_block
-    bad_ids = db[db[:, COLS.P] == -1][1:, COLS.ID]
+    bad_ids = db[db[:, _COLS.P] == -1][1:, _COLS.ID]
     return CheckResult(len(bad_ids) == 0, bad_ids.tolist())
 
 
@@ -86,7 +86,7 @@ def has_increasing_ids(data_wrapper):
         with their predecessor
     """
     db = data_wrapper.data_block
-    ids = db[:, COLS.ID]
+    ids = db[:, _COLS.ID]
     steps = ids[np.where(np.diff(ids) <= 0)[0] + 1].astype(int)
     return CheckResult(len(steps) == 0, steps)
 
@@ -98,7 +98,7 @@ def has_soma_points(data_wrapper):
         CheckResult with result
     """
     db = data_wrapper.data_block
-    return CheckResult(POINT_TYPE.SOMA in db[:, COLS.TYPE], None)
+    return CheckResult(POINT_TYPE.SOMA in db[:, _COLS.TYPE], None)
 
 
 def has_all_finite_radius_neurites(data_wrapper, threshold=0.0):
@@ -108,9 +108,9 @@ def has_all_finite_radius_neurites(data_wrapper, threshold=0.0):
         CheckResult with result and list of IDs of neurite points with zero radius
     """
     db = data_wrapper.data_block
-    neurite_ids = np.in1d(db[:, COLS.TYPE], POINT_TYPE.NEURITES)
+    neurite_ids = np.in1d(db[:, _COLS.TYPE], POINT_TYPE.NEURITES)
     zero_radius_ids = db[:, COLS.R] <= threshold
-    bad_pts = np.array(db[neurite_ids & zero_radius_ids][:, COLS.ID],
+    bad_pts = np.array(db[neurite_ids & zero_radius_ids][:, _COLS.ID],
                        dtype=int).tolist()
     return CheckResult(len(bad_pts) == 0, bad_pts)
 

--- a/neurom/core/_soma.py
+++ b/neurom/core/_soma.py
@@ -32,7 +32,7 @@ import warnings
 
 import numpy as np
 from neurom import morphmath
-from neurom.core.dataformat import COLS
+from neurom.core.dataformat import COLS, _COLS
 from neurom.exceptions import SomaError
 
 
@@ -242,9 +242,9 @@ def _get_type(points, soma_class):
                 2: None}.get(npoints, SomaSimpleContour)
 
     if(npoints == 3 and
-       points[0][COLS.P] == -1 and
-       points[1][COLS.P] == 1 and
-       points[2][COLS.P] == 1):
+       points[0][_COLS.P] == -1 and
+       points[1][_COLS.P] == 1 and
+       points[2][_COLS.P] == 1):
         warnings.warn('Using neuromorpho 3-Point soma')
         # NeuroMorpho is the main provider of morphologies, but they
         # with SWC as their default file format: they convert all

--- a/neurom/core/dataformat.py
+++ b/neurom/core/dataformat.py
@@ -27,20 +27,45 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Data format definitions."""
+import warnings
 
 
 _COL_COUNT = 7
 
 
-class COLS(object):
+class _COLS(object):
+    """A class for internal columns."""
+    TYPE, ID, P = 4, 5, 6
+
+
+class _PublicColumns(object):
     """Column labels for internal data representation."""
     COL_COUNT = _COL_COUNT
-    (X, Y, Z, R, TYPE, ID, P) = range(_COL_COUNT)
+    (X, Y, Z, R, _TYPE, _ID, _P) = range(COL_COUNT)
     XY = slice(0, 2)
     XZ = slice(0, 3, 2)
     YZ = slice(1, 3)
     XYZ = slice(0, 3)
     XYZR = slice(0, 4)
+
+    @property
+    def TYPE(self):
+        warnings.warn('Using _COLS.TYPE is now deprecated. '
+                      'Please consider using "section.type" to get the type of a section.')
+        return __COLS.TYPE
+
+    @property
+    def ID(self):
+        warnings.warn('Using _COLS.ID is now deprecated')
+        return __COLS.ID
+
+    @property
+    def P(self):
+        warnings.warn('Using _COLS.P is now deprecated')
+        return __COLS.P
+
+
+COLS = _PublicColumns()
 
 
 class POINT_TYPE(object):

--- a/neurom/core/dataformat.py
+++ b/neurom/core/dataformat.py
@@ -41,7 +41,7 @@ class _COLS(object):
 class _PublicColumns(object):
     """Column labels for internal data representation."""
     COL_COUNT = _COL_COUNT
-    (X, Y, Z, R, _TYPE, _ID, _P) = range(COL_COUNT)
+    (X, Y, Z, R) = range(4)
     XY = slice(0, 2)
     XZ = slice(0, 3, 2)
     YZ = slice(1, 3)
@@ -52,17 +52,17 @@ class _PublicColumns(object):
     def TYPE(self):
         warnings.warn('Using _COLS.TYPE is now deprecated. '
                       'Please consider using "section.type" to get the type of a section.')
-        return __COLS.TYPE
+        return _COLS.TYPE
 
     @property
     def ID(self):
         warnings.warn('Using _COLS.ID is now deprecated')
-        return __COLS.ID
+        return _COLS.ID
 
     @property
     def P(self):
         warnings.warn('Using _COLS.P is now deprecated')
-        return __COLS.P
+        return _COLS.P
 
 
 COLS = _PublicColumns()

--- a/neurom/core/point.py
+++ b/neurom/core/point.py
@@ -29,7 +29,7 @@
 """Point classes and functions."""
 
 from collections import namedtuple
-from neurom.core.dataformat import COLS
+from neurom.core.dataformat import COLS, _COLS
 
 
 Point = namedtuple('Point', ('x', 'y', 'z', 'r', 't'))
@@ -38,4 +38,4 @@ Point = namedtuple('Point', ('x', 'y', 'z', 'r', 't'))
 def as_point(row):
     """Create a Point from a data block row."""
     return Point(row[COLS.X], row[COLS.Y], row[COLS.Z],
-                 row[COLS.R], int(row[COLS.TYPE]))
+                 row[COLS.R], int(row[_COLS.TYPE]))

--- a/neurom/fst/_core.py
+++ b/neurom/fst/_core.py
@@ -33,7 +33,7 @@ from copy import deepcopy
 import numpy as np
 
 from neurom.core import (Section, Neurite, Neuron, NeuriteType, SomaError)
-from neurom.core.dataformat import POINT_TYPE, COLS, ROOT_ID
+from neurom.core.dataformat import POINT_TYPE, COLS, ROOT_ID, _COLS
 from neurom.core._soma import make_soma, SOMA_CONTOUR, SOMA_CYLINDER
 
 
@@ -108,7 +108,7 @@ def make_neurites(rdw):
 
 def _remove_soma_initial_point(tree):
     """Remove tree's initial point if soma."""
-    if tree.points[0][COLS.TYPE] == POINT_TYPE.SOMA:
+    if tree.points[0][_COLS.TYPE] == POINT_TYPE.SOMA:
         tree.points = tree.points[1:]
 
 
@@ -121,7 +121,7 @@ def _check_soma_topology_swc(points):
     if len(points) == 3:
         return
 
-    parents = tuple(p[COLS.P] for p in points if p[COLS.P] != ROOT_ID)
+    parents = tuple(p[_COLS.P] for p in points if p[_COLS.P] != ROOT_ID)
     if len(parents) > len(set(parents)):
         raise SomaError("Bifurcating soma")
 

--- a/neurom/io/datawrapper.py
+++ b/neurom/io/datawrapper.py
@@ -32,7 +32,7 @@ import logging
 from collections import defaultdict, namedtuple
 
 import numpy as np
-from neurom.core.dataformat import COLS, POINT_TYPE, ROOT_ID
+from neurom.core.dataformat import COLS, _COLS, POINT_TYPE, ROOT_ID
 
 L = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class DataWrapper(object):
     def soma_points(self):
         """Get the soma points."""
         db = self.data_block
-        return db[db[:, COLS.TYPE] == POINT_TYPE.SOMA]
+        return db[db[:, _COLS.TYPE] == POINT_TYPE.SOMA]
 
 
 def _merge_sections(sec_a, sec_b):
@@ -144,7 +144,7 @@ class DataBlockSection(object):
 
 def _extract_sections(data_block):
     """Make a list of sections from an SWC-style data wrapper block."""
-    structure_block = data_block[:, COLS.TYPE:COLS.COL_COUNT].astype(np.int)
+    structure_block = data_block[:, _COLS.TYPE:COLS.COL_COUNT].astype(np.int)
 
     # SWC ID -> structure_block position
     id_map = {-1: -1}
@@ -262,8 +262,8 @@ class BlockNeuronBuilder(object):
             id_to_insert_id[section_id] = row_count - 1
 
         datablock = np.empty((row_count, COLS.COL_COUNT), dtype=np.float)
-        datablock[:, COLS.ID] = np.arange(len(datablock))
-        datablock[:, COLS.P] = datablock[:, COLS.ID] - 1
+        datablock[:, _COLS.ID] = np.arange(len(datablock))
+        datablock[:, _COLS.P] = datablock[:, _COLS.ID] - 1
 
         sections = []
         insert_index = 0
@@ -273,8 +273,8 @@ class BlockNeuronBuilder(object):
 
             idx = slice(insert_index, insert_index + len(points))
             datablock[idx, COLS.XYZR] = points
-            datablock[idx, COLS.TYPE] = section_type
-            datablock[idx.start, COLS.P] = id_to_insert_id.get(parent_id, ROOT_ID)
+            datablock[idx, _COLS.TYPE] = section_type
+            datablock[idx.start, _COLS.P] = id_to_insert_id.get(parent_id, ROOT_ID)
             sections.append(DataBlockSection(idx, section_type, parent_id))
             insert_index = idx.stop
 

--- a/neurom/io/neurolucida.py
+++ b/neurom/io/neurolucida.py
@@ -36,7 +36,7 @@ from io import open
 
 import numpy as np
 
-from neurom.core.dataformat import COLS, POINT_TYPE
+from neurom.core.dataformat import _COLS, COLS, POINT_TYPE
 
 from .datawrapper import DataWrapper
 
@@ -232,7 +232,7 @@ def _sections_to_raw_data(sections):
         if neurite is None:
             continue
 
-        if neurite[0][COLS.TYPE] == POINT_TYPE.SOMA:
+        if neurite[0][_COLS.TYPE] == POINT_TYPE.SOMA:
             assert soma is None, 'Multiple somas defined in file'
             soma = neurite
         else:
@@ -247,10 +247,10 @@ def _sections_to_raw_data(sections):
     for neurite in neurites:
         end = pos + len(neurite)
         ret[pos:end, :] = neurite
-        ret[pos:end, COLS.P] += pos
-        ret[pos:end, COLS.ID] += pos
+        ret[pos:end, _COLS.P] += pos
+        ret[pos:end, _COLS.ID] += pos
         # TODO: attach the neurite at the closest point on the soma
-        ret[pos, COLS.P] = len(soma) - 1
+        ret[pos, _COLS.P] = len(soma) - 1
         pos = end
 
     return ret

--- a/neurom/io/tests/test_datawrapper.py
+++ b/neurom/io/tests/test_datawrapper.py
@@ -1,10 +1,10 @@
 """Test neurom.io.utils."""
-from pathlib import Path
-import numpy as np
-from nose import tools as nt
+import warnings
 
+import numpy as np
+from neurom.core.dataformat import COLS, POINT_TYPE, ROOT_ID
 from neurom.io import datawrapper as dw
-from neurom.core.dataformat import POINT_TYPE, ROOT_ID
+from nose import tools as nt
 
 
 def test__merge_sections():
@@ -61,3 +61,23 @@ def test_BlockNeuronBuilder():
                   [ 1., 0., 0., 1., 2., 1.,  0.],
                   [ 2., 0., 0., 1., 4., 2.,  0.],
                   [10., 0., 0., 1., 4., 3.,  2.]]))
+
+
+def test_deprecated_columns():
+    with warnings.catch_warnings(record=True) as w:
+        COLS.TYPE
+        nt.eq_(len(w), 1)
+        nt.eq_(str(w[0].message),
+            'Using _COLS.TYPE is now deprecated. Please consider using "section.type" to get the type of a section.')
+
+    with warnings.catch_warnings(record=True) as w:
+        COLS.ID
+        nt.eq_(len(w), 1)
+        nt.eq_(str(w[0].message),
+               'Using _COLS.ID is now deprecated')
+
+    with warnings.catch_warnings(record=True) as w:
+        COLS.P
+        nt.eq_(len(w), 1)
+        nt.eq_(str(w[0].message),
+               'Using _COLS.P is now deprecated')

--- a/neurom/io/tests/test_datawrapper.py
+++ b/neurom/io/tests/test_datawrapper.py
@@ -68,7 +68,8 @@ def test_deprecated_columns():
         COLS.TYPE
         nt.eq_(len(w), 1)
         nt.eq_(str(w[0].message),
-            'Using _COLS.TYPE is now deprecated. Please consider using "section.type" to get the type of a section.')
+               'Using _COLS.TYPE is now deprecated. '
+               'Please consider using "section.type" to get the type of a section.')
 
     with warnings.catch_warnings(record=True) as w:
         COLS.ID

--- a/neurom/io/tests/test_h5_reader.py
+++ b/neurom/io/tests/test_h5_reader.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
-from neurom.core.dataformat import COLS
+from neurom.core.dataformat import COLS, _COLS
 from neurom.io import hdf5, swc
 from nose import tools as nt
 
@@ -110,7 +110,7 @@ class TestDataWrapper_Neuron_H5V1(DataWrapper_Neuron):
 
     def setup(self):
         self.data = hdf5.read(Path(H5V1_PATH, 'Neuron.h5'))
-        self.first_id = int(self.data.data_block[0][COLS.ID])
+        self.first_id = int(self.data.data_block[0][_COLS.ID])
         self.rows = len(self.data.data_block)
 
 
@@ -119,7 +119,7 @@ class TestDataWrapper_Neuron_H5V2(DataWrapper_Neuron):
 
     def setup(self):
         self.data = hdf5.read(Path(H5V2_PATH, 'Neuron.h5'))
-        self.first_id = int(self.data.data_block[0][COLS.ID])
+        self.first_id = int(self.data.data_block[0][_COLS.ID])
         self.rows = len(self.data.data_block)
 
 

--- a/neurom/io/tests/test_neurolucida.py
+++ b/neurom/io/tests/test_neurolucida.py
@@ -8,7 +8,7 @@ import neurom.io.neurolucida as nasc
 import numpy as np
 from mock import patch
 from neurom import load_neuron
-from neurom.core.dataformat import COLS
+from neurom.core.dataformat import COLS, _COLS
 from neurom.io.datawrapper import DataWrapper
 from nose.tools import eq_, ok_
 from numpy.testing import assert_array_equal
@@ -91,8 +91,8 @@ def test__flatten_section():
                   ]
     ret = np.array([row for row in nasc._flatten_subsection(subsection, 0, offset=0, parent=-1)])
     # correct parents
-    ok_(np.allclose(ret[:, COLS.P], np.arange(-1, 4)))
-    ok_(np.allclose(ret[:, COLS.ID], np.arange(0, 5)))
+    ok_(np.allclose(ret[:, _COLS.P], np.arange(-1, 4)))
+    ok_(np.allclose(ret[:, _COLS.ID], np.arange(0, 5)))
 
     subsection = [['-1', '-1', '-1', '-1'],
                   [['0', '0', '0', '0'],
@@ -109,10 +109,10 @@ def test__flatten_section():
                   ]
     ret = np.array([row for row in nasc._flatten_subsection(subsection, 0, offset=0, parent=-1)])
     # correct parents
-    eq_(ret[0, COLS.P], -1.)
-    eq_(ret[1, COLS.P], 0.0)
-    eq_(ret[6, COLS.P], 0.0)
-    ok_(np.allclose(ret[:, COLS.ID], np.arange(0, 11)))  # correct ID
+    eq_(ret[0, _COLS.P], -1.)
+    eq_(ret[1, _COLS.P], 0.0)
+    eq_(ret[6, _COLS.P], 0.0)
+    ok_(np.allclose(ret[:, _COLS.ID], np.arange(0, 11)))  # correct ID
 
     # Try a non-standard bifurcation, ie: missing '|' separator
     subsection = [['-1', '-1', '-1', '-1'],
@@ -135,11 +135,11 @@ def test__flatten_section():
                   ]
     ret = np.array([row for row in nasc._flatten_subsection(subsection, 0, offset=0, parent=-1)])
     # correct parents
-    eq_(ret[0, COLS.P], -1.)
-    eq_(ret[1, COLS.P], 0.0)
-    eq_(ret[3, COLS.P], 0.0)
-    eq_(ret[5, COLS.P], 0.0)
-    ok_(np.allclose(ret[:, COLS.ID], np.arange(0, 7)))  # correct ID
+    eq_(ret[0, _COLS.P], -1.)
+    eq_(ret[1, _COLS.P], 0.0)
+    eq_(ret[3, _COLS.P], 0.0)
+    eq_(ret[5, _COLS.P], 0.0)
+    ok_(np.allclose(ret[:, _COLS.ID], np.arange(0, 7)))  # correct ID
 
 
 def test__extract_section():
@@ -190,9 +190,9 @@ def test_sections_to_raw_data():
     sections = [soma, fake_neurite, axon, dendrite, ]
     raw_data = nasc._sections_to_raw_data(sections)
     eq_(raw_data.shape, (15, 7))
-    ok_(np.allclose(raw_data[:, COLS.ID], np.arange(0, 15)))  # correct ID
+    ok_(np.allclose(raw_data[:, _COLS.ID], np.arange(0, 15)))  # correct ID
     # 3 is ID of end of the soma, 2 sections attach to this
-    ok_(np.count_nonzero(raw_data[:, COLS.P] == 3),  2)
+    ok_(np.count_nonzero(raw_data[:, _COLS.P] == 3),  2)
 
 
 # what I think the
@@ -241,9 +241,9 @@ def test_read():
     raw_data = rdw.data_block
 
     eq_(raw_data.shape, (19, 7))
-    ok_(np.allclose(raw_data[:, COLS.ID], np.arange(0, 19)))  # correct ID
+    ok_(np.allclose(raw_data[:, _COLS.ID], np.arange(0, 19)))  # correct ID
     # 3 is ID of end of the soma, 2 sections attach to this
-    ok_(np.count_nonzero(raw_data[:, COLS.P] == 3),  2)
+    ok_(np.count_nonzero(raw_data[:, _COLS.P] == 3),  2)
 
     with warnings.catch_warnings(record=True):
         neuron = load_neuron(StringIO(MORPH_ASC), reader='asc')


### PR DESCRIPTION
They represent internal states and should not be public.

A section type is supposed to be accessed with section.type
and ID and parent ID are just some details of the datastructure we use
internally.