### PR TITLE
Fix load_morpholgies to always resolve paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,7 @@ Changelog
 Version 4.0.0
 -------------
 
-- Make ``neurom.core.Population`` resolve paths. Symlinks are resolved up until the
-  parent directory. If the file is symlinked, then it will not be resolved.
+- Make ``neurom.core.Population`` resolve paths. Symlinks are not resolved.
 - Mixed subtree processing can be used in morph_stats app via the use_subtrees flag.
 - ``neurom.view.[plot_tree|plot_tree3d|plot_soma|plot_soma3D]`` were hidden from the
   neurom.view module. They can still be imported from neurom.view.matplotlib_impl.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Version 4.0.0
 -------------
 
+- Fix ``neurom.load_morphologies`` to always pass resolved paths to Population.
 - Mixed subtree processing can be used in morph_stats app via the use_subtrees flag.
 - ``neurom.view.[plot_tree|plot_tree3d|plot_soma|plot_soma3D]`` were hidden from the
   neurom.view module. They can still be imported from neurom.view.matplotlib_impl.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 Version 4.0.0
 -------------
 
-- Fix ``neurom.load_morphologies`` to always pass resolved paths to Population.
+- Make ``neurom.core.Population`` resolve paths. Symlinks are resolved up until the
+  parent directory. If the file is symlinked, then it will not be resolved.
 - Mixed subtree processing can be used in morph_stats app via the use_subtrees flag.
 - ``neurom.view.[plot_tree|plot_tree3d|plot_soma|plot_soma3D]`` were hidden from the
   neurom.view module. They can still be imported from neurom.view.matplotlib_impl.

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -39,7 +39,7 @@ L = logging.getLogger(__name__)
 
 
 def _resolve_if_morphology_paths(files_or_objects):
-    """Resolve the files in the list"""
+    """Resolve the files in the list."""
     return [
         Path(f).expanduser().absolute() if isinstance(f, (Path, str)) else f
         for f in files_or_objects

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -28,6 +28,7 @@
 
 """Morphology Population Classes and Functions."""
 import logging
+import os
 from pathlib import Path
 
 from morphio import MorphioError
@@ -40,17 +41,7 @@ L = logging.getLogger(__name__)
 
 def _resolve_if_morphology_paths(files_or_objects):
     """Resolve the files in the list."""
-
-    def resolve_path(path):
-        """Resolve only the parent of the file path.
-
-        Not resolving the filename allows to have symlinks to files with different filename, but
-        any symlink in the parent tree would be correctly resolved.
-        """
-        path = Path(path)
-        return path.parent.resolve() / path.name
-
-    return [resolve_path(f) if isinstance(f, (Path, str)) else f for f in files_or_objects]
+    return [Path(os.path.abspath(f)) if isinstance(f, (Path, str)) else f for f in files_or_objects]
 
 
 class Population:
@@ -74,6 +65,9 @@ class Population:
                 will be loaded everytime it is accessed within the population. Which is good when
                 population is big. If true then all morphs will be loaded upon the construction
                 and kept in memory.
+
+        Notes:
+            symlinks in paths are not resolved.
         """
         self._ignored_exceptions = ignored_exceptions
         self.name = name

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -28,6 +28,7 @@
 
 """Morphology Population Classes and Functions."""
 import logging
+from pathlib import Path
 
 from morphio import MorphioError
 
@@ -35,6 +36,14 @@ import neurom
 from neurom.exceptions import NeuroMError
 
 L = logging.getLogger(__name__)
+
+
+def _resolve_if_morphology_paths(files_or_objects):
+    """Resolve the files in the list"""
+    return [
+        Path(f).expanduser().absolute() if isinstance(f, (Path, str)) else f
+        for f in files_or_objects
+    ]
 
 
 class Population:
@@ -61,10 +70,11 @@ class Population:
         """
         self._ignored_exceptions = ignored_exceptions
         self.name = name
+
+        self._files = _resolve_if_morphology_paths(files)
+
         if cache:
-            self._files = [self._load_file(f) for f in files if f is not None]
-        else:
-            self._files = files
+            self._files = [self._load_file(f) for f in self._files if f is not None]
 
     @property
     def morphologies(self):

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -40,10 +40,17 @@ L = logging.getLogger(__name__)
 
 def _resolve_if_morphology_paths(files_or_objects):
     """Resolve the files in the list."""
-    return [
-        Path(f).expanduser().absolute() if isinstance(f, (Path, str)) else f
-        for f in files_or_objects
-    ]
+
+    def resolve_path(path):
+        """Resolve only the parent of the file path.
+
+        Not resolving the filename allows to have symlinks to files with different filename, but
+        any symlink in the parent tree would be correctly resolved.
+        """
+        path = Path(path)
+        return path.parent.resolve() / path.name
+
+    return [resolve_path(f) if isinstance(f, (Path, str)) else f for f in files_or_objects]
 
 
 class Population:

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -99,7 +99,7 @@ def get_files_by_path(path):
 
     Return list of files with path
     """
-    path = Path(path).expanduser().resolve()
+    path = Path(path)
     if path.is_file():
         return [path]
     if path.is_dir():

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -99,7 +99,7 @@ def get_files_by_path(path):
 
     Return list of files with path
     """
-    path = Path(path)
+    path = Path(path).expanduser().resolve()
     if path.is_file():
         return [path]
     if path.is_dir():

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,4 @@
-## look at http://docutils.sourceforge.net/sandbox/py-rest-doc/utils/pylintrc
+# look at http://docutils.sourceforge.net/sandbox/py-rest-doc/utils/pylintrc
 # for some of the options that are available
 
 [MESSAGES CONTROL]
@@ -23,7 +23,7 @@ max-locals=15
 # Maximum number of return / yield for function / method body
 max-returns=6
 # Maximum number of branch for function / method body
-max-branchs=12
+max-branches=12
 # Maximum number of statements in function / method body
 max-statements=50
 # Maximum number of parents for a class (see R0901).

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -28,6 +28,7 @@
 
 """Test neurom.io.utils."""
 import warnings
+import os
 from io import StringIO
 from pathlib import Path
 
@@ -126,6 +127,35 @@ def test_load_morphologies():
     pop = utils.load_morphologies(SWC_PATH, ignored_exceptions=(MissingParentError, MorphioError))
     # is subset so that if new morpho are added to SWC_PATH, the test does not break
     assert {f.name for f in FILES}.issubset({m.name for m in pop})
+
+
+def test_load_morphologies__resolve_paths():
+
+    # store the dir of executing the tests
+    current_dir = os.getcwd()
+
+    # get the tests dir
+    tests_dir = Path(__file__).parent.parent
+
+    # move there for this test
+    os.chdir(tests_dir)
+
+    # get dir to morphs relative to tets dir
+    relative_morph_dir = SWC_PATH.relative_to(tests_dir)
+
+    pop = utils.load_morphologies(
+        str(relative_morph_dir), ignored_exceptions=(MissingParentError, MorphioError)
+    )
+
+    assert {f.name for f in FILES}.issubset({m.name for m in pop})
+
+    # move one up to break if the population is not using asbpaths
+    os.chdir("..")
+
+    assert {f.name for f in FILES}.issubset({m.name for m in pop})
+
+    # move back to our initial dir
+    os.chdir(current_dir)
 
 
 def test_ignore_exceptions():

--- a/tests/io/test_io_utils.py
+++ b/tests/io/test_io_utils.py
@@ -140,7 +140,7 @@ def test_load_morphologies__resolve_paths():
     # move there for this test
     os.chdir(tests_dir)
 
-    # get dir to morphs relative to tets dir
+    # get dir to morphs relative to test dir
     relative_morph_dir = SWC_PATH.relative_to(tests_dir)
 
     pop = utils.load_morphologies(


### PR DESCRIPTION
**Issue:** If a relative morphology directory is passed into `neurom.load_morphologies`, a Population object is created with relative paths to the morphologies. If the directory is changed after the Population is created, the paths will not be valid anymore.
**Changes:** Population makes paths absolute. Note that it does not resolve symlinks.
Fixes #1046 