### PR TITLE
Fix view cli

### DIFF
--- a/neurom/apps/cli.py
+++ b/neurom/apps/cli.py
@@ -76,6 +76,7 @@ def view(input_file, is_3d, plane, backend, realistic_diameters):
 
     plot(load_morphology(input_file))
     if is_matplotlib:
+        plt.axis('equal')
         plt.show()
 
 

--- a/neurom/apps/cli.py
+++ b/neurom/apps/cli.py
@@ -76,7 +76,10 @@ def view(input_file, is_3d, plane, backend, realistic_diameters):
 
     plot(load_morphology(input_file))
     if is_matplotlib:
-        plt.axis('equal')
+        try:
+            plt.axis('equal')
+        except NotImplementedError:  # for python 3.7 it will not have equal scales
+            plt.axis('auto')
         plt.show()
 
 

--- a/neurom/check/morphtree.py
+++ b/neurom/check/morphtree.py
@@ -53,7 +53,7 @@ def is_monotonic(neurite, tol):
             if sec[point_id + 1][COLS.R] > sec[point_id][COLS.R] + tol:
                 return False
         # Check that section boundary points satisfy monotonicity
-        if(node.parent is not None and
+        if (node.parent is not None and
            sec[0][COLS.R] > node.parent.points[-1][COLS.R] + tol):
             return False
 


### PR DESCRIPTION
Upon using `neurom view neuron.asc` with matplotlib, we get a massive zoom at the origin. This ensures we see the entire morphology with equal axis scales.