### PR TITLE
Add from_origin to trunk_vectors and related features

### DIFF
--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -165,7 +165,6 @@ def trunk_vectors(morph, neurite_type=NeuriteType.all, from_origin=False):
     """Calculate the vectors between all the trunks of the morphology and the soma center.
 
     Args:
-
         morph: The morphology to process.
         neurite_type: Only the neurites of this type are considered.
         from_origin: If True, computes angle from [0, 0, 0] instead of soma.center


### PR DESCRIPTION
In some usecases, for example in synthesis, the reference point to compute trunk angles should be [0, 0, 0] instead of soma.center.

See https://github.com/BlueBrain/NeuroTS/pull/49/files#diff-a465052b0c2a633fd29c380c8f81a1143bc78e09982d08b847901e453ab99f4eR105 