### PR TITLE
Refactor Sholl analysis code, fix #663

### DIFF
--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -249,13 +249,14 @@ def sholl_crossings(neurites, center, radii, neurite_filter=None):
 
 
 @feature(shape=(...,))
-def sholl_frequency(nrn, neurite_type=NeuriteType.all, bins=None):
+def sholl_frequency(nrn, neurite_type=NeuriteType.all, bins=10):
     """Perform Sholl frequency calculations on a population of neurites.
 
     Args:
         nrn(morph): nrn or population
         neurite_type(NeuriteType): which neurites to operate on
-        bins(iterable of floats|int|None): binning to use for the Sholl radii
+        bins(iterable of floats|int): binning to use for the Sholl radii. If ``int`` is used then \
+            it sets the number of bins in the interval between min and max radii of ``nrn``.
 
     Note:
         Given a neuron, the soma center is used for the concentric circles,

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -268,13 +268,10 @@ def sholl_frequency(nrn, neurite_type=NeuriteType.all, bins=10):
         having crossed multiple times.
     """
     nrns = neuron_population(nrn)
-    if bins is None or isinstance(bins, int):
+    if isinstance(bins, int):
         min_soma_edge = min(neuron.soma.radius for neuron in nrns)
         max_radii = np.max([np.abs(bounding_box(neuron)) for neuron in nrns])
-        n_bins = bins
-        if bins is None:
-            n_bins = 10
-        bins = np.linspace(min_soma_edge, max_radii, n_bins)
+        bins = np.linspace(min_soma_edge, max_radii, bins)
 
     return sum(sholl_crossings(neuron, neuron.soma.center, bins, is_type(neurite_type))
                for neuron in nrns)

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -211,7 +211,7 @@ def trunk_angles(nrn, neurite_type=NeuriteType.all):
             for i, _ in enumerate(ordered_vectors)]
 
 
-def sholl_crossings(neurites, center, radii):
+def sholl_crossings(neurites, center, radii, neurite_filter=None):
     """Calculate crossings of neurites.
 
     This function can also be used with a list aa neurites, as follow:
@@ -244,18 +244,18 @@ def sholl_crossings(neurites, center, radii):
         return count
 
     return np.array([sum(_count_crossings(neurite, r)
-                         for neurite in iter_neurites(neurites))
+                         for neurite in iter_neurites(neurites, filt=neurite_filter))
                      for r in radii])
 
 
 @feature(shape=(...,))
-def sholl_frequency(nrn, neurite_type=NeuriteType.all, step_size=10):
+def sholl_frequency(nrn, neurite_type=NeuriteType.all, bins=None):
     """Perform Sholl frequency calculations on a population of neurites.
 
     Args:
         nrn(morph): nrn or population
         neurite_type(NeuriteType): which neurites to operate on
-        step_size(float): step size between Sholl radii
+        bins(iterable of floats|int|None): binning to use for the Sholl radii
 
     Note:
         Given a neuron, the soma center is used for the concentric circles,
@@ -267,22 +267,13 @@ def sholl_frequency(nrn, neurite_type=NeuriteType.all, step_size=10):
         having crossed multiple times.
     """
     nrns = neuron_population(nrn)
-    neurite_filter = is_type(neurite_type)
+    if bins is None or isinstance(bins, int):
+        min_soma_edge = min(neuron.soma.radius for neuron in nrns)
+        max_radii = np.max([np.abs(bounding_box(neuron)) for neuron in nrns])
+        n_bins = bins
+        if bins is None:
+            n_bins = 10
+        bins = np.linspace(min_soma_edge, max_radii, n_bins)
 
-    min_soma_edge = float('Inf')
-    max_radii = 0
-    neurites_list = []
-    for neuron in nrns:
-        neurites_list.extend(((neurites, neuron.soma.center)
-                              for neurites in neuron.neurites
-                              if neurite_filter(neurites)))
-
-        min_soma_edge = min(min_soma_edge, neuron.soma.radius)
-        max_radii = max(max_radii, np.max(np.abs(bounding_box(neuron))))
-
-    radii = np.arange(min_soma_edge, max_radii + step_size, step_size)
-    ret = np.zeros_like(radii)
-    for neurites, center in neurites_list:
-        ret += sholl_crossings(neurites, center, radii)
-
-    return ret
+    return sum(sholl_crossings(neuron, neuron.soma.center, bins, is_type(neurite_type))
+               for neuron in nrns)

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -859,19 +859,19 @@ def test_soma_surface_areas():
 
 def test_sholl_frequency():
     assert_allclose(get_feature('sholl_frequency', NEURON),
-                    [4, 8, 8, 14, 9, 8, 7, 7])
+                    [4, 6, 10, 8, 8, 11, 7, 9, 8, 8])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.all),
-                    [4, 8, 8, 14, 9, 8, 7, 7])
+                    [4, 6, 10, 8, 8, 11, 7, 9, 8, 8])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.apical_dendrite),
-                    [1, 2, 2, 2, 2, 2, 1, 1])
+                    [1, 1, 2, 2, 2, 3, 1, 2, 2, 2])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.basal_dendrite),
-                    [2, 4, 4, 6, 5, 4, 4, 4])
+                    [2, 4, 6, 4, 4, 4, 4, 5, 4, 4])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.axon),
-                    [1, 2, 2, 6, 2, 2, 2, 2])
+                    [1, 1, 2, 2, 2, 4, 2, 2, 2, 2])
 
 
 @pytest.mark.skip('test_get_segment_lengths is disabled in test_get_features')


### PR DESCRIPTION
Neuron attributes soma center and soma radius were being computed for each neurite. Now they are computed only once.