### PR TITLE
Fix language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.asc linguist-detectable=false


### PR DESCRIPTION
Github language detection reports that 53% of this repository is AGS script because of the `*.asc` files, so we can ignore `*.asc` files in the `.gitattributes` file.