### PR TITLE
Update `neurom.features.get` docstring with available builtin features

### DIFF
--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -195,17 +195,17 @@ from neurom.features import neurite, morphology, \
 def _features_catalogue():
     """Returns a string with all the available builtin features."""
     indentation = "\t"
-    title = "\n    Builtin Features:\n"
+    preamble = "\n    .. Builtin Features:\n"
 
     def format_category(category):
-        separator = "=" * len(category)
+        separator = "-" * len(category)
         return f"\n{indentation}{category}\n{indentation}{separator}"
 
     def format_features(features):
         prefix = f"\n{indentation}* "
         return prefix + f"{prefix}".join(sorted(features))
 
-    return title + "".join(
+    return preamble + "".join(
         [
             format_category(category) + format_features(features) + "\n"
             for category, features in zip(

--- a/neurom/features/__init__.py
+++ b/neurom/features/__init__.py
@@ -190,3 +190,31 @@ def feature(shape, namespace: NameSpace, name=None):
 # These imports are necessary in order to register the features
 from neurom.features import neurite, morphology, \
     population  # noqa, pylint: disable=wrong-import-position
+
+
+def _features_catalogue():
+    """Returns a string with all the available builtin features."""
+    indentation = "\t"
+    title = "\n    Builtin Features:\n"
+
+    def format_category(category):
+        separator = "=" * len(category)
+        return f"\n{indentation}{category}\n{indentation}{separator}"
+
+    def format_features(features):
+        prefix = f"\n{indentation}* "
+        return prefix + f"{prefix}".join(sorted(features))
+
+    return title + "".join(
+        [
+            format_category(category) + format_features(features) + "\n"
+            for category, features in zip(
+                ("Population", "Morphology", "Neurite"),
+                (_POPULATION_FEATURES, _MORPHOLOGY_FEATURES, _NEURITE_FEATURES),
+            )
+        ]
+    )
+
+
+# Update the get docstring to include all available builtin features
+get.__doc__ += _features_catalogue()


### PR DESCRIPTION
Implements #1014 
Example resulting docstring:
```
Obtain a feature from a set of morphology objects.

Features can be either Neurite, Morphology or Population features. For Neurite features see
:mod:`neurom.features.neurite`. For Morphology features see :mod:`neurom.features.morphology`.
For Population features see :mod:`neurom.features.population`.

Arguments:
    feature_name(string): feature to extract
    obj: a morphology, a morphology population or a neurite tree
    kwargs: parameters to forward to underlying worker functions

Returns:
    List|Number: feature value as a list or a single number.

.. Builtin Features:

    Population
    ----------
    * sholl_frequency

    Morphology
    ----------
    * aspect_ratio
    * circularity
    * max_radial_distance
    * neurite_volume_density
    * number_of_neurites
    * number_of_sections_per_neurite
    * shape_factor
    * sholl_crossings
    * sholl_frequency
    * soma_radius
    * soma_surface_area
    * soma_volume
    * total_area_per_neurite
    * total_depth
    * total_height
    * total_length_per_neurite
    * total_volume_per_neurite
    * total_width
    * trunk_angles
    * trunk_angles_from_vector
    * trunk_angles_inter_types
    * trunk_origin_azimuths
    * trunk_origin_elevations
    * trunk_origin_radii
    * trunk_section_lengths
    * trunk_vectors
    * volume_density

    Neurite
    -------
    * bifurcation_partitions
    * diameter_power_relations
    * local_bifurcation_angles
    * max_radial_distance
    * number_of_bifurcations
    * number_of_forking_points
    * number_of_leaves
    * number_of_sections
    * number_of_segments
    * partition_asymmetry
    * partition_asymmetry_length


```