### PR TITLE
Fix h5py < 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url='http://https://github.com/BlueBrain/NeuroM',
     install_requires=[
         'click>=7.0',
-        'h5py>=2.7.1',
+        'h5py>=2.7.1,<3.0.0',
         'matplotlib>=3.2.1',
         'numpy>=1.8.0',
         'pandas>=1.0.5',


### PR DESCRIPTION
So that packages having as dependencies both bluepy and neurom (like
morph-validator), get h5py < 3.
Otherwise bluepy breaks