### PR TITLE
Refactor features.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 Version 2.4.0
 -------------
-- Refactor viewer. :ref:`Migration guide<migration-v2.4.0>`.
+- Refactor ``viewer``. :ref:`Migration guide<migration-v2.4.0>`.
     - deprecate ``neurom.view.viewer``
     - swap arguments ``ax`` and ``nrn`` of all plot functions in ``neurom.view.view``
     - delete ``neurom.view.plotly.draw``. Use instead ``neurom.view.plotly.plot_neuron`` and
@@ -11,6 +11,12 @@ Version 2.4.0
     - rename ``neurom.view.view`` to ``neurom.view.matplotlib_impl``
     - rename ``neurom.view.plotly`` to ``neurom.view.plotly_impl``
     - rename ``neurom.view.common`` to ``neurom.view.matplotlib_utils``
+
+- Refactor ``features``.
+    - Move ``neuritefunc`` functions that expect neurons to ``neuronfunc``. The functions are:
+    ``max_radial_distances, number_of_sections, number_of_neurites, number_of_bifurcations, number_of_forking_points, number_of_terminations, number_of_segments``
+    - Make ``neuronfunc`` to work with list of neurons besides a neuron and a neuron population.
+    - Name consistency among private variables.
 
 Version 2.3.0
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Version 2.4.0
 
 - Refactor ``features``.
     - Move ``neuritefunc`` functions that expect neurons to ``neuronfunc``. The functions are:
-    ``max_radial_distances, number_of_sections, number_of_neurites, number_of_bifurcations, number_of_forking_points, number_of_terminations, number_of_segments``
+      ``max_radial_distances, number_of_sections, number_of_neurites, number_of_bifurcations, number_of_forking_points, number_of_terminations, number_of_segments``
     - Make ``neuronfunc`` to work with list of neurons besides a neuron and a neuron population.
     - Name consistency among private variables.
 

--- a/neurom/core/neuron.py
+++ b/neurom/core/neuron.py
@@ -30,6 +30,7 @@
 
 from collections import deque
 from itertools import chain
+import warnings
 
 import morphio
 import numpy as np
@@ -37,6 +38,7 @@ from neurom import morphmath
 from neurom.core.soma import make_soma
 from neurom.core.dataformat import COLS
 from neurom.core.types import NeuriteIter, NeuriteType
+from neurom.core.population import Population
 
 
 class Section:
@@ -239,6 +241,9 @@ def iter_neurites(obj, mapfun=None, filt=None, neurite_order=NeuriteIter.FileOrd
     neurites = ((obj,) if isinstance(obj, Neurite) else
                 obj.neurites if hasattr(obj, 'neurites') else obj)
     if neurite_order == NeuriteIter.NRN:
+        if isinstance(obj, Population):
+            warnings.warn('`iter_neurites` with `neurite_order` over Population orders neurites'
+                          'within the whole population, not within each neuron separately.')
         last_position = max(NRN_ORDER.values()) + 1
         neurites = sorted(neurites, key=lambda neurite: NRN_ORDER.get(neurite.type, last_position))
 

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -49,7 +49,6 @@ from neurom.core.neuron import NeuriteType, Section, iter_neurites, iter_section
 from neurom.core.dataformat import COLS
 from neurom.core.types import tree_type_checker as is_type
 from neurom.features import _register_feature, bifurcationfunc, feature, sectionfunc
-from neurom.features.neuronfunc import _neuron_population
 from neurom.geom import convex_hull
 from neurom.morphmath import interval_lengths
 
@@ -178,57 +177,6 @@ def section_path_lengths(neurites, neurite_type=NeuriteType.all):
 
     return _map_sections(pl2, neurites, neurite_type=neurite_type)
 
-
-################################################################################
-# Features returning one value per NEURON                                      #
-################################################################################
-
-def _map_neurons(fun, neurites, neurite_type):
-    """Map `fun` to all the neurites in a single or collection of neurons."""
-    nrns = _neuron_population(neurites)
-    return [fun(n, neurite_type=neurite_type) for n in nrns]
-
-
-@feature(shape=(...,))
-def max_radial_distances(neurites, neurite_type=NeuriteType.all):
-    """Get the maximum radial distances of the termination sections for a collection of neurites."""
-    return _map_neurons(max_radial_distance, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_sections(neurites, neurite_type=NeuriteType.all):
-    """Number of sections in a collection of neurites."""
-    return _map_neurons(n_sections, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_neurites(neurites, neurite_type=NeuriteType.all):
-    """Number of neurites in a collection of neurites."""
-    return _map_neurons(n_neurites, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_bifurcations(neurites, neurite_type=NeuriteType.all):
-    """Number of bifurcation points in a collection of neurites."""
-    return _map_neurons(n_bifurcation_points, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_forking_points(neurites, neurite_type=NeuriteType.all):
-    """Number of forking points in a collection of neurites."""
-    return _map_neurons(n_forking_points, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_terminations(neurites, neurite_type=NeuriteType.all):
-    """Number of leaves points in a collection of neurites."""
-    return _map_neurons(n_leaves, neurites, neurite_type)
-
-
-@feature(shape=(...,))
-def number_of_segments(neurites, neurite_type=NeuriteType.all):
-    """Number of sections in a collection of neurites."""
-    return _map_neurons(n_segments, neurites, neurite_type)
 
 ################################################################################
 # Features returning one value per SEGMENT                                     #

--- a/neurom/features/neuritefunc.py
+++ b/neurom/features/neuritefunc.py
@@ -167,10 +167,6 @@ def section_term_branch_orders(neurites, neurite_type=NeuriteType.all):
 @feature(shape=(...,), name='section_path_distances')
 def section_path_lengths(neurites, neurite_type=NeuriteType.all):
     """Path lengths of a collection of neurites."""
-    # Calculates and stores the section lengths in one pass,
-    # then queries the lengths in the path length iterations.
-    # This avoids repeatedly calculating the lengths of the
-    # same sections.
     def pl2(node):
         """Calculate the path length using cached section lengths."""
         return sum(n.length for n in node.iupstream())

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -298,49 +298,50 @@ def total_length(neurons, neurite_type=NeuriteType.all):
 
 @feature(shape=(...,))
 def max_radial_distances(neurons, neurite_type=NeuriteType.all):
-    """Get the maximum radial distances of the termination sections for a collection of neurites,
-    neurons or a population."""
+    """Get the maximum radial distances of the termination sections.
+
+    For a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.max_radial_distance(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_sections(neurons, neurite_type=NeuriteType.all):
-    """Number of sections in a collection of neurites, neurons or a population."""
+    """Number of sections in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_sections(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_neurites(neurons, neurite_type=NeuriteType.all):
-    """Number of neurites in a collection of neurites, neurons or a population."""
+    """Number of neurites in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_neurites(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_bifurcations(neurons, neurite_type=NeuriteType.all):
-    """Number of bifurcation points in a collection of neurites, neurons or a population."""
+    """Number of bifurcation points in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_bifurcation_points(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_forking_points(neurons, neurite_type=NeuriteType.all):
-    """Number of forking points in a collection of neurites, neurons or a population."""
+    """Number of forking points in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_forking_points(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_terminations(neurons, neurite_type=NeuriteType.all):
-    """Number of leaves points in a collection of neurites, neurons or a population."""
+    """Number of leaves points in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_leaves(n, neurite_type) for n in neurons]
 
 
 @feature(shape=(...,))
 def number_of_segments(neurons, neurite_type=NeuriteType.all):
-    """Number of sections in a collection of neurites, neurons or a population."""
+    """Number of sections in a collection of neurites, neurons or a neuron population."""
     neurons = _assure_iterable(neurons)
     return [neuritefunc.n_segments(n, neurite_type) for n in neurons]

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -60,10 +60,9 @@ def _assure_iterable(neurons):
     """Makes sure `neurons` is an iterable of neurons."""
     if hasattr(neurons, 'neurons'):
         return neurons.neurons
-    elif isinstance(neurons, Iterable):
+    if isinstance(neurons, Iterable):
         return neurons
-    else:
-        return (neurons,)
+    return (neurons,)
 
 
 def _iter_neurites(neurons, neurite_type):

--- a/neurom/features/neuronfunc.py
+++ b/neurom/features/neuronfunc.py
@@ -300,7 +300,8 @@ def total_length(neurons, neurite_type=NeuriteType.all):
 def max_radial_distances(neurons, neurite_type=NeuriteType.all):
     """Get the maximum radial distances of the termination sections.
 
-    For a collection of neurites, neurons or a neuron population."""
+    For a collection of neurites, neurons or a neuron population.
+    """
     neurons = _assure_iterable(neurons)
     return [neuritefunc.max_radial_distance(n, neurite_type) for n in neurons]
 

--- a/tests/core/test_iter.py
+++ b/tests/core/test_iter.py
@@ -25,7 +25,7 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+import warnings
 from io import StringIO
 from pathlib import Path
 
@@ -87,6 +87,14 @@ def test_iter_neurites_filter_mapping():
 
     ref = [500, 500, 500]
     assert n == ref
+
+
+def test_iter_population():
+    with warnings.catch_warnings(record=True) as w_list:
+        for _ in iter_neurites(POP, neurite_order=NeuriteIter.NRN):
+            pass
+        assert len(w_list) == 1
+        assert '`iter_neurites` with `neurite_order` over Population' in str(w_list[0].message)
 
 
 def test_iter_sections_default():

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -42,7 +42,7 @@ from neurom.core.types import tree_type_checker as _is_type
 from neurom.exceptions import NeuroMError
 from neurom.features import NEURITEFEATURES
 from neurom.features import get as get_feature
-from neurom.features import neuritefunc as nf, neuronfunc
+from neurom.features import neuritefunc as nf
 
 import pytest
 from numpy.testing import assert_allclose
@@ -875,25 +875,6 @@ def test_sholl_frequency():
 
     assert_allclose(get_feature('sholl_frequency', NEURON, neurite_type=NeuriteType.axon),
                     [1, 2, 2, 6, 2, 2, 2, 2, 2])
-
-
-@pytest.mark.skip('test_get_segment_lengths is disabled in test_get_features')
-def test_section_path_distances_endpoint():
-
-    ref_sec_path_len_start = list(iter_neurites(NEURON, sec.start_point_path_length))
-    ref_sec_path_len = list(iter_neurites(NEURON, sec.end_point_path_length))
-    path_lengths = get_feature('section_path_distances', NEURON)
-    assert ref_sec_path_len != ref_sec_path_len_start
-    assert len(path_lengths) == 84
-    assert np.all(path_lengths == ref_sec_path_len)
-
-
-@pytest.mark.skip('test_get_segment_lengths is disabled in test_get_features')
-def test_section_path_distances_start_point():
-    ref_sec_path_len_start = list(iter_neurites(NEURON, sec.start_point_path_length))
-    path_lengths = get_feature('section_path_distances', NEURON, use_start_point=True)
-    assert len(path_lengths) == 84
-    assert np.all(path_lengths == ref_sec_path_len_start)
 
 
 def test_partition():

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -117,13 +117,13 @@ def test_max_radial_distances():
     }
     assert_features_for_neurite(feat, POP, expected, exact=False)
 
-    # Test with a list of neurites
+    # Test with a single Neuron
     expected = {
         None: [99.58945832],
         NeuriteType.all: [99.58945832],
         NeuriteType.apical_dendrite: [99.589458],
     }
-    assert_features_for_neurite(feat, NRN.neurites, expected, exact=False)
+    assert_features_for_neurite(feat, (NRN,), expected, exact=False)
 
 
 def test_max_radial_distance():


### PR DESCRIPTION
- Move ``neuritefunc`` functions that expect neurons to ``neuronfunc``. The functions are:
``max_radial_distances, number_of_sections, number_of_neurites, number_of_bifurcations, number_of_forking_points, number_of_terminations, number_of_segments``
- Make ``neuronfunc`` to work with list of neurons besides a neuron and a neuron population.
- Name consistency among private variables.
