### PR TITLE
Return nan if no points found in shape features

### DIFF
--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -643,7 +643,7 @@ def aspect_ratio(morph, neurite_type=NeuriteType.all, projection_plane="xy"):
         The aspect ratio feature of the morphology points.
     """
     projected_points = _unique_projected_points(morph, projection_plane, neurite_type)
-    return [] if len(projected_points) == 0 else morphmath.aspect_ratio(projected_points)
+    return np.nan if len(projected_points) == 0 else morphmath.aspect_ratio(projected_points)
 
 
 @feature(shape=())
@@ -663,7 +663,7 @@ def circularity(morph, neurite_type=NeuriteType.all, projection_plane="xy"):
         The circularity of the morphology points.
     """
     projected_points = _unique_projected_points(morph, projection_plane, neurite_type)
-    return [] if len(projected_points) == 0 else morphmath.circularity(projected_points)
+    return np.nan if len(projected_points) == 0 else morphmath.circularity(projected_points)
 
 
 @feature(shape=())
@@ -683,4 +683,4 @@ def shape_factor(morph, neurite_type=NeuriteType.all, projection_plane="xy"):
         The shape factor of the morphology points.
     """
     projected_points = _unique_projected_points(morph, projection_plane, neurite_type)
-    return [] if len(projected_points) == 0 else morphmath.shape_factor(projected_points)
+    return np.nan if len(projected_points) == 0 else morphmath.shape_factor(projected_points)

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -916,6 +916,7 @@ def test_aspect_ratio():
         0.731076,
         decimal=6
     )
+    assert np.isnan(features.get("aspect_ratio", morph, neurite_type=nm.NeuriteType.custom5))
 
 
 def test_circularity():
@@ -942,6 +943,7 @@ def test_circularity():
         0.730983,
         decimal=6
     )
+    assert np.isnan(features.get("circularity", morph, neurite_type=nm.NeuriteType.custom5))
 
 
 def test_shape_factor():
@@ -968,3 +970,4 @@ def test_shape_factor():
         0.364678,
         decimal=6
     )
+    assert np.isnan(features.get("shape_factor", morph, neurite_type=nm.NeuriteType.custom5))


### PR DESCRIPTION
Given that morphology shape features return single numbers, it's more meaningful to return NaN when no points have been found for the specific type, instead of returning an empty list.