### PR TITLE
Remove a few useless shebang lines

### DIFF
--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
 # All rights reserved.
 #

--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
 # All rights reserved.
 #

--- a/neurom/check/runner.py
+++ b/neurom/check/runner.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, Ecole Polytechnique Federale de Lausanne, Blue Brain Project
 # All rights reserved.
 #


### PR DESCRIPTION
Remove shebang lines from a few files that do not need them.

A shebang line is only meaningful in a file with the executable bit set in its permissions. These files are already correctly non-executable, as they have no “main routine” or interesting side effects and are purely importable modules.

Slightly more detail is available in the commit messages.