### PR TITLE
Expose subtree processing from the morph_stats api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Version 4.0.0
 -------------
 
+- Mixed subtree processing can be used in morph_stats app via the use_subtrees flag.
 - ``neurom.view.[plot_tree|plot_tree3d|plot_soma|plot_soma3D]`` were hidden from the
   neurom.view module. They can still be imported from neurom.view.matplotlib_impl.
 - Deprecated modules and classes were removed.

--- a/neurom/apps/cli.py
+++ b/neurom/apps/cli.py
@@ -95,9 +95,13 @@ def view(input_file, is_3d, plane, backend, realistic_diameters):
               help='If enabled the directory is treated as a population')
 @click.option('-I', '--ignored-exceptions', help='Exception to ignore',
               type=click.Choice(morph_stats.IGNORABLE_EXCEPTIONS.keys()))
-def stats(datapath, config, output, full_config, as_population, ignored_exceptions):
+@click.option('--use-subtrees', is_flag=True, show_default=True, default=False,
+              help="Enable mixed subtree processing.")
+def stats(datapath, config, output, full_config, as_population, ignored_exceptions, use_subtrees):
     """Cli for apps/morph_stats."""
-    morph_stats.main(datapath, config, output, full_config, as_population, ignored_exceptions)
+    morph_stats.main(
+        datapath, config, output, full_config, as_population, ignored_exceptions, use_subtrees
+    )
 
 
 @cli.command(short_help='Perform checks on morphologies, more details at'

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -59,14 +59,14 @@ EXAMPLE_CONFIG = Path(pkg_resources.resource_filename('neurom.apps', 'config'), 
 IGNORABLE_EXCEPTIONS = {'SomaError': SomaError}
 
 
-def _run_extract_stats(morph, config):
+def _run_extract_stats(morph, config, use_subtrees=False):
     """The function to be called by multiprocessing.Pool.imap_unordered."""
     if not isinstance(morph, Morphology):
         morph = nm.load_morphology(morph)
-    return morph.name, extract_stats(morph, config)
+    return morph.name, extract_stats(morph, config, use_subtrees=use_subtrees)
 
 
-def extract_dataframe(morphs, config, n_workers=1):
+def extract_dataframe(morphs, config, n_workers=1, use_subtrees=False):
     """Extract stats grouped by neurite type from morphs.
 
     Arguments:
@@ -94,7 +94,7 @@ def extract_dataframe(morphs, config, n_workers=1):
     if isinstance(morphs, Morphology):
         morphs = [morphs]
 
-    func = partial(_run_extract_stats, config=config)
+    func = partial(_run_extract_stats, config=config, use_subtrees=use_subtrees)
     if n_workers == 1:
         stats = list(map(func, morphs))
     else:
@@ -114,12 +114,12 @@ def extract_dataframe(morphs, config, n_workers=1):
 extract_dataframe.__doc__ += str(EXAMPLE_CONFIG)
 
 
-def _get_feature_stats(feature_name, morphs, modes, kwargs):
+def _get_feature_stats(feature_name, morphs, modes, use_subtrees=False, **kwargs):
     """Insert the stat data in the dict.
 
     If the feature is 2-dimensional, the feature is flattened on its last axis
     """
-    def stat_name_format(mode, feature_name, kwargs):
+    def stat_name_format(mode, feature_name, **kwargs):
         """Returns the key name for the data dictionary.
 
         The key is a combination of the mode, feature_name and an optional suffix of all the extra
@@ -135,14 +135,16 @@ def _get_feature_stats(feature_name, morphs, modes, kwargs):
         return f"{mode}_{feature_name}"
 
     data = {}
-    value, func = _get_feature_value_and_func(feature_name, morphs, **kwargs)
+    value, func = _get_feature_value_and_func(
+        feature_name, morphs, use_subtrees=use_subtrees, **kwargs
+    )
     shape = func.shape
     if len(shape) > 2:
         raise ValueError(f'Len of "{feature_name}" feature shape must be <= 2')  # pragma: no cover
 
     for mode in modes:
 
-        stat_name = stat_name_format(mode, feature_name, kwargs)
+        stat_name = stat_name_format(mode, feature_name, **kwargs)
 
         stat = value
         if isinstance(value, Sized):
@@ -161,7 +163,7 @@ def _get_feature_stats(feature_name, morphs, modes, kwargs):
     return data
 
 
-def extract_stats(morphs, config):
+def extract_stats(morphs, config, use_subtrees=False):
     """Extract stats from morphs.
 
     Arguments:
@@ -215,12 +217,18 @@ def extract_stats(morphs, config):
                     for neurite_type in types:
                         feature_kwargs["neurite_type"] = neurite_type
                         stats[neurite_type.name].update(
-                            _get_feature_stats(feature_name, morphs, modes, feature_kwargs)
+                            _get_feature_stats(
+                                feature_name, morphs, modes,
+                                use_subtrees=use_subtrees, **feature_kwargs
+                            )
                         )
 
                 else:
                     stats[category].update(
-                        _get_feature_stats(feature_name, morphs, modes, feature_kwargs)
+                        _get_feature_stats(
+                            feature_name, morphs, modes,
+                            use_subtrees=use_subtrees, **feature_kwargs
+                        )
                     )
 
     return dict(stats)
@@ -347,7 +355,15 @@ def _sanitize_config(config):
     return config
 
 
-def main(datapath, config, output_file, is_full_config, as_population, ignored_exceptions):
+def main(
+    datapath,
+    config,
+    output_file,
+    is_full_config,
+    as_population,
+    ignored_exceptions,
+    use_subtrees=False
+):
     """Main function that get statistics for morphologies.
 
     Args:
@@ -357,6 +373,7 @@ def main(datapath, config, output_file, is_full_config, as_population, ignored_e
         is_full_config (bool): should be statistics made over all possible features, modes, neurites
         as_population (bool): treat ``datapath`` as directory of morphologies population
         ignored_exceptions (list|tuple|None): exceptions to ignore when loading a morphology
+        use_subtrees (bool): Enable of heterogeneous subtree processing
     """
     config = full_config() if is_full_config else get_config(config, EXAMPLE_CONFIG)
 
@@ -374,9 +391,9 @@ def main(datapath, config, output_file, is_full_config, as_population, ignored_e
     )
 
     if as_population:
-        results = {datapath: extract_stats(morphs, config)}
+        results = {datapath: extract_stats(morphs, config, use_subtrees=use_subtrees)}
     else:
-        results = {m.name: extract_stats(m, config) for m in morphs}
+        results = {m.name: extract_stats(m, config, use_subtrees=use_subtrees) for m in morphs}
 
     if not output_file:
         print(json.dumps(results, indent=2, separators=(',', ':'), cls=NeuromJSON))

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -83,6 +83,7 @@ def extract_dataframe(morphs, config, n_workers=1, use_subtrees=False):
             - morphology: same as neurite entry, but it will not be run on each neurite_type,
               but only once on the whole morphology.
         n_workers (int): number of workers for multiprocessing (on collection of morphs)
+        use_subtrees (bool): Enable of heterogeneous subtree processing.
 
     Returns:
         The extracted statistics
@@ -182,6 +183,7 @@ def extract_stats(morphs, config, use_subtrees=False):
                   ['min', 'max', 'median', 'mean', 'std', 'raw', 'sum']
             - morphology: same as neurite entry, but it will not be run on each neurite_type,
               but only once on the whole morphology.
+        use_subtrees (bool): Enable of heterogeneous subtree processing.
 
     Returns:
         The extracted statistics

--- a/tests/apps/test_cli.py
+++ b/tests/apps/test_cli.py
@@ -83,6 +83,16 @@ def test_morph_stat_full_config():
         assert not df.empty
 
 
+def test_morph_stat_full_config__subtrees():
+    runner = CliRunner()
+    filename = DATA / 'h5/v1/Neuron.h5'
+    with tempfile.NamedTemporaryFile() as f:
+        result = runner.invoke(cli, ['stats', str(filename), '--full-config', '--use-subtrees', '--output', f.name])
+        assert result.exit_code == 0
+        df = pd.read_csv(f)
+        assert not df.empty
+
+
 def test_morph_stat_invalid_config():
     runner = CliRunner()
     with tempfile.NamedTemporaryFile('w') as config_f:


### PR DESCRIPTION
Allow to process heterogeneous subtrees for morph_stats analysis.

Examples usage:
```python
neurom.apps.morph_stats.extract_dataframe(moprh, config, use_subtrees=True)
neurom.apps.morph_stats.extract_stats(moprh, config, use_subtrees=True)
```
#975 