### PR TITLE
Add volume density at the morphology level

### DIFF
--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -57,6 +57,7 @@ from neurom.core.types import NeuriteType
 from neurom.exceptions import NeuroMError
 from neurom.features import feature, NameSpace, neurite as nf
 from neurom.utils import str_to_plane
+from neurom.geom import convex_hull
 
 
 feature = partial(feature, namespace=NameSpace.NEURON)
@@ -276,7 +277,7 @@ def trunk_angles_inter_types(
     if len(source_vectors) == 0 or len(target_vectors) == 0:
         return []
 
-    angles = np.empty((len(source_vectors), len(target_vectors), 3), dtype=np.float)
+    angles = np.empty((len(source_vectors), len(target_vectors), 3), dtype=float)
 
     for i, source in enumerate(source_vectors):
         for j, target in enumerate(target_vectors):
@@ -571,3 +572,29 @@ def total_height(morph, neurite_type=NeuriteType.all):
 def total_depth(morph, neurite_type=NeuriteType.all):
     """Extent of morphology along axis z."""
     return _extent_along_axis(morph, axis=COLS.Z, neurite_type=neurite_type)
+
+
+@feature(shape=())
+def volume_density(morph, neurite_type=NeuriteType.all):
+
+    def get_points(neurite):
+        return neurite.points[:, COLS.XYZ]
+
+    # note: duplicate points are present but do not affect convex hull calculation
+    points = [
+        point
+        for point_list in iter_neurites(morph, mapfun=get_points, filt=is_type(neurite_type))
+        for point in point_list
+    ]
+
+    if not points:
+        return np.nan
+
+    morph_hull = convex_hull(points)
+
+    if morph_hull is None:
+        return np.nan
+
+    total_volume = sum(iter_neurites(morph, mapfun=nf.total_volume, filt=is_type(neurite_type)))
+
+    return total_volume / morph_hull.volume

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -576,6 +576,14 @@ def total_depth(morph, neurite_type=NeuriteType.all):
 
 @feature(shape=())
 def volume_density(morph, neurite_type=NeuriteType.all):
+    """Get the volume density.
+
+    The volume density is defined as the ratio of the neurite volume and
+    the volume of the neurite's enclosing convex hull
+
+    .. note:: Returns `np.nan` if the convex hull computation fails or there are not points
+              available due to neurite type filtering.
+    """
 
     def get_points(neurite):
         return neurite.points[:, COLS.XYZ]

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -595,9 +595,6 @@ def volume_density(morph, neurite_type=NeuriteType.all):
         for point in point_list
     ]
 
-    if not points:
-        return np.nan
-
     morph_hull = convex_hull(points)
 
     if morph_hull is None:

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -579,7 +579,7 @@ def volume_density(morph, neurite_type=NeuriteType.all):
     """Get the volume density.
 
     The volume density is defined as the ratio of the neurite volume and
-    the volume of the neurite's enclosing convex hull
+    the volume of the morphology's enclosing convex hull
 
     .. note:: Returns `np.nan` if the convex hull computation fails or there are not points
               available due to neurite type filtering.

--- a/neurom/features/neurite.py
+++ b/neurom/features/neurite.py
@@ -48,7 +48,6 @@ from functools import partial
 from itertools import chain
 
 import numpy as np
-import scipy
 from neurom import morphmath
 from neurom.core.morphology import Section
 from neurom.core.dataformat import COLS

--- a/neurom/features/neurite.py
+++ b/neurom/features/neurite.py
@@ -457,14 +457,12 @@ def volume_density(neurite):
 
     .. note:: Returns `np.nan` if the convex hull computation fails.
     """
-    try:
-        volume = convex_hull(neurite).volume
-    except scipy.spatial.qhull.QhullError:
-        L.exception('Failure to compute neurite volume using the convex hull. '
-                    'Feature `volume_density` will return `np.nan`.\n')
+    neurite_hull = convex_hull(neurite.points[:, COLS.XYZ])
+
+    if neurite_hull is None:
         return np.nan
 
-    return neurite.volume / volume
+    return neurite.volume / neurite_hull.volume
 
 
 @feature(shape=(...,))

--- a/neurom/features/neurite.py
+++ b/neurom/features/neurite.py
@@ -457,11 +457,7 @@ def volume_density(neurite):
     .. note:: Returns `np.nan` if the convex hull computation fails.
     """
     neurite_hull = convex_hull(neurite.points[:, COLS.XYZ])
-
-    if neurite_hull is None:
-        return np.nan
-
-    return neurite.volume / neurite_hull.volume
+    return neurite.volume / neurite_hull.volume if neurite_hull is not None else np.nan
 
 
 @feature(shape=(...,))

--- a/neurom/geom/__init__.py
+++ b/neurom/geom/__init__.py
@@ -56,12 +56,18 @@ def convex_hull(point_data):
     Returns:
         scipy.spatial.ConvexHull object if successful, otherwise None
     """
-    assert len(point_data) > 0, "Empty array passed to convex hull function."
+    if len(point_data) == 0:
+        L.exception(
+            "Failure to compute convex hull because there are no points"
+        )
+        return None
 
     points = np.asarray(point_data)[:, COLS.XYZ]
+
     try:
         return ConvexHull(points)
     except QhullError:
-        L.exception('Failure to compute neurite volume using the convex hull. '
-                    'Feature `volume_density` will return `np.nan`.\n')
+        L.exception(
+            "Failure to compute convex hull because points like on a 2D plane."
+        )
         return None

--- a/neurom/geom/__init__.py
+++ b/neurom/geom/__init__.py
@@ -51,7 +51,7 @@ def bounding_box(obj):
 
 
 def convex_hull(point_data):
-    """Get the convex hull from point data
+    """Get the convex hull from point data.
 
     Returns:
         scipy.spatial.ConvexHull object if successful, otherwise None

--- a/neurom/geom/__init__.py
+++ b/neurom/geom/__init__.py
@@ -28,10 +28,16 @@
 
 """Geometrical Operations for NeuroM."""
 
+import logging
+
 import numpy as np
 from scipy.spatial import ConvexHull
+from scipy.spatial.qhull import QhullError
 from neurom.core.dataformat import COLS
 from neurom.geom.transform import translate, rotate
+
+
+L = logging.getLogger(__name__)
 
 
 def bounding_box(obj):
@@ -44,10 +50,18 @@ def bounding_box(obj):
                      np.max(obj.points[:, COLS.XYZ], axis=0)])
 
 
-def convex_hull(obj):
-    """Get the convex hull of an object containing points.
+def convex_hull(point_data):
+    """Get the convex hull from point data
 
     Returns:
-        scipy.spatial.ConvexHull object built from obj.points
+        scipy.spatial.ConvexHull object if successful, otherwise None
     """
-    return ConvexHull(obj.points[:, COLS.XYZ])
+    assert len(point_data) > 0, "Empty array passed to convex hull function."
+
+    points = np.asarray(point_data)[:, COLS.XYZ]
+    try:
+        return ConvexHull(points)
+    except QhullError:
+        L.exception('Failure to compute neurite volume using the convex hull. '
+                    'Feature `volume_density` will return `np.nan`.\n')
+        return None

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -486,6 +486,22 @@ def test_neurite_density():
         (0.24068543213643726, 0.52464681266899216, 0.76533224480542938, 0.38266612240271469))
 
 
+def test_morphology_volume_density():
+
+    volume_density = features.get("volume_density", NEURON)
+
+    # volume density should not be calculated as the sum of the neurite volume densities,
+    # because it is not additive
+    volume_density_from_neurites = sum(
+        features.get("volume_density", neu) for neu in NEURON.neurites
+    )
+
+    # calculating the convex hull per neurite, results into smaller hull volumes and higher
+    # neurite_volume / hull_volume ratios
+    assert not np.isclose(volume_density, volume_density_from_neurites)
+    assert volume_density < volume_density_from_neurites
+
+
 def test_section_lengths():
     ref_seclen = [n.length for n in iter_sections(NEURON)]
     seclen = features.get('section_lengths', NEURON)

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -496,7 +496,7 @@ def test_morphology_volume_density():
         features.get("volume_density", neu) for neu in NEURON.neurites
     )
 
-    # calculating the convex hull per neurite, results into smaller hull volumes and higher
+    # calculating the convex hull per neurite results into smaller hull volumes and higher
     # neurite_volume / hull_volume ratios
     assert not np.isclose(volume_density, volume_density_from_neurites)
     assert volume_density < volume_density_from_neurites

--- a/tests/features/test_morphology.py
+++ b/tests/features/test_morphology.py
@@ -619,7 +619,7 @@ def test_volume_density():
     """)
 
     # the neurites sprout from the center of a cube to its vertices, therefore the convex hull
-    # is the cube itself of side 2.0
+    # is the cube itself of side 1.0
     expected_hull_volume = 1.0
 
     # diagonal - radius

--- a/tests/features/test_neurite.py
+++ b/tests/features/test_neurite.py
@@ -65,7 +65,7 @@ def test_number_of_leaves():
 
 def test_neurite_volume_density():
     vol = np.array(morphology.total_volume_per_neurite(NRN))
-    hull_vol = np.array([convex_hull(n).volume for n in nm.iter_neurites(NRN)])
+    hull_vol = np.array([convex_hull(n.points).volume for n in nm.iter_neurites(NRN)])
 
     vol_density = [neurite.volume_density(s) for s in NRN.neurites]
     assert len(vol_density) == 4
@@ -77,10 +77,18 @@ def test_neurite_volume_density():
 
 
 def test_neurite_volume_density_failed_convex_hull():
-    with patch('neurom.features.neurite.convex_hull',
-               side_effect=scipy.spatial.qhull.QhullError('boom')):
-        vol_density = neurite.volume_density(NRN)
-        assert vol_density, np.nan
+
+    flat_neuron = nm.load_morphology(
+    """
+    1  1   0  0  0  0.5 -1
+    2  3   1  0  0  0.1  1
+    3  3   2  0  0  0.1  2
+    """,
+    reader="swc")
+
+    assert np.isnan(
+        neurite.volume_density(flat_neuron.neurites[0])
+    )
 
 
 def test_terminal_path_length_per_neurite():

--- a/tests/geom/test_geom.py
+++ b/tests/geom/test_geom.py
@@ -87,3 +87,8 @@ def test_convex_hull_volume():
     # to re-test scipy, so simply regression test the volume
     hull = geom.convex_hull(NRN.points[:, COLS.XYZ])
     assert_almost_equal(hull.volume, 208641, decimal=0)
+
+
+def test_convex_hull_invalid():
+    assert geom.convex_hull([]) is None
+    assert geom.convex_hull([[1., 0., 0.], [1., 0., 0.]]) is None

--- a/tests/geom/test_geom.py
+++ b/tests/geom/test_geom.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import neurom as nm
 import numpy as np
 from neurom import geom
+from neurom.core.dataformat import COLS
 from numpy.testing import assert_almost_equal
 
 SWC_DATA_PATH = Path(__file__).parent.parent / 'data/swc'
@@ -76,7 +77,7 @@ def test_convex_hull_points():
 
     # This leverages scipy ConvexHull and we don't want
     # to re-test scipy, so simply check that the points are the same.
-    hull = geom.convex_hull(NRN)
+    hull = geom.convex_hull(NRN.points[:, COLS.XYZ])
     assert np.alltrue(hull.points == NRN.points[:, :3])
 
 
@@ -84,5 +85,5 @@ def test_convex_hull_volume():
 
     # This leverages scipy ConvexHull and we don't want
     # to re-test scipy, so simply regression test the volume
-    hull = geom.convex_hull(NRN)
+    hull = geom.convex_hull(NRN.points[:, COLS.XYZ])
     assert_almost_equal(hull.volume, 208641, decimal=0)


### PR DESCRIPTION
* Adds `volume_density` at the morphology level.
* When a morphology is passed in get and volume_density is called, there is no more delegation to the neurite version of the feature
* Adds exhaustive testing

Fixes #995 