### PR TITLE
Implement new feature of length above soma

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 Version 3.2.0
 -------------
 
-- Add ``neurom.featuyre
+- Add ``neurom.features.morphology.length_fraction_above_soma`` feature.
 - List of multiple kwargs configurations are now allowed in``neurom.apps.morph_stats``.
 - ``neurom.features.neurite.principal_direction_extents`` directions correspond to extents
   ordered in a descending order.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Version 3.2.0
 -------------
 
+- Add ``neurom.featuyre
 - List of multiple kwargs configurations are now allowed in``neurom.apps.morph_stats``.
 - ``neurom.features.neurite.principal_direction_extents`` directions correspond to extents
   ordered in a descending order.

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -700,7 +700,7 @@ def length_fraction_above_soma(morph, neurite_type=NeuriteType.all, up="Y"):
     """
     axis = up.upper()
 
-    if axis not in ("X", "Y", "Z"):
+    if axis not in {"X", "Y", "Z"}:
         raise NeuroMError(f"Unknown axis {axis}. Please choose 'X', 'Y', or 'Z'.")
 
     col = getattr(COLS, axis)

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -687,18 +687,18 @@ def shape_factor(morph, neurite_type=NeuriteType.all, projection_plane="xy"):
 
 
 @feature(shape=())
-def length_fraction_above_soma(morph, neurite_type=NeuriteType.all, axis="Y"):
+def length_fraction_above_soma(morph, neurite_type=NeuriteType.all, up="Y"):
     """Returns the length fraction of the segments that have their midpoints higher than the soma.
 
     Args:
         morph: Morphology object.
         neurite_type: The neurite type to use. By default all neurite types are used.
-        axis: The axis along which the computation is performed. One of ('X', 'Y', 'Z').
+        up: The axis along which the computation is performed. One of ('X', 'Y', 'Z').
 
     Returns:
         The fraction of neurite length that lies on the right of the soma along the given axis.
     """
-    axis = axis.upper()
+    axis = up.upper()
 
     if axis not in ("X", "Y", "Z"):
         raise NeuroMError(f"Unknown axis {axis}. Please choose 'X', 'Y', or 'Z'.")

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -990,7 +990,7 @@ def test_length_fraction_from_soma(neurite_type, axis, expected_value):
     morph = load_morphology(DATA_PATH / "neurolucida/bio_neuron-000.asc")
 
     npt.assert_almost_equal(
-        features.get("length_fraction_above_soma", morph, neurite_type=neurite_type, axis=axis),
+        features.get("length_fraction_above_soma", morph, neurite_type=neurite_type, up=axis),
         expected_value,
         decimal=2
     )
@@ -1001,4 +1001,4 @@ def test_length_fraction_from_soma__wrong_axis():
     morph = load_morphology(DATA_PATH / "neurolucida/bio_neuron-000.asc")
 
     with pytest.raises(NeuroMError):
-        features.get("length_fraction_above_soma", morph, axis='K')
+        features.get("length_fraction_above_soma", morph, up='K')

--- a/tests/features/test_get_features.py
+++ b/tests/features/test_get_features.py
@@ -971,3 +971,34 @@ def test_shape_factor():
         decimal=6
     )
     assert np.isnan(features.get("shape_factor", morph, neurite_type=nm.NeuriteType.custom5))
+
+
+@pytest.mark.parametrize("neurite_type, axis, expected_value", [
+    (nm.AXON, "X", 0.50),
+    (nm.AXON, "Y", 0.74),
+    (nm.AXON, "Z", 0.16),
+    (nm.APICAL_DENDRITE, "X", np.nan),
+    (nm.APICAL_DENDRITE, "Y", np.nan),
+    (nm.APICAL_DENDRITE, "Z", np.nan),
+    (nm.BASAL_DENDRITE, "X", 0.50),
+    (nm.BASAL_DENDRITE, "Y", 0.59),
+    (nm.BASAL_DENDRITE, "Z", 0.48),
+]
+)
+def test_length_fraction_from_soma(neurite_type, axis, expected_value):
+
+    morph = load_morphology(DATA_PATH / "neurolucida/bio_neuron-000.asc")
+
+    npt.assert_almost_equal(
+        features.get("length_fraction_above_soma", morph, neurite_type=neurite_type, axis=axis),
+        expected_value,
+        decimal=2
+    )
+
+
+def test_length_fraction_from_soma__wrong_axis():
+
+    morph = load_morphology(DATA_PATH / "neurolucida/bio_neuron-000.asc")
+
+    with pytest.raises(NeuroMError):
+        features.get("length_fraction_above_soma", morph, axis='K')


### PR DESCRIPTION
New feature for calculating the fraction of neurite length above the soma, where the up direction is determined by the `up` argument.

Implements #1022