### PR TITLE
do not compute dangling check if no dendrites

### DIFF
--- a/neurom/check/neuron_checks.py
+++ b/neurom/check/neuron_checks.py
@@ -304,6 +304,10 @@ def has_no_dangling_branch(neuron):
                                                          for n in iter_neurites(neuron)
                                                          if n.type != NeuriteType.axon)))
 
+    if not len(dendritic_points) > 0:
+        # returns True if no dendrites are present
+        return CheckResult(True)
+
     def is_dangling(neurite):
         """Is the neurite dangling ?."""
         starting_point = neurite.points[0][COLS.XYZ]

--- a/neurom/check/neuron_checks.py
+++ b/neurom/check/neuron_checks.py
@@ -304,7 +304,7 @@ def has_no_dangling_branch(neuron):
                                                          for n in iter_neurites(neuron)
                                                          if n.type != NeuriteType.axon)))
 
-    if not len(dendritic_points) > 0:
+    if len(dendritic_points) == 0:
         # returns True if no dendrites are present
         return CheckResult(True)
 


### PR DESCRIPTION
this crashes the error detection on morphologies with only axon, but should not