### PR TITLE
improve sholl

### DIFF
--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -40,8 +40,6 @@ from neurom.core.types import NeuriteType
 from neurom.core.types import tree_type_checker as is_type
 from neurom.features import feature
 
-from neurom.geom import bounding_box
-
 feature = partial(feature, namespace='NEURONFEATURES')
 
 
@@ -257,7 +255,7 @@ def sholl_frequency(nrn, neurite_type=NeuriteType.all, step_size=10, bins=None):
         neurite_type(NeuriteType): which neurites to operate on
         step_size(float): step size between Sholl radii
         bins(iterable of floats): custom binning to use for the Sholl radii. If None, it uses
-            intervals of step_size between min and max radii of ``nrn``.
+        intervals of step_size between min and max radii of ``nrn``.
 
     Note:
         Given a neuron, the soma center is used for the concentric circles,

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -273,9 +273,8 @@ def sholl_frequency(nrn, neurite_type=NeuriteType.all, step_size=10, bins=None):
 
     if bins is None:
         min_soma_edge = min(neuron.soma.radius for neuron in nrns)
-        max_radii = np.max([np.abs(bounding_box(neurite))
-                            for neuron in nrns
-                            for neurite in iter_neurites(neuron, filt=neurite_filter)])
-        bins = np.arange(min_soma_edge, max_radii, step_size)
+        max_radii = max(np.max(np.linalg.norm(neurite.points[:, COLS.XYZ], axis=1))
+                        for nrn in nrns for neurite in iter_neurites(nrn, filt=neurite_filter))
+        bins = np.arange(min_soma_edge, min_soma_edge + max_radii, step_size)
 
     return sum(sholl_crossings(neuron, neuron.soma.center, bins, neurite_filter) for neuron in nrns)

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -859,7 +859,7 @@ def test_soma_surface_areas():
 
 def test_sholl_frequency():
     assert_allclose(get_feature('sholl_frequency', NEURON),
-                    [4, 6, 10, 8, 8, 11, 7, 9, 8, 8])
+                    [4, 8, 8, 14, 9, 8, 7, 7])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.all),
                     [4, 6, 10, 8, 8, 11, 7, 9, 8, 8])

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -859,19 +859,19 @@ def test_soma_surface_areas():
 
 def test_sholl_frequency():
     assert_allclose(get_feature('sholl_frequency', NEURON),
-                    [4, 8, 8, 14, 9, 8, 7, 7])
+                    [4, 8, 8, 14, 9, 8, 7, 7, 7, 5])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.all),
-                    [4, 6, 10, 8, 8, 11, 7, 9, 8, 8])
+                    [4, 8, 8, 14, 9, 8, 7, 7, 7, 5])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.apical_dendrite),
-                    [1, 1, 2, 2, 2, 3, 1, 2, 2, 2])
+                    [1, 2, 2, 2, 2, 2, 1, 1, 3, 3])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.basal_dendrite),
-                    [2, 4, 6, 4, 4, 4, 4, 5, 4, 4])
+                    [2, 4, 4, 6, 5, 4, 4, 4, 2, 2])
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.axon),
-                    [1, 1, 2, 2, 2, 4, 2, 2, 2, 2])
+                    [1, 2, 2, 6, 2, 2, 2, 2, 2])
 
 
 @pytest.mark.skip('test_get_segment_lengths is disabled in test_get_features')


### PR DESCRIPTION
This reverts part of https://github.com/BlueBrain/NeuroM/pull/905 (related to step_size argument, crucial for sholl) and fixes https://github.com/BlueBrain/NeuroM/issues/663 by replacing the box on the entire neurons, to max radial distance using the neurite filter. Now, we are guaranteed to have sholl shells every step_size, until the last sphere before there is no more crossing. Still we can provide a custom bins for more flexibility.