### PR TITLE
Fix various morph_stats issues

### DIFF
--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -42,7 +42,7 @@ import pkg_resources
 
 import neurom as nm
 from neurom.exceptions import ConfigError
-from neurom.features import NEURITEFEATURES, NEURONFEATURES, _get_feature_and_shape
+from neurom.features import NEURITEFEATURES, NEURONFEATURES, _get_feature_value_and_func
 from neurom.fst._core import FstNeuron
 
 L = logging.getLogger(__name__)
@@ -167,10 +167,11 @@ def extract_stats(neurons, config):
 
         If the feature is 2-dimensional, the feature is flattened on its last axis
         """
-        assert len(shape) <= 2, f'Wrong shape: {shape}'
         if len(shape) == 2:
             for i in range(shape[1]):
                 data[f'{stat_name}_{i}'] = stat[i] if stat is not None else None
+        elif len(shape) > 2:
+            raise ValueError(f'Feature with wrong shape: {shape}')
         else:
             data[stat_name] = stat
 
@@ -180,14 +181,15 @@ def extract_stats(neurons, config):
                                                        config.get('neurite_type',
                                                                   _NEURITE_MAP.keys())):
         neurite_type = _NEURITE_MAP[neurite_type]
-        feature, func = _get_feature_and_shape(feature_name, neurons, neurite_type=neurite_type)
+        feature, func = _get_feature_value_and_func(feature_name, neurons,
+                                                    neurite_type=neurite_type)
         for mode in modes:
             stat_name = _stat_name(feature_name, mode)
             stat = eval_stats(feature, mode)
             _fill_stats_dict(stats[neurite_type.name], stat_name, stat, func.shape)
 
     for feature_name, modes in config.get('neuron', {}).items():
-        feature, func = _get_feature_and_shape(feature_name, neurons)
+        feature, func = _get_feature_value_and_func(feature_name, neurons)
         for mode in modes:
             stat_name = _stat_name(feature_name, mode)
             stat = eval_stats(feature, mode)

--- a/neurom/apps/tests/test_morph_stats.py
+++ b/neurom/apps/tests/test_morph_stats.py
@@ -67,36 +67,36 @@ REF_OUT = {
         'max_section_length': 11.018460736176685,
         'max_section_branch_order': 10,
         'total_section_volume': 276.73857657289523,
-        'max_segment_midpoint_X': 0.0,
-        'max_segment_midpoint_Y': 0.0,
-        'max_segment_midpoint_Z': 49.520305964149998,
+        'max_segment_midpoint_0': 0.0,
+        'max_segment_midpoint_1': 0.0,
+        'max_segment_midpoint_2': 49.520305964149998,
     },
     'all': {
         'total_section_length': 840.68521442251949,
         'max_section_length': 11.758281556059444,
         'max_section_branch_order': 10,
         'total_section_volume': 1104.9077419665782,
-        'max_segment_midpoint_X': 64.401674984050004,
-        'max_segment_midpoint_Y': 48.48197694465,
-        'max_segment_midpoint_Z': 53.750947521650005,
+        'max_segment_midpoint_0': 64.401674984050004,
+        'max_segment_midpoint_1': 48.48197694465,
+        'max_segment_midpoint_2': 53.750947521650005,
     },
     'apical_dendrite': {
         'total_section_length': 214.37304577550353,
         'max_section_length': 11.758281556059444,
         'max_section_branch_order': 10,
         'total_section_volume': 271.9412385728449,
-        'max_segment_midpoint_X': 64.401674984050004,
-        'max_segment_midpoint_Y': 0.0,
-        'max_segment_midpoint_Z': 53.750947521650005,
+        'max_segment_midpoint_0': 64.401674984050004,
+        'max_segment_midpoint_1': 0.0,
+        'max_segment_midpoint_2': 53.750947521650005,
     },
     'basal_dendrite': {
         'total_section_length': 418.43241643793476,
         'max_section_length': 11.652508126101711,
         'max_section_branch_order': 10,
         'total_section_volume': 556.22792682083821,
-        'max_segment_midpoint_X': 64.007872333250006,
-        'max_segment_midpoint_Y': 48.48197694465,
-        'max_segment_midpoint_Z': 51.575580778049996,
+        'max_segment_midpoint_0': 64.007872333250006,
+        'max_segment_midpoint_1': 48.48197694465,
+        'max_segment_midpoint_2': 51.575580778049996,
     },
 }
 
@@ -126,7 +126,11 @@ def test_eval_stats_on_empty_stat():
     assert_equal(ms.eval_stats(np.array([]), 'mean'), None)
     assert_equal(ms.eval_stats(np.array([]), 'std'), None)
     assert_equal(ms.eval_stats(np.array([]), 'median'), None)
+    assert_equal(ms.eval_stats(np.array([]), 'min'), None)
+    assert_equal(ms.eval_stats(np.array([]), 'max'), None)
 
+    assert_equal(ms.eval_stats(np.array([]), 'raw'), [])
+    assert_equal(ms.eval_stats(np.array([]), 'total'), 0.0)
 
 def test_eval_stats_applies_numpy_function():
     modes = ('min', 'max', 'mean', 'median', 'std')
@@ -275,10 +279,12 @@ def test_sanitize_config():
     new_config = ms.sanitize_config(full_config)
     assert_equal(3, len(new_config))  # neurite, neurite_type & neuron
 
-def test_fix_issue_858():
-    '''Features should be split into X/Y/Z parts even when
-    they are None
+def test_multidimensional_features():
+    '''Features should be split into sub-features when they
+    are multidimensional.
 
+
+    This should be the case even when the feature is `None` or `[]`
     The following neuron has no axon but the axon feature segment_midpoints for
     the axon should still be made of 3 values (X, Y and Z)
 
@@ -289,7 +295,16 @@ def test_fix_issue_858():
     config = {'neurite': {'segment_midpoints': ['max']},
               'neurite_type': ['AXON']}
     actual = ms.extract_dataframe(neuron, config)
-    assert_array_equal(actual[['max_segment_midpoint_X',
-                               'max_segment_midpoint_Y',
-                               'max_segment_midpoint_Z']].values,
+    assert_array_equal(actual[['max_segment_midpoint_0',
+                               'max_segment_midpoint_1',
+                               'max_segment_midpoint_2']].values,
                        [[None, None, None]])
+
+    config = {'neurite': {'partition_pairs': ['max']}}
+    actual = ms.extract_dataframe(neuron, config)
+    assert_array_equal(actual[['max_partition_pair_0',
+                               'max_partition_pair_1']].values,
+                       [[np.nan, np.nan],
+                        [1.0, 1.0],
+                        [1.0, 1.0],
+                        [1.0, 1.0]])

--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -78,6 +78,22 @@ def _find_feature_func(feature_name):
     raise NeuroMError(f'Unable to find feature: {feature_name}')
 
 
+def _get_feature_and_shape(feature_name, obj, **kwargs):
+    """Obtain a feature from a set of morphology objects.
+
+    Arguments:
+        feature(string): feature to extract
+        obj: a neuron, population or neurite tree
+        kwargs: parameters to forward to underlying worker functions
+
+    Returns:
+        A tuple (feature, func) of the feature value and its function
+    """
+    feat = _find_feature_func(feature_name)
+
+    return np.array(list(feat(obj, **kwargs))), feat
+
+
 def get(feature_name, obj, **kwargs):
     """Obtain a feature from a set of morphology objects.
 
@@ -87,7 +103,7 @@ def get(feature_name, obj, **kwargs):
         kwargs: parameters to forward to underlying worker functions
 
     Returns:
-        features as a 1D or 2D numpy array.
+        features as a 1D, 2D or 3D numpy array.
     """
     feat = _find_feature_func(feature_name)
 

--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -70,6 +70,14 @@ def register_neurite_feature(name, func):
     _register_feature('NEURITEFEATURES', name, _fun, shape=(...,))
 
 
+def _find_feature_func(feature_name):
+    """Returns the python function used when getting a feature with `neurom.get(feature_name)`."""
+    for feature_dict in (NEURITEFEATURES, NEURONFEATURES):
+        if feature_name in feature_dict:
+            return feature_dict[feature_name]
+    raise NeuroMError(f'Unable to find feature: {feature_name}')
+
+
 def get(feature_name, obj, **kwargs):
     """Obtain a feature from a set of morphology objects.
 
@@ -81,12 +89,7 @@ def get(feature_name, obj, **kwargs):
     Returns:
         features as a 1D or 2D numpy array.
     """
-    for feature_dict in (NEURITEFEATURES, NEURONFEATURES):
-        if feature_name in feature_dict:
-            feat = feature_dict[feature_name]
-            break
-    else:
-        raise NeuroMError(f'Unable to find feature: {feature_name}')
+    feat = _find_feature_func(feature_name)
 
     return np.array(list(feat(obj, **kwargs)))
 

--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -78,7 +78,7 @@ def _find_feature_func(feature_name):
     raise NeuroMError(f'Unable to find feature: {feature_name}')
 
 
-def _get_feature_and_shape(feature_name, obj, **kwargs):
+def _get_feature_value_and_func(feature_name, obj, **kwargs):
     """Obtain a feature from a set of morphology objects.
 
     Arguments:
@@ -105,9 +105,7 @@ def get(feature_name, obj, **kwargs):
     Returns:
         features as a 1D, 2D or 3D numpy array.
     """
-    feat = _find_feature_func(feature_name)
-
-    return np.array(list(feat(obj, **kwargs)))
+    return _get_feature_value_and_func(feature_name, obj, **kwargs)[0]
 
 
 _INDENT = ' ' * 4

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -541,11 +541,9 @@ def neurite_volume_density(neurites, neurite_type=NeuriteType.all):
         """Volume density of a single neurite."""
         try:
             volume = convex_hull(neurite).volume
-        except scipy.spatial.qhull.QhullError as e:
+        except scipy.spatial.qhull.QhullError:
             L.exception('Failure to compute neurite volume using the convex hull. '
-                        'Feature `neurite_volume_density` will return `np.nan`.\n'
-                        'Caught stacktrace:\n %s',
-                        e)
+                        'Feature `neurite_volume_density` will return `np.nan`.\n')
             return np.nan
 
         return neurite.volume / volume

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -534,13 +534,18 @@ def neurite_volume_density(neurites, neurite_type=NeuriteType.all):
 
     The volume density is defined as the ratio of the neurite volume and
     the volume of the neurite's enclosing convex hull
+
+    .. note:: Returns `np.nan` if the convex hull computation fails.
     """
     def vol_density(neurite):
         """Volume density of a single neurite."""
         try:
             volume = convex_hull(neurite).volume
         except scipy.spatial.qhull.QhullError as e:
-            L.warning(e)
+            L.exception('Failure to compute neurite volume using the convex hull. '
+                        'Feature `neurite_volume_density` will return `np.nan`.\n'
+                        'Caught stacktrace:\n %s',
+                        e)
             return np.nan
 
         return neurite.volume / volume

--- a/neurom/features/tests/test_bifurcationfunc.py
+++ b/neurom/features/tests/test_bifurcationfunc.py
@@ -40,10 +40,6 @@ import neurom as nm
 from neurom import load_neuron
 from neurom.exceptions import NeuroMError
 
-# NOTE: The 'bf' alias is used in the fst/tests modules
-# Do NOT change it.
-# TODO: If other neurom.features are imported,
-# the should use the aliasing used in fst/tests module files
 from neurom.features import bifurcationfunc as bf
 
 DATA_PATH = Path(__file__).parent / '../../../test_data/'

--- a/neurom/features/tests/test_feature_compat.py
+++ b/neurom/features/tests/test_feature_compat.py
@@ -39,10 +39,6 @@ import neurom as nm
 from neurom.core import Tree
 from neurom.core.types import NeuriteType
 
-# NOTE: The 'bf' alias is used in the fst/tests modules
-# Do NOT change it.
-# TODO: If other neurom.features are imported,
-# the should use the aliasing used in fst/tests module files
 from neurom.features import bifurcationfunc as _bf
 from neurom.features import neuritefunc as _nrt
 from neurom.features import neuronfunc as _nrn

--- a/neurom/features/tests/test_neuritefunc.py
+++ b/neurom/features/tests/test_neuritefunc.py
@@ -132,6 +132,7 @@ def test_neurite_volume_density():
                    0.24068543213643726, 0.26289304906104355]
     assert_allclose(vol_density, ref_density)
 
+def test_neurite_volume_density_failed_convex_hull():
     with patch('neurom.features.neuritefunc.convex_hull',
                side_effect=scipy.spatial.qhull.QhullError('boom')):
         vol_density = _nf.neurite_volume_density(NRN)

--- a/neurom/features/tests/test_neuritefunc.py
+++ b/neurom/features/tests/test_neuritefunc.py
@@ -30,17 +30,16 @@
 
 from pathlib import Path
 from math import pi, sqrt
+from mock import patch, Mock
+
 
 import numpy as np
 from nose import tools as nt
 from numpy.testing import assert_allclose
+import scipy
 
 import neurom as nm
 
-# NOTE: The 'bf' alias is used in the fst/tests modules
-# Do NOT change it.
-# TODO: If other neurom.features are imported,
-# the should use the aliasing used in fst/tests module files
 from neurom.features import neuritefunc as _nf
 from neurom.features import sectionfunc as sectionfunc
 from neurom.geom import convex_hull
@@ -132,6 +131,11 @@ def test_neurite_volume_density():
     ref_density = [0.43756606998299519, 0.52464681266899216,
                    0.24068543213643726, 0.26289304906104355]
     assert_allclose(vol_density, ref_density)
+
+    with patch('neurom.features.neuritefunc.convex_hull',
+               side_effect=scipy.spatial.qhull.QhullError('boom')):
+        vol_density = _nf.neurite_volume_density(NRN)
+        nt.ok_(vol_density, np.nan)
 
 
 def test_terminal_path_length_per_neurite():

--- a/neurom/features/tests/test_neuronfunc.py
+++ b/neurom/features/tests/test_neuronfunc.py
@@ -40,10 +40,6 @@ from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
 from neurom import NeuriteType, load_neuron
 from neurom.core.population import Population
 
-# NOTE: The 'bf' alias is used in the fst/tests modules
-# Do NOT change it.
-# TODO: If other neurom.features are imported,
-# the should use the aliasing used in fst/tests module files
 from neurom.features import neuronfunc as _nf
 
 DATA_PATH = Path(__file__).parent.parent.parent.parent / 'test_data'

--- a/neurom/features/tests/test_sectionfunc.py
+++ b/neurom/features/tests/test_sectionfunc.py
@@ -37,10 +37,6 @@ from io import StringIO
 from numpy.testing import assert_allclose
 from neurom import load_neuron
 
-# NOTE: The 'bf' alias is used in the fst/tests modules
-# Do NOT change it.
-# TODO: If other neurom.features are imported,
-# the should use the aliasing used in fst/tests module files
 from neurom.features import sectionfunc as _sf
 from neurom.features import neuritefunc as _nf
 from neurom import morphmath as mmth

--- a/neurom/fst/__init__.py
+++ b/neurom/fst/__init__.py
@@ -1,5 +1,5 @@
 """This module used to have all fst related function that were deprecated and now removed.
 
 The class FstNeuron is still here and has not been moved to a better
-suited plane since moving it would imply a breaking change.
+suited place since moving it would imply a breaking change.
 """

--- a/test_data/extracted-stats.csv
+++ b/test_data/extracted-stats.csv
@@ -1,4 +1,4 @@
-,name,neurite_type,max_section_length,total_section_length,total_section_volume,max_section_branch_order,max_segment_midpoint_X,max_segment_midpoint_Y,max_segment_midpoint_Z
+,name,neurite_type,max_section_length,total_section_length,total_section_volume,max_section_branch_order,max_segment_midpoint_0,max_segment_midpoint_1,max_segment_midpoint_2
 0,Neuron,axon,11.018460736176685,207.8797522090813,276.7385765728952,10.0,0.0,0.0,49.52030596415
 1,Neuron,apical_dendrite,11.758281556059444,214.37304577550353,271.9412385728449,10.0,64.40167498405,0.0,53.750947521650005
 2,Neuron,basal_dendrite,11.652508126101711,418.43241643793476,556.2279268208382,10.0,64.00787233325,48.48197694465,51.575580778049996


### PR DESCRIPTION
# Fixes handling of multi-dimensional features in `morph_stats`

Context:

Previously, 3 dimensional features where split into 3 components X, Y and Z.
However this way of handling multidim features have issues:

- It only handles 3-dim features and not other dimensionality
- 3-dim features may not be spatial so X, Y and Z might not be appropriate.

Solution:

Use an integer suffix of arbitrary length (ie. `_0`, `_1`, ..., `_N`) instead of `_X`, `_Y` and `_Z`.

:information_source: This fixes #859 

# Fixed issue with computing the mean, std and median of empty features

When features are returning an empty array, the mean, median and std of those
values will be set to None instead of crashing.

# Fixed issue with the convex hull computation in feature `neurite_volume_density`

The neurite volume computation made using a convex hull is now wrapped in a
try/catch block and the feature will return `np.nan` if the convex hull crashes.

# <cleanup> Removed no longer relevant NOTE comment related to `neurom.fst`

It was dating from when we had to maintain the compatibility between neurom.features and neurom.fst