### PR TITLE
Allow using lists of kwargs in morph_stats features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Version 3.2.0
 -------------
 
+- List of multiple kwargs configurations are now allowed in``neurom.apps.morph_stats``.
 - ``neurom.features.neurite.principal_direction_extents`` directions correspond to extents
   ordered in a descending order.
 - Add features ``neurom.features.morphology.(aspect_ration, circularity, shape_factor)```

--- a/doc/source/morph_stats.rst
+++ b/doc/source/morph_stats.rst
@@ -58,7 +58,7 @@ Short format (prior version 3.0.0)
 An example config:
 
 .. code-block:: yaml
-    
+
     neurite:
         section_lengths:
             - max
@@ -67,13 +67,13 @@ An example config:
             - total
         section_branch_orders:
             - max
-    
+
     neurite_type:
         - AXON
         - APICAL_DENDRITE
         - BASAL_DENDRITE
         - ALL
-    
+
     neuron:
         soma_radius:
             - mean
@@ -93,7 +93,7 @@ function, e.g.
 * ``raw``: array of raw values
 * ``max``, ``min``, ``mean``, ``median``, ``std``: self-explanatory.
 * ``total``: sum of the raw values
-  
+
 An additional field ``neurite_type`` specifies the neurite types into which the morphometrics
 are to be split. It applies only to ``neurite`` features. A sample output using the above
 configuration:
@@ -196,6 +196,66 @@ So the example config from `Short format (prior version 3.0.0)`_ looks:
         soma_radius:
             modes:
                - mean
+
+
+List of features format (starting version 3.2.0)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The kwargs format was extended to allow the listing of the same feature multiple times with different kwargs.
+
+The ``partition_asymmetry`` feature in the example above can be specified multiple times with different arguments as follows:
+
+.. code-block:: yaml
+
+    neurite:
+    - - partion_asymmetry:
+      - kwargs:
+          variant: 'length'
+          method: 'petilla'
+        modes:
+          - max
+          - sum
+    - - partion_asymmetry:
+      - kwargs:
+          variant: 'branch-order'
+          method: 'uylings'
+        modes:
+          - min
+          - sum
+
+To allow differentiation between the features multiples, the keys and values of the kwargs are appended at the end of the feature name:
+
+.. code-block::
+
+    partition_asymmetry__variant:length__method:petilla
+    partition_asymmetry__variant:branch-order__method:uylings
+
+The example config from `Short format (prior version 3.0.0)`_ becomes:
+
+.. code-block:: yaml
+
+  neurite:
+  - - section_lengths
+    - modes:
+      - max
+      - sum
+  - - section_volumes:
+    - modes:
+      - sum
+  - - section_branch_orders:
+    - modes:
+      - max
+
+  neurite_type:
+    - AXON
+    - APICAL_DENDRITE
+    - BASAL_DENDRITE
+    - ALL
+
+  morphology:
+  - - soma_radius:
+    - modes:
+      - mean
 
 
 Features

--- a/doc/source/morph_stats.rst
+++ b/doc/source/morph_stats.rst
@@ -201,29 +201,22 @@ So the example config from `Short format (prior version 3.0.0)`_ looks:
 List of features format (starting version 3.2.0)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The kwargs format was extended to allow the listing of the same feature multiple times with different kwargs.
-
-The ``partition_asymmetry`` feature in the example above can be specified multiple times with different arguments as follows:
+The kwargs entry was converted into a list to allow running the same feature with different arguments. The ``partition_asymmetry`` feature in the example above can be specified multiple times with different arguments as follows:
 
 .. code-block:: yaml
 
     neurite:
-    - - partion_asymmetry:
-      - kwargs:
-          variant: 'length'
-          method: 'petilla'
+      partition_asymmetry:
+        kwargs:
+        - method: petilla
+          variant: length
+        - method: uylings
+          variant: branch-order
         modes:
-          - max
-          - sum
-    - - partion_asymmetry:
-      - kwargs:
-          variant: 'branch-order'
-          method: 'uylings'
-        modes:
-          - min
-          - sum
+        - max
+        - sum
 
-To allow differentiation between the features multiples, the keys and values of the kwargs are appended at the end of the feature name:
+To allow differentiation between the feature multiples, the keys and values of the kwargs are appended at the end of the feature name:
 
 .. code-block::
 
@@ -234,28 +227,34 @@ The example config from `Short format (prior version 3.0.0)`_ becomes:
 
 .. code-block:: yaml
 
-  neurite:
-  - - section_lengths
-    - modes:
-      - max
-      - sum
-  - - section_volumes:
-    - modes:
-      - sum
-  - - section_branch_orders:
-    - modes:
-      - max
-
-  neurite_type:
+    neurite:
+      section_branch_orders:
+        kwargs:
+        - {}
+        modes:
+        - max
+      section_lengths:
+        kwargs:
+        - {}
+        modes:
+        - max
+        - sum
+      section_volumes:
+        kwargs:
+        - {}
+        modes:
+        - sum
+    morphology:
+      soma_radius:
+        kwargs:
+        - {}
+        modes:
+        - mean
+    neurite_type:
     - AXON
     - APICAL_DENDRITE
     - BASAL_DENDRITE
     - ALL
-
-  morphology:
-  - - soma_radius:
-    - modes:
-      - mean
 
 
 Features

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -74,9 +74,11 @@ def extract_dataframe(morphs, config, n_workers=1):
         config (dict): configuration dict. The keys are:
             - neurite_type: a list of neurite types for which features are extracted
               If not provided, all neurite_type will be used
-            - neurite: a dictionary {{neurite_feature: mode}} where:
-                - neurite_feature is a string from NEURITEFEATURES or NEURONFEATURES
-                - mode is an aggregation operation provided as a string such as:
+            - neurite:
+                Either a list of features: [feature_name, {kwargs: {}, modes: []}] or
+                a dictionary of features {feature_name: {kwargs: {}, modes: []}}.
+                - kwargs is an optional entry allowing to pass kwargs to the feature function
+                - modes is an aggregation operation provided as a string such as:
                   ['min', 'max', 'median', 'mean', 'std', 'raw', 'sum']
             - morphology: same as neurite entry, but it will not be run on each neurite_type,
               but only once on the whole morphology.
@@ -88,7 +90,6 @@ def extract_dataframe(morphs, config, n_workers=1):
     Note:
         An example config can be found at:
 
-    {config_path}
     """
     if isinstance(morphs, Morphology):
         morphs = [morphs]
@@ -110,7 +111,7 @@ def extract_dataframe(morphs, config, n_workers=1):
     return pd.DataFrame(columns=pd.MultiIndex.from_tuples(columns), data=rows)
 
 
-extract_dataframe.__doc__ = extract_dataframe.__doc__.format(config_path=EXAMPLE_CONFIG)
+extract_dataframe.__doc__ += str(EXAMPLE_CONFIG)
 
 
 def _get_feature_stats(feature_name, morphs, modes, kwargs):
@@ -168,7 +169,12 @@ def extract_stats(morphs, config):
         config (dict): configuration dict. The keys are:
             - neurite_type: a list of neurite types for which features are extracted
               If not provided, all neurite_type will be used.
-            - neurite: a dictionary {{neurite_feature: mode}} where:
+            - neurite:
+                Either a list of features: [feature_name, {kwargs: {}, modes: []}] or
+                a dictionary of features {feature_name: {kwargs: {}, modes: []}}.
+                - kwargs is an optional entry allowing to pass kwargs to the feature function
+                - modes is an aggregation operation provided as a string such as:
+                  ['min', 'max', 'median', 'mean', 'std', 'raw', 'sum']
                 - neurite_feature is a string from NEURITEFEATURES or NEURONFEATURES
                 - mode is an aggregation operation provided as a string such as:
                   ['min', 'max', 'median', 'mean', 'std', 'raw', 'sum']
@@ -181,7 +187,6 @@ def extract_stats(morphs, config):
     Note:
         An example config can be found at:
 
-    {config_path}
     """
     config = _sanitize_config(config)
 
@@ -214,7 +219,7 @@ def extract_stats(morphs, config):
     return dict(stats)
 
 
-extract_stats.__doc__ = extract_stats.__doc__.format(config_path=EXAMPLE_CONFIG)
+extract_stats.__doc__ += str(EXAMPLE_CONFIG)
 
 
 def _get_header(results):

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -287,6 +287,9 @@ def _sanitize_config(config):
     """Check that the config has the correct keys, add missing keys if necessary."""
     config = deepcopy(config)
 
+    if "neuron" in config:
+        config["morphology"] = config.pop("neuron")
+
     for category in ("neurite", "morphology", "population"):
         config[category] = _kwargs_modes_layout(config[category]) if category in config else []
 

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -43,6 +43,7 @@ from pandas.testing import assert_frame_equal
 
 DATA_PATH = Path(__file__).parent.parent / 'data'
 SWC_PATH = DATA_PATH / 'swc'
+
 REF_CONFIG = {
     'neurite': {
         'section_lengths': ['max', 'sum'],
@@ -72,6 +73,23 @@ REF_CONFIG_NEW = {
         'max_radial_distance': {'modes': ['mean']},
     }
 }
+
+REF_CONFIG_LIST_FEATURES = {
+    'neurite': [
+        ['section_lengths', {'modes': ['max', 'sum']}],
+        ['section_volumes', {'modes': ['sum']}],
+        ['section_branch_orders', {'modes': ['max', 'raw']}],
+        ['segment_midpoints', {'modes': ['max']}],
+        ['max_radial_distance', {'modes': ['mean']}],
+    ],
+    'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
+    'morphology': [
+        ['soma_radius', {'modes': ['mean']}],
+        ['max_radial_distance', {'modes': ['mean']}],
+    ],
+}
+
+
 
 REF_OUT = {
     'morphology': {
@@ -634,6 +652,13 @@ def test_sanitize_config():
         ],
         "population": [],
     }
+
+    # check that all formats are converted to the same sanitized config:
+    assert (
+        ms._sanitize_config(REF_CONFIG)
+        == ms._sanitize_config(REF_CONFIG_NEW)
+        == ms._sanitize_config(REF_CONFIG_LIST_FEATURES)
+    )
 
 
 def test_multidimensional_features():

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -181,6 +181,109 @@ def test_extract_stats_scalar_feature():
                    'morphology': {'sum_soma_volume': 1424.4383771584492}}
 
 
+
+def test_extract_stats__kwarg_modes_multiple_features():
+
+    m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
+    config = {
+        'neurite': [
+            ['principal_direction_extents', {'kwargs': {"direction": 2}, 'modes': ['sum', "min"]}],
+            ['principal_direction_extents', {'kwargs': {"direction": 1}, 'modes': ['sum', "max"]}],
+            ['principal_direction_extents', {'kwargs': {"direction": 0}, 'modes': ['mean']}],
+        ],
+        'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
+        'morphology': [
+            ['soma_radius', {'modes': ['mean']}],
+            ['partition_asymmetry', {
+                'kwargs': {'variant': 'branch-order', 'method': 'petilla'},
+                'modes': ['min', 'max'],
+            }],
+            ['partition_asymmetry', {
+                'kwargs': {'variant': 'length', 'method': 'uylings'},
+                'modes': ['min', 'max'],
+            }]
+        ]
+    }
+
+    res = ms.extract_stats(m, config)
+
+    assert set(res.keys()) == {"axon", "basal_dendrite", "apical_dendrite", "all", "morphology"}
+
+    for key in ("axon", "basal_dendrite", "apical_dendrite", "all"):
+
+        assert set(res[key].keys()) == {
+            "sum_principal_direction_extents__direction:2",
+            "min_principal_direction_extents__direction:2",
+            "sum_principal_direction_extents__direction:1",
+            "max_principal_direction_extents__direction:1",
+            "mean_principal_direction_extents__direction:0",
+        }
+
+    assert set(res["morphology"].keys()) == {
+        "mean_soma_radius",
+        "min_partition_asymmetry__variant:branch-order_method:petilla",
+        "max_partition_asymmetry__variant:branch-order_method:petilla",
+        "min_partition_asymmetry__variant:length_method:uylings",
+        "max_partition_asymmetry__variant:length_method:uylings",
+    }
+
+
+def test_extract_dataframe__kwarg_modes_multiple_features():
+    m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
+    config = {
+        'neurite': [
+            ['principal_direction_extents', {'kwargs': {"direction": 2}, 'modes': ['sum', "min"]}],
+            ['principal_direction_extents', {'kwargs': {"direction": 1}, 'modes': ['sum', "max"]}],
+            ['principal_direction_extents', {'kwargs': {"direction": 0}, 'modes': ['mean']}],
+        ],
+        'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
+        'morphology': [
+            ['soma_radius', {'modes': ['mean']}],
+            ['partition_asymmetry', {
+                'kwargs': {'variant': 'branch-order', 'method': 'petilla'},
+                'modes': ['min', 'max'],
+            }],
+            ['partition_asymmetry', {
+                'kwargs': {'variant': 'length', 'method': 'uylings'},
+                'modes': ['min', 'max'],
+            }]
+        ]
+    }
+
+    res = ms.extract_dataframe(m, config)
+
+    expected_columns = pd.MultiIndex.from_tuples([
+        ('property', 'name'),
+        ('axon', 'sum_principal_direction_extents__direction:2'),
+        ('axon', 'min_principal_direction_extents__direction:2'),
+        ('axon', 'sum_principal_direction_extents__direction:1'),
+        ('axon', 'max_principal_direction_extents__direction:1'),
+        ('axon', 'mean_principal_direction_extents__direction:0'),
+        ('apical_dendrite', 'sum_principal_direction_extents__direction:2'),
+        ('apical_dendrite', 'min_principal_direction_extents__direction:2'),
+        ('apical_dendrite', 'sum_principal_direction_extents__direction:1'),
+        ('apical_dendrite', 'max_principal_direction_extents__direction:1'),
+        ('apical_dendrite', 'mean_principal_direction_extents__direction:0'),
+        ('basal_dendrite', 'sum_principal_direction_extents__direction:2'),
+        ('basal_dendrite', 'min_principal_direction_extents__direction:2'),
+        ('basal_dendrite', 'sum_principal_direction_extents__direction:1'),
+        ('basal_dendrite', 'max_principal_direction_extents__direction:1'),
+        ('basal_dendrite', 'mean_principal_direction_extents__direction:0'),
+        ('all', 'sum_principal_direction_extents__direction:2'),
+        ('all', 'min_principal_direction_extents__direction:2'),
+        ('all', 'sum_principal_direction_extents__direction:1'),
+        ('all', 'max_principal_direction_extents__direction:1'),
+        ('all', 'mean_principal_direction_extents__direction:0'),
+        ('morphology', 'mean_soma_radius'),
+        ('morphology', 'min_partition_asymmetry__variant:branch-order_method:petilla'),
+        ('morphology', 'max_partition_asymmetry__variant:branch-order_method:petilla'),
+        ('morphology', 'min_partition_asymmetry__variant:length_method:uylings'),
+        ('morphology', 'max_partition_asymmetry__variant:length_method:uylings'),
+    ])
+
+    pd.testing.assert_index_equal(res.columns, expected_columns)
+
+
 def test_extract_dataframe():
     # Vanilla test
     initial_config = deepcopy(REF_CONFIG_NEW)

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -74,21 +74,6 @@ REF_CONFIG_NEW = {
     }
 }
 
-REF_CONFIG_LIST_FEATURES = {
-    'neurite': [
-        ['section_lengths', {'modes': ['max', 'sum']}],
-        ['section_volumes', {'modes': ['sum']}],
-        ['section_branch_orders', {'modes': ['max', 'raw']}],
-        ['segment_midpoints', {'modes': ['max']}],
-        ['max_radial_distance', {'modes': ['mean']}],
-    ],
-    'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
-    'morphology': [
-        ['soma_radius', {'modes': ['mean']}],
-        ['max_radial_distance', {'modes': ['mean']}],
-    ],
-}
-
 
 
 REF_OUT = {
@@ -204,23 +189,27 @@ def test_extract_stats__kwarg_modes_multiple_features():
 
     m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
     config = {
-        'neurite': [
-            ['principal_direction_extents', {'kwargs': {"direction": 2}, 'modes': ['sum', "min"]}],
-            ['principal_direction_extents', {'kwargs': {"direction": 1}, 'modes': ['sum', "max"]}],
-            ['principal_direction_extents', {'kwargs': {"direction": 0}, 'modes': ['mean']}],
-        ],
+        'neurite': {
+            'principal_direction_extents': {
+                'kwargs': [
+                    {"direction": 2},
+                    {"direction": 1},
+                    {"direction": 0},
+                ],
+                'modes': ['sum', "min"]
+            },
+        },
         'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
-        'morphology': [
-            ['soma_radius', {'modes': ['mean']}],
-            ['partition_asymmetry', {
-                'kwargs': {'variant': 'branch-order', 'method': 'petilla'},
+        'morphology': {
+            'soma_radius': {'modes': ['mean']},
+            'partition_asymmetry': {
+                'kwargs': [
+                    {'variant': 'branch-order', 'method': 'petilla'},
+                    {'variant': 'length', 'method': 'uylings'},
+                ],
                 'modes': ['min', 'max'],
-            }],
-            ['partition_asymmetry', {
-                'kwargs': {'variant': 'length', 'method': 'uylings'},
-                'modes': ['min', 'max'],
-            }]
-        ]
+            },
+        }
     }
 
     res = ms.extract_stats(m, config)
@@ -233,8 +222,9 @@ def test_extract_stats__kwarg_modes_multiple_features():
             "sum_principal_direction_extents__direction:2",
             "min_principal_direction_extents__direction:2",
             "sum_principal_direction_extents__direction:1",
-            "max_principal_direction_extents__direction:1",
-            "mean_principal_direction_extents__direction:0",
+            "min_principal_direction_extents__direction:1",
+            "sum_principal_direction_extents__direction:0",
+            "min_principal_direction_extents__direction:0",
         }
 
     assert set(res["morphology"].keys()) == {
@@ -249,23 +239,27 @@ def test_extract_stats__kwarg_modes_multiple_features():
 def test_extract_dataframe__kwarg_modes_multiple_features():
     m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
     config = {
-        'neurite': [
-            ['principal_direction_extents', {'kwargs': {"direction": 2}, 'modes': ['sum', "min"]}],
-            ['principal_direction_extents', {'kwargs': {"direction": 1}, 'modes': ['sum', "max"]}],
-            ['principal_direction_extents', {'kwargs': {"direction": 0}, 'modes': ['mean']}],
-        ],
+        'neurite': {
+            'principal_direction_extents': {
+                'kwargs': [
+                    {"direction": 2},
+                    {"direction": 1},
+                    {"direction": 0},
+                ],
+                'modes': ['sum', "min"],
+            },
+        },
         'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
-        'morphology': [
-            ['soma_radius', {'modes': ['mean']}],
-            ['partition_asymmetry', {
-                'kwargs': {'variant': 'branch-order', 'method': 'petilla'},
+        'morphology': {
+            'soma_radius': {'modes': ['mean']},
+            'partition_asymmetry': {
+                'kwargs': [
+                    {'variant': 'branch-order', 'method': 'petilla'},
+                    {'variant': 'length', 'method': 'uylings'},
+                ],
                 'modes': ['min', 'max'],
-            }],
-            ['partition_asymmetry', {
-                'kwargs': {'variant': 'length', 'method': 'uylings'},
-                'modes': ['min', 'max'],
-            }]
-        ]
+            },
+        },
     }
 
     res = ms.extract_dataframe(m, config)
@@ -275,23 +269,27 @@ def test_extract_dataframe__kwarg_modes_multiple_features():
         ('axon', 'sum_principal_direction_extents__direction:2'),
         ('axon', 'min_principal_direction_extents__direction:2'),
         ('axon', 'sum_principal_direction_extents__direction:1'),
-        ('axon', 'max_principal_direction_extents__direction:1'),
-        ('axon', 'mean_principal_direction_extents__direction:0'),
+        ('axon', 'min_principal_direction_extents__direction:1'),
+        ('axon', 'sum_principal_direction_extents__direction:0'),
+        ('axon', 'min_principal_direction_extents__direction:0'),
         ('apical_dendrite', 'sum_principal_direction_extents__direction:2'),
         ('apical_dendrite', 'min_principal_direction_extents__direction:2'),
         ('apical_dendrite', 'sum_principal_direction_extents__direction:1'),
-        ('apical_dendrite', 'max_principal_direction_extents__direction:1'),
-        ('apical_dendrite', 'mean_principal_direction_extents__direction:0'),
+        ('apical_dendrite', 'min_principal_direction_extents__direction:1'),
+        ('apical_dendrite', 'sum_principal_direction_extents__direction:0'),
+        ('apical_dendrite', 'min_principal_direction_extents__direction:0'),
         ('basal_dendrite', 'sum_principal_direction_extents__direction:2'),
         ('basal_dendrite', 'min_principal_direction_extents__direction:2'),
         ('basal_dendrite', 'sum_principal_direction_extents__direction:1'),
-        ('basal_dendrite', 'max_principal_direction_extents__direction:1'),
-        ('basal_dendrite', 'mean_principal_direction_extents__direction:0'),
+        ('basal_dendrite', 'min_principal_direction_extents__direction:1'),
+        ('basal_dendrite', 'sum_principal_direction_extents__direction:0'),
+        ('basal_dendrite', 'min_principal_direction_extents__direction:0'),
         ('all', 'sum_principal_direction_extents__direction:2'),
         ('all', 'min_principal_direction_extents__direction:2'),
         ('all', 'sum_principal_direction_extents__direction:1'),
-        ('all', 'max_principal_direction_extents__direction:1'),
-        ('all', 'mean_principal_direction_extents__direction:0'),
+        ('all', 'min_principal_direction_extents__direction:1'),
+        ('all', 'sum_principal_direction_extents__direction:0'),
+        ('all', 'min_principal_direction_extents__direction:0'),
         ('morphology', 'mean_soma_radius'),
         ('morphology', 'min_partition_asymmetry__variant:branch-order__method:petilla'),
         ('morphology', 'max_partition_asymmetry__variant:branch-order__method:petilla'),
@@ -576,22 +574,22 @@ def test_full_config():
     config = ms.full_config()
     assert set(config.keys()) == {'neurite', 'population', 'morphology', 'neurite_type'}
 
-    assert set(entry[0] for entry in config['neurite']) == set(_NEURITE_FEATURES.keys())
-    assert set(entry[0] for entry in config['morphology']) == set(_MORPHOLOGY_FEATURES.keys())
-    assert set(entry[0] for entry in config['population']) == set(_POPULATION_FEATURES.keys())
+    assert set(config['neurite'].keys()) == set(_NEURITE_FEATURES.keys())
+    assert set(config['morphology'].keys()) == set(_MORPHOLOGY_FEATURES.keys())
+    assert set(config['population'].keys()) == set(_POPULATION_FEATURES.keys())
 
 
-def test_convert_to_kwargs_modes_layout():
+def test_standardize_layout():
     """Converts the config category entries (e.g. neurite, morphology, population) to using
     the kwarg and modes layout.
     """
     # from short format
     entry = {"f1": ["min", "max"], "f2": ["min"], "f3": []}
-    assert ms._kwargs_modes_layout(entry) == [
-        ["f1", {"kwargs": {}, "modes": ["min", "max"]}],
-        ["f2", {"kwargs": {}, "modes": ["min"]}],
-        ["f3", {"kwargs": {}, "modes": []}],
-    ]
+    assert ms._standardize_layout(entry) == {
+        "f1": {"kwargs": [{}], "modes": ["min", "max"]},
+        "f2": {"kwargs": [{}], "modes": ["min"]},
+        "f3": {"kwargs": [{}], "modes": []},
+    }
 
     # from kwarg/modes with missing options
     entry = {
@@ -600,26 +598,26 @@ def test_convert_to_kwargs_modes_layout():
         "f3": {"kwargs": {"a1": 1, "a2": 2}},
         "f4": {},
     }
-    assert ms._kwargs_modes_layout(entry) == [
-        ["f1", {"kwargs": {"a1": 1, "a2": 2}, "modes": ["min", "max"]}],
-        ["f2", {"kwargs": {}, "modes": ["min", "median"]}],
-        ["f3", {"kwargs": {"a1": 1, "a2": 2}, "modes": []}],
-        ["f4", {"kwargs": {}, "modes": []}],
-    ]
+    assert ms._standardize_layout(entry) == {
+        "f1": {"kwargs": [{"a1": 1, "a2": 2}], "modes": ["min", "max"]},
+        "f2": {"kwargs": [{}], "modes": ["min", "median"]},
+        "f3": {"kwargs": [{"a1": 1, "a2": 2}], "modes": []},
+        "f4": {"kwargs": [{}], "modes": []},
+    }
 
-    # from list layout
-    entry = [
-        ["f1", {"kwargs": {"a1": 1, "a2": 2}, "modes": ["min", "max"]}],
-        ["f2", {"modes": ["min", "median"]}],
-        ["f3", {"kwargs": {"a1": 1, "a2": 2}}],
-        ["f4", {}],
-    ]
-    assert ms._kwargs_modes_layout(entry) == [
-        ["f1", {"kwargs": {"a1": 1, "a2": 2}, "modes": ["min", "max"]}],
-        ["f2", {"kwargs": {}, "modes": ["min", "median"]}],
-        ["f3", {"kwargs": {"a1": 1, "a2": 2}, "modes": []}],
-        ["f4", {"kwargs": {}, "modes": []}],
-    ]
+    # from list of kwargs format
+    entry = {
+        "f1": {"kwargs": [{"a1": 1, "a2": 2}], "modes": ["min", "max"]},
+        "f2": {"modes": ["min", "median"]},
+        "f3": {"kwargs": [{"a1": 1, "a2": 2}]},
+        "f4": {},
+    }
+    assert ms._standardize_layout(entry) == {
+        "f1": {"kwargs": [{"a1": 1, "a2": 2}], "modes": ["min", "max"]},
+        "f2": {"kwargs": [{}], "modes": ["min", "median"]},
+        "f3": {"kwargs": [{"a1": 1, "a2": 2}], "modes": []},
+        "f4": {"kwargs": [{}], "modes": []},
+    }
 
 
 def test_sanitize_config():
@@ -641,16 +639,16 @@ def test_sanitize_config():
     new_config = ms._sanitize_config(full_config)
 
     expected_config = {
-        'neurite': [
-            ['section_lengths', {"kwargs": {}, "modes": ['max', 'sum']}],
-            ['section_volumes', {"kwargs": {}, "modes": ['sum']}],
-            ['section_branch_orders', {"kwargs": {}, "modes": ['max']}],
-        ],
+        'neurite': {
+            'section_lengths': {"kwargs": [{}], "modes": ['max', 'sum']},
+            'section_volumes': {"kwargs": [{}], "modes": ['sum']},
+            'section_branch_orders': {"kwargs": [{}], "modes": ['max']},
+        },
         'neurite_type': ['AXON', 'APICAL_DENDRITE', 'BASAL_DENDRITE', 'ALL'],
-        'morphology': [
-            ['soma_radius', {"kwargs": {}, "modes": ["mean"]}],
-        ],
-        "population": [],
+        'morphology': {
+            'soma_radius': {"kwargs": [{}], "modes": ["mean"]},
+        },
+        "population": {},
     }
     assert new_config == expected_config
 
@@ -659,11 +657,7 @@ def test_sanitize_config():
     assert ms._sanitize_config(full_config) == expected_config
 
     # check that all formats are converted to the same sanitized config:
-    assert (
-        ms._sanitize_config(REF_CONFIG)
-        == ms._sanitize_config(REF_CONFIG_NEW)
-        == ms._sanitize_config(REF_CONFIG_LIST_FEATURES)
-    )
+    assert ms._sanitize_config(REF_CONFIG) == ms._sanitize_config(REF_CONFIG_NEW)
 
 
 def test_multidimensional_features():

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -221,10 +221,10 @@ def test_extract_stats__kwarg_modes_multiple_features():
 
     assert set(res["morphology"].keys()) == {
         "mean_soma_radius",
-        "min_partition_asymmetry__variant:branch-order_method:petilla",
-        "max_partition_asymmetry__variant:branch-order_method:petilla",
-        "min_partition_asymmetry__variant:length_method:uylings",
-        "max_partition_asymmetry__variant:length_method:uylings",
+        "min_partition_asymmetry__variant:branch-order__method:petilla",
+        "max_partition_asymmetry__variant:branch-order__method:petilla",
+        "min_partition_asymmetry__variant:length__method:uylings",
+        "max_partition_asymmetry__variant:length__method:uylings",
     }
 
 
@@ -275,10 +275,10 @@ def test_extract_dataframe__kwarg_modes_multiple_features():
         ('all', 'max_principal_direction_extents__direction:1'),
         ('all', 'mean_principal_direction_extents__direction:0'),
         ('morphology', 'mean_soma_radius'),
-        ('morphology', 'min_partition_asymmetry__variant:branch-order_method:petilla'),
-        ('morphology', 'max_partition_asymmetry__variant:branch-order_method:petilla'),
-        ('morphology', 'min_partition_asymmetry__variant:length_method:uylings'),
-        ('morphology', 'max_partition_asymmetry__variant:length_method:uylings'),
+        ('morphology', 'min_partition_asymmetry__variant:branch-order__method:petilla'),
+        ('morphology', 'max_partition_asymmetry__variant:branch-order__method:petilla'),
+        ('morphology', 'min_partition_asymmetry__variant:length__method:uylings'),
+        ('morphology', 'max_partition_asymmetry__variant:length__method:uylings'),
     ])
 
     pd.testing.assert_index_equal(res.columns, expected_columns)
@@ -408,10 +408,82 @@ def test_get_header():
                     'fake_name1': REF_OUT,
                     'fake_name2': REF_OUT,
                     }
-    header = ms.get_header(fake_results)
+    header = ms._get_header(fake_results)
+
     assert 1 + 2 + 4 * (4 + 5) == len(header)  # name + everything in REF_OUT
     assert 'name' in header
     assert 'morphology:mean_soma_radius' in header
+
+
+def test_get_header__with_kwargs():
+
+    fake_results = {
+        "fake_name0": {
+            'axon': {
+                'sum_principal_direction_extents__direction:2': 4.236138323156951,
+                'min_principal_direction_extents__direction:2': 4.236138323156951,
+                'sum_principal_direction_extents__direction:1': 8.070668782620396,
+                'max_principal_direction_extents__direction:1': 8.070668782620396,
+                'mean_principal_direction_extents__direction:0': 82.38543140446015
+            },
+            'apical_dendrite': {
+                'sum_principal_direction_extents__direction:2': 3.6493184467335213,
+                'min_principal_direction_extents__direction:2': 3.6493184467335213,
+                'sum_principal_direction_extents__direction:1': 5.5082642304864695,
+                'max_principal_direction_extents__direction:1': 5.5082642304864695,
+                'mean_principal_direction_extents__direction:0': 99.57940514500457
+            },
+            'basal_dendrite': {
+                'sum_principal_direction_extents__direction:2': 7.32638745131256,
+                'min_principal_direction_extents__direction:2': 3.10141343122575,
+                'sum_principal_direction_extents__direction:1': 11.685447149154676,
+                'max_principal_direction_extents__direction:1': 6.410958014733595,
+                'mean_principal_direction_extents__direction:0': 87.2112016874677
+            },
+            'all': {
+                'sum_principal_direction_extents__direction:2': 15.211844221203034,
+                'min_principal_direction_extents__direction:2': 3.10141343122575,
+                'sum_principal_direction_extents__direction:1': 25.26438016226154,
+                'max_principal_direction_extents__direction:1': 8.070668782620396,
+                'mean_principal_direction_extents__direction:0': 89.09680998110002
+            },
+            'morphology': {
+                'mean_soma_radius': 0.13065629977308288,
+                'min_partition_asymmetry__variant:branch-order__method:petilla': 0.0,
+                'max_partition_asymmetry__variant:branch-order__method:petilla': 0.9,
+                'min_partition_asymmetry__variant:length__method:uylings': 0.00030289197373727377,
+                'max_partition_asymmetry__variant:length__method:uylings': 0.8795344229855895}
+            }
+    }
+
+    assert ms._get_header(fake_results) == [
+        'name',
+        'axon:sum_principal_direction_extents__direction:2',
+        'axon:min_principal_direction_extents__direction:2',
+        'axon:sum_principal_direction_extents__direction:1',
+        'axon:max_principal_direction_extents__direction:1',
+        'axon:mean_principal_direction_extents__direction:0',
+        'apical_dendrite:sum_principal_direction_extents__direction:2',
+        'apical_dendrite:min_principal_direction_extents__direction:2',
+        'apical_dendrite:sum_principal_direction_extents__direction:1',
+        'apical_dendrite:max_principal_direction_extents__direction:1',
+        'apical_dendrite:mean_principal_direction_extents__direction:0',
+        'basal_dendrite:sum_principal_direction_extents__direction:2',
+        'basal_dendrite:min_principal_direction_extents__direction:2',
+        'basal_dendrite:sum_principal_direction_extents__direction:1',
+        'basal_dendrite:max_principal_direction_extents__direction:1',
+        'basal_dendrite:mean_principal_direction_extents__direction:0',
+        'all:sum_principal_direction_extents__direction:2',
+        'all:min_principal_direction_extents__direction:2',
+        'all:sum_principal_direction_extents__direction:1',
+        'all:max_principal_direction_extents__direction:1',
+        'all:mean_principal_direction_extents__direction:0',
+        'morphology:mean_soma_radius',
+        'morphology:min_partition_asymmetry__variant:branch-order__method:petilla',
+        'morphology:max_partition_asymmetry__variant:branch-order__method:petilla',
+        'morphology:min_partition_asymmetry__variant:length__method:uylings',
+        'morphology:max_partition_asymmetry__variant:length__method:uylings'
+    ]
 
 
 def test_generate_flattened_dict():
@@ -419,10 +491,67 @@ def test_generate_flattened_dict():
                     'fake_name1': REF_OUT,
                     'fake_name2': REF_OUT,
                     }
-    header = ms.get_header(fake_results)
-    rows = list(ms.generate_flattened_dict(header, fake_results))
+    header = ms._get_header(fake_results)
+    rows = list(ms._generate_flattened_dict(header, fake_results))
     assert 3 == len(rows)  # one for fake_name[0-2]
     assert 1 + 2 + 4 * (4 + 5) == len(rows[0])  # name + everything in REF_OUT
+
+
+def test_generate_flattened_dict__with_kwargs():
+
+    results = {
+        'axon': {
+            'sum_principal_direction_extents__direction:2': 0.0,
+            'min_principal_direction_extents__direction:2': 1.0,
+            'sum_principal_direction_extents__direction:1': 2.0,
+            'max_principal_direction_extents__direction:1': 3.0,
+            'mean_principal_direction_extents__direction:0': 4.0,
+        },
+        'apical_dendrite': {
+            'sum_principal_direction_extents__direction:2': 5.0,
+            'min_principal_direction_extents__direction:2': 6.0,
+            'sum_principal_direction_extents__direction:1': 7.0,
+            'max_principal_direction_extents__direction:1': 8.0,
+            'mean_principal_direction_extents__direction:0': 9.0,
+        },
+        'basal_dendrite': {
+            'sum_principal_direction_extents__direction:2': 1.0,
+            'min_principal_direction_extents__direction:2': 2.0,
+            'sum_principal_direction_extents__direction:1': 3.0,
+            'max_principal_direction_extents__direction:1': 4.0,
+            'mean_principal_direction_extents__direction:0': 5.0,
+        },
+        'all': {
+            'sum_principal_direction_extents__direction:2': 6.0,
+            'min_principal_direction_extents__direction:2': 7.0,
+            'sum_principal_direction_extents__direction:1': 8.0,
+            'max_principal_direction_extents__direction:1': 9.0,
+            'mean_principal_direction_extents__direction:0': 1.0,
+        },
+        'morphology': {
+            'mean_soma_radius': 2.0,
+            'min_partition_asymmetry__variant:branch-order__method:petilla': 3.0,
+            'max_partition_asymmetry__variant:branch-order__method:petilla': 4.0,
+            'min_partition_asymmetry__variant:length__method:uylings': 5.0,
+            'max_partition_asymmetry__variant:length__method:uylings': 6.0,
+        }
+    }
+
+    fake_results = {
+        "fake_name0": results,
+        "fake_name1": results,
+    }
+
+    header = ms._get_header(fake_results)
+
+    assert list(ms._generate_flattened_dict(header, fake_results)) == [
+        [
+            'fake_name0', 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        [
+            'fake_name1', 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    ]
 
 
 def test_full_config():

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -640,7 +640,7 @@ def test_sanitize_config():
     }
     new_config = ms._sanitize_config(full_config)
 
-    assert new_config == {
+    expected_config = {
         'neurite': [
             ['section_lengths', {"kwargs": {}, "modes": ['max', 'sum']}],
             ['section_volumes', {"kwargs": {}, "modes": ['sum']}],
@@ -652,6 +652,11 @@ def test_sanitize_config():
         ],
         "population": [],
     }
+    assert new_config == expected_config
+
+    # check that legacy neuron entries are converted to morphology ones
+    full_config["neuron"] = full_config.pop("morphology")
+    assert ms._sanitize_config(full_config) == expected_config
 
     # check that all formats are converted to the same sanitized config:
     assert (

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -324,15 +324,15 @@ def test_full_config():
     config = ms.full_config()
     assert set(config.keys()) == {'neurite', 'population', 'morphology', 'neurite_type'}
 
-    assert set(config['neurite'].keys()) == set(_NEURITE_FEATURES.keys())
-    assert set(config['morphology'].keys()) == set(_MORPHOLOGY_FEATURES.keys())
-    assert set(config['population'].keys()) == set(_POPULATION_FEATURES.keys())
+    assert set(entry[0] for entry in config['neurite']) == set(_NEURITE_FEATURES.keys())
+    assert set(entry[0] for entry in config['morphology']) == set(_MORPHOLOGY_FEATURES.keys())
+    assert set(entry[0] for entry in config['population']) == set(_POPULATION_FEATURES.keys())
 
 
 def test_sanitize_config():
 
-    with pytest.raises(ConfigError):
-        ms.sanitize_config({'neurite': []})
+    #with pytest.raises(ConfigError):
+    #    ms.sanitize_config({'neurite': []})
 
     new_config = ms.sanitize_config({})  # empty
     assert 2 == len(new_config)  # neurite & morphology created


### PR DESCRIPTION
Summary:
* Added new config support for adding the same feature multiple times with different arguments (see below)
* If kwargs are populated in feature they are appended to its name (`f'{mode}_{feature_name}__{suffix}'`)
* The suffix includes each feature's kwarg present in the config, apart from `neurite_type`, e.g. `variant:branch-order__method:uylings`
* Config sanitization has become the point where all different versions are converted to the single valid one for the rest of the program.
* Made protected all the functions apart from `extract_stats`, `extract_dataframe`, and `main`.
* Sanitization has moved from main to `extract_stats` to guarantee that regardless of the entry point in the module, i.e. using any of the three functions in the previous point, the config is sanitized the same way.


A list of features looks like this:
```yaml
morphology:
  soma_radius:
    modes:
      - mean
  max_radial_distance:
    modes:
      - mean
neurite:
  section_lengths:
    modes:
      - max
      - sum
  section_volumes:
    modes:
      - sum
  section_branch_orders:
    modes:
      - max
      - raw
  segment_midpoints:
    modes:
      - max
  max_radial_distance:
    modes:
      - mean
  principal_direction_extents:
    kwargs:
      - direction: 1
      - direction: 0
    modes:
      - min
      - sum
  partition_asymmetry:
    kwargs:
        - variant: branch-order
          method: petilla
        - variant: length
          method: uylings
    modes:
        - min
        - max
neurite_type:
- AXON
- APICAL_DENDRITE
- BASAL_DENDRITE
- ALL
```
Using that `extract_stats` results to:
```python
{'all': {'max_partition_asymmetry__variant:branch-order__method:petilla': 0.9,
         'max_partition_asymmetry__variant:length__method:uylings': 0.8795344229855895,
         'max_section_branch_orders': 10,
         'max_section_lengths': 11.758282,
         'max_segment_midpoints_0': 64.40167236328125,
         'max_segment_midpoints_1': 48.48197937011719,
         'max_segment_midpoints_2': 53.750946044921875,
         'mean_max_radial_distance': 99.58946,
         'min_partition_asymmetry__variant:branch-order__method:petilla': 0.0,
         'min_partition_asymmetry__variant:length__method:uylings': 0.00030289197373727377,
         'min_principal_direction_extents__direction:0': 80.01260723801528,
         'min_principal_direction_extents__direction:1': 5.274489134421081,
         'raw_section_branch_orders': [0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7,
                                       7, 8, 8, 9, 9, 10, 10, 0, 1, 1, 2, 2, 3,
                                       3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9,
                                       10, 10, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5,
                                       6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 0, 1, 1,
                                       2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8,
                                       9, 9, 10, 10],
         'sum_principal_direction_extents__direction:0': 356.3872399244001,
         'sum_principal_direction_extents__direction:1': 25.26438016226154,
         'sum_section_lengths': 840.68524,
         'sum_section_volumes': 1104.9077745403258},
...
 'morphology': {'mean_max_radial_distance': 99.58946,
                'mean_soma_radius': 0.13065629977308288}}


```

Notice how the multiple feature entries with different kwargs result into different name:
```
 min_principal_direction_extents__direction:1
```
Closes #1015 