### PR TITLE
Fix `sholl_frequency` for NA neurite_type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,18 @@ Changelog
 
 Version 3.2.0
 -------------
+- Fix ``neurom.features.morphology.sholl_frequency`` to return an empty list when a
+  neurite_type that is not present in the morphology is specified.
+- Fix ``neurom.features.morphology.trunk_origin_radii`` to warn and use only the root
+  section for the calculation of the path distances. Edge cases from the combination
+  of ``min_length_filter`` and ``max_length_filter`` are addressed.
+- Fix ``neurom.features.morphology.sholl_frequency`` to use soma center in distance
+  calculation, instead of using the origin.
 - Add ``neurom.features.morphology.trunk_angles_inter_types`` and
   ``neurom.features.morphology.trunk_angles_from_vector`` features, make
   ``neurom.features.morphology.trunk_angles`` more generic and add length filter to
   ``neurom.features.morphology.trunk_origin_radii``.
+- Deprecate python3.6
 - Add doc on spherical coordinates.
 
 Version 3.1.0

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -515,6 +515,9 @@ def sholl_frequency(morph, neurite_type=NeuriteType.all, step_size=10, bins=None
         in steps of `step_size`. Each segment of the morphology is tested, so a neurite that
         bends back on itself, and crosses the same Sholl radius will get counted as
         having crossed multiple times.
+
+        If a `neurite_type` is specified and there are no trees corresponding to it, an empty
+        list will be returned.
     """
     neurite_filter = is_type(neurite_type)
 

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -520,11 +520,16 @@ def sholl_frequency(morph, neurite_type=NeuriteType.all, step_size=10, bins=None
 
     if bins is None:
         min_soma_edge = morph.soma.radius
-        max_radii = max(
+
+        max_radius_per_neurite = [
             np.max(np.linalg.norm(n.points[:, COLS.XYZ] - morph.soma.center, axis=1))
             for n in morph.neurites if neurite_filter(n)
-        )
-        bins = np.arange(min_soma_edge, min_soma_edge + max_radii, step_size)
+        ]
+
+        if not max_radius_per_neurite:
+            return []
+
+        bins = np.arange(min_soma_edge, min_soma_edge + max(max_radius_per_neurite), step_size)
 
     return sholl_crossings(morph, neurite_type, morph.soma.center, bins)
 

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -717,7 +717,7 @@ def test_sholl_frequency():
 
     assert features.get('sholl_frequency', m, step_size=5.0) == [0, 1, 1, 1]
 
-    # check that if there is not neurite of specific type an empty list is returned
+    # check that if there is no neurite of a specific type, an empty list is returned
     assert features.get('sholl_frequency', m, neurite_type=NeuriteType.axon) == []
 
 

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -717,6 +717,10 @@ def test_sholl_frequency():
 
     assert features.get('sholl_frequency', m, step_size=5.0) == [0, 1, 1, 1]
 
+    # check that if there is not neurite of specific type an empty list is returned
+    assert features.get('sholl_frequency', m, neurite_type=NeuriteType.axon) == []
+
+
 def test_bifurcation_partitions():
     assert_allclose(features.get('bifurcation_partitions', POP)[:10],
                     [19., 17., 15., 13., 11., 9., 7., 5., 3., 1.])


### PR DESCRIPTION
With this change, `sholl_frequency` returns an empty list for a `neurite_type` that is not present in the morphology.

Fixes #987 