### PR TITLE
Replace PyPI mock test dependency with unittest.mock

### DIFF
--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -68,7 +68,7 @@ all required dependencies in your virtual environment:
 
 .. code-block:: bash
 
-    (your virtual env name)$ pip install neurom[plotly] pytest mock
+    (your virtual env name)$ pip install neurom[plotly] pytest
 
 Then, run the tests manually. For example,
 

--- a/tests/apps/test_cli.py
+++ b/tests/apps/test_cli.py
@@ -5,7 +5,7 @@ import tempfile
 import pandas as pd
 import yaml
 from click.testing import CliRunner
-from mock import patch
+from unittest.mock import patch
 
 from neurom.apps.cli import cli
 from neurom.exceptions import ConfigError

--- a/tests/core/test_soma.py
+++ b/tests/core/test_soma.py
@@ -29,12 +29,12 @@
 import math
 import warnings
 from io import StringIO
+from unittest.mock import Mock
 
 import numpy as np
 from morphio import MorphioError, SomaError, set_raise_warnings
 from neurom import load_morphology
 from neurom.core import soma
-from mock import Mock
 
 import pytest
 from numpy.testing import assert_array_equal, assert_almost_equal

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -27,7 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from mock import Mock
+from unittest.mock import Mock
+
 from neurom.core.types import NEURITES, NeuriteType, axon_filter, dendrite_filter, tree_type_checker
 import pytest
 

--- a/tests/features/test_neurite.py
+++ b/tests/features/test_neurite.py
@@ -30,11 +30,11 @@
 
 from math import pi, sqrt
 from pathlib import Path
+from unittest.mock import patch
 
 import neurom as nm
 import numpy as np
 import scipy
-from mock import patch
 from neurom.features import neurite, morphology
 from neurom.geom import convex_hull
 

--- a/tests/features/test_section.py
+++ b/tests/features/test_section.py
@@ -37,7 +37,6 @@ from unittest.mock import Mock
 import pytest
 import numpy as np
 from numpy import testing as npt
-from mock import Mock
 
 from neurom import load_morphology, iter_sections
 from neurom import morphmath

--- a/tests/view/test_plotly_impl.py
+++ b/tests/view/test_plotly_impl.py
@@ -1,11 +1,11 @@
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import neurom
 from neurom import load_morphology
 from neurom.view import plotly_impl
 
-import mock
 from numpy.testing import assert_allclose
 
 SWC_PATH = Path(__file__).parent.parent / 'data/swc'
@@ -20,7 +20,7 @@ def _reload_module(module):
 
 
 def test_plotly_extra_not_installed():
-    with mock.patch.dict(sys.modules, {'plotly': None}):
+    with patch.dict(sys.modules, {'plotly': None}):
         try:
             _reload_module(neurom.view.plotly_impl)
             assert False, "ImportError not triggered"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [base]
 name = neurom
 testdeps =
-    mock
     pytest>3.0
 
 [tox]


### PR DESCRIPTION
The [`unittest.mock` module](https://docs.python.org/3/library/unittest.mock.html) is part of the standard library since Python 3.3, so there is no longer any benefit to carrying the PyPI package as a test dependency.

See https://fedoraproject.org/wiki/Changes/DeprecatePythonMock for further context.