### PR TITLE
Draft of composite type

### DIFF
--- a/neurom/core/morphology.py
+++ b/neurom/core/morphology.py
@@ -219,11 +219,6 @@ NRN_ORDER = {
 }
 
 
-def _get_heterogeneous_type(neurite):
-
-    it = neurite.root_node.ipreorder()
-
-
 def _homogeneous_subtrees(neurite):
     """Returns a list of the root nodes of the sub-neurites.
 

--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -53,9 +53,12 @@ class CompositeType(int):
     Each subtype corresponds to a homogeneous subtree in the morphology.
 
     Args:
-        value (int): The integer value 
+        value (int): The integer value.
+        types: (List[SectionType]): The list of subtypes for given type.
     """
+
     def __new__(cls, value, types):
+        """Create an int object and assign to it the `subtypes` attribute."""
         obj = super().__new__(cls, value)
         obj.subtypes = types
         return obj
@@ -84,6 +87,7 @@ class NeuriteType(IntEnum):
     )
 
     def __eq__(self, other):
+        """Logic for checking single and composite types."""
         is_self_composite = hasattr(self, "value") and isinstance(self.value, CompositeType)
         is_other_composite = hasattr(other, "value") and isinstance(other.value, CompositeType)
 
@@ -101,6 +105,10 @@ class NeuriteType(IntEnum):
         return self.value
 
     def __new__(cls, value):
+        """Create a new integer enum entry and replace its `_value_` entry with the value object.
+
+        This allows passing the CompositeType instance to self.value.
+        """
         obj = int.__new__(cls, value)
         if isinstance(value, CompositeType):
             obj._value_ = value

--- a/neurom/core/types.py
+++ b/neurom/core/types.py
@@ -57,21 +57,15 @@ class Subtypes:
 
     def __eq__(self, other):
 
-        if isinstance(self, Subtypes):
-            if isinstance(other, Subtypes):
-                if self.is_composite():
-                    if other.is_composite():
-                        return self.subtypes == other.subtypes
-                    return other.subtypes[0] in self.subtypes
-                if other.is_composite():
-                    return self.subtypes[0] in other.subtypes
-                return self.subtypes[0] == other.subtypes[0]
-            return other in self.subtypes
-
         if isinstance(other, Subtypes):
-            return self in other.subtypes
-
-        return self == other
+            if self.is_composite():
+                if other.is_composite():
+                    return self.subtypes == other.subtypes
+                return other.subtypes[0] in self.subtypes
+            if other.is_composite():
+                return self.subtypes[0] in other.subtypes
+            return self.subtypes[0] == other.subtypes[0]
+        return other in self.subtypes
 
 
 # for backward compatibility with 'v1' version

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -172,11 +172,10 @@ def test_iter_neurites__heterogeneous(mixed_morph):
 
     subtrees = list(neurom.core.morphology.iter_neurites(mixed_morph, use_subtrees=True))
 
-    assert len(subtrees) == 4
+    assert len(subtrees) == 3
     assert subtrees[0].type == NeuriteType.basal_dendrite
-    assert subtrees[1].type == NeuriteType.basal_dendrite
-    assert subtrees[2].type == NeuriteType.axon
-    assert subtrees[3].type == NeuriteType.apical_dendrite
+    assert subtrees[1].type == NeuriteType.axon_carrying_dendrite
+    assert subtrees[2].type == NeuriteType.apical_dendrite
 
 
 def test_core_iter_sections__heterogeneous(mixed_morph):


### PR DESCRIPTION
**Issue:**
When subtrees are considered, the neurites are broken into their homogeneous subtrees, increasing the tree cardinality. This can be problematic if this data is used for synthesis for instance because an entire tree is considered a subtree that can be as small as a single section.

**Proposal**
This is a draft of adding a composite type without breaking the existing integer types of NeuriteType.

The following will hold true for neurites with composite types:
1. The `CompositeType` behaves like an integer, plus an extra '_types' attribute, and is a `NeuriteType`.
2. Equality with a single section type is determined by equality with one of its subtypes. For example, an `axon_carrying_dendrite` will pass from `axon` or `basal_dendrite` filters.
3. Features that return values per neurite will maintain the neurite cardinality.
4. Features that specify filters other than `All` will apply to the composite neurites according to (1). For example, if `number_of_sections` is called for an `axon_carrying_dendrite`, it will return a positive value for both `neurite_type=NeuriteType.axon` and `neurite_type=NeuriteType.basal_dendrite`
5. Can be assigned only if `use_subtrees` is enabled. Otherwise, the simple type of the root node will be used.

**Note**
There are sane alternatives to this implementation, but they will probably require sacrificing something, such as NeuriteType deriving from IntEnum, etc.
