### PR TITLE
rename ``Population.somata`` to ``Population.soma``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 2.4.0
+-------------
+- rename ``Population.somata`` to ``Population.soma`` to have name consistency among ``Population``
+  and ``Neuron``.
+
 Version 2.3.0
 -------------
 - Introduce a new method to calculate partition asymmetry by Uylings. See docstring of

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,8 @@ Changelog
 
 Version 2.4.0
 -------------
-- rename ``Population.somata`` to ``Population.soma`` to have name consistency among ``Population``
-  and ``Neuron``.
+- deprecate ``Population.somata`` in favor of ``Population.soma`` to have name consistency among
+  ``Population`` and ``Neuron``.
 
 Version 2.3.0
 -------------

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -32,7 +32,7 @@ import logging
 from morphio import MorphioError
 import neurom
 from neurom.exceptions import NeuroMError
-
+from neurom.utils import deprecated
 
 L = logging.getLogger(__name__)
 
@@ -69,6 +69,12 @@ class Population:
     def neurons(self):
         """Iterator to populations's somas."""
         return (n for n in self)
+
+    @property
+    @deprecated('`somata`', 'Use `soma` instead.')
+    def somata(self):
+        """Iterator to populations's somas."""
+        return self.soma
 
     @property
     def soma(self):

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -49,7 +49,7 @@ class Population:
 
         Arguments:
             files (collections.abc.Sequence[str|Path|Neuron]): collection of neuron files or
-                paths to them
+                paths to them or instances of Neuron
             name (str): Optional name for this Population
             ignored_exceptions (tuple): NeuroM and MorphIO exceptions that you want to ignore when
                 loading neurons.
@@ -71,7 +71,7 @@ class Population:
         return (n for n in self)
 
     @property
-    def somata(self):
+    def soma(self):
         """Iterator to populations's somas."""
         return (n.soma for n in self)
 

--- a/tests/core/test_population.py
+++ b/tests/core/test_population.py
@@ -82,7 +82,7 @@ def test_iterating():
     for a, b in zip(NEURONS, pop):
         assert a is b
 
-    for a, b in zip(NEURONS, pop.somata):
+    for a, b in zip(NEURONS, pop.soma):
         assert a.soma is b
 
 

--- a/tests/core/test_population.py
+++ b/tests/core/test_population.py
@@ -85,6 +85,9 @@ def test_iterating():
     for a, b in zip(NEURONS, pop.soma):
         assert a.soma is b
 
+    for a, b in zip(NEURONS, pop.somata):
+        assert a.soma is b
+
 
 @pytest.mark.parametrize('pop', populations)
 def test_len(pop):


### PR DESCRIPTION
to have name consistency among ``Population`` and ``Neuron``.