### PR TITLE
Fix: extract_stats could not work on single neurite

### DIFF
--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -46,7 +46,7 @@ from morphio import SomaError
 
 import neurom as nm
 from neurom.apps import get_config
-from neurom.core.morphology import Morphology
+from neurom.core.morphology import Morphology, Neurite
 from neurom.exceptions import ConfigError
 from neurom.features import _NEURITE_FEATURES, _MORPHOLOGY_FEATURES, _POPULATION_FEATURES, \
     _get_feature_value_and_func
@@ -213,7 +213,8 @@ def extract_stats(morphs, config):
                     )
 
                     for neurite_type in types:
-                        feature_kwargs["neurite_type"] = neurite_type
+                        if not isinstance(morphs, Neurite):
+                            feature_kwargs["neurite_type"] = neurite_type
                         stats[neurite_type.name].update(
                             _get_feature_stats(feature_name, morphs, modes, feature_kwargs)
                         )

--- a/neurom/apps/morph_stats.py
+++ b/neurom/apps/morph_stats.py
@@ -185,9 +185,10 @@ def extract_stats(morphs, config):
         The extracted statistics
 
     Note:
-        An example config can be found at:
+        An example config can be found in the `CLI -> neurom stats` page of the documentation.
 
     """
+    # pylint: disable=too-many-nested-blocks
     config = _sanitize_config(config)
 
     neurite_types = [_NEURITE_MAP[t] for t in config.get('neurite_type', _NEURITE_MAP.keys())]

--- a/pylintrc
+++ b/pylintrc
@@ -23,7 +23,7 @@ max-locals=15
 # Maximum number of return / yield for function / method body
 max-returns=6
 # Maximum number of branch for function / method body
-max-branchs=12
+max-branches=12
 # Maximum number of statements in function / method body
 max-statements=50
 # Maximum number of parents for a class (see R0901).

--- a/tests/apps/test_morph_stats.py
+++ b/tests/apps/test_morph_stats.py
@@ -138,6 +138,22 @@ def test_extract_stats_single_morphology():
             assert_almost_equal(res[k][kk], REF_OUT[k][kk], decimal=4)
 
 
+def test_extract_stats_single_neurite():
+    m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
+    neurite = m.neurites[0]
+    config = deepcopy(REF_CONFIG_NEW)
+    config.pop("neurite_type")
+    config.pop("morphology")
+    res = ms.extract_stats(neurite, config)
+
+    REF_OUT_NEURITE = deepcopy(REF_OUT)
+    REF_OUT_NEURITE.pop("morphology", None)
+    assert set(res.keys()) == set(REF_OUT_NEURITE.keys())
+    assert set(res["axon"].keys()) == set(REF_OUT_NEURITE["axon"].keys())
+    for kk in res["axon"].keys():
+        assert_almost_equal(res["axon"][kk], REF_OUT_NEURITE["axon"][kk], decimal=4)
+
+
 def test_extract_stats_new_format():
     m = nm.load_morphology(SWC_PATH / 'Neuron.swc')
     res = ms.extract_stats(m, REF_CONFIG_NEW)


### PR DESCRIPTION
Context: A `neurite_type` entry is automatically added in `extract_stats` while `neurom.features._get_feature_value_and_func` requires that there is no `neurite_type` entry in kwargs when the object type is `Neurite`. So these two functions are not compatible together in the case of a single `Neurite` object, this PR fixes it.