### PR TITLE
Remove pyXX prefix for lint, docs, and coverage

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -56,4 +56,4 @@ ignore-docstrings=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,numpy.*,scipy,scipy.spatial,scipy.stats,scipy.spatial.qhull
+ignored-modules=numpy,numpy.*,scipy.stats,scipy.spatial

--- a/pylintrc
+++ b/pylintrc
@@ -56,4 +56,4 @@ ignore-docstrings=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,numpy.*,scipy.stats,scipy.spatial
+ignored-modules=numpy,numpy.*,scipy,scipy.spatial,scipy.stats,scipy.spatial.qhull

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ convention = google
 
 [gh-actions]
 python =
-  3.8: py38, lint, docs
-  3.9: py39
+  3.8: py38, lint
+  3.9: py39, docs
   3.10: py310
   3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,25 @@ testdeps =
 
 [tox]
 envlist =
+    lint
+    docs
+    coverage
     py{38,39,310,311}
-    py38-lint
-    py38-coverage
-    py38-docs
 
 [testenv]
-deps = {[base]testdeps}
+deps =
+    {[base]testdeps}
+    pytest-cov
 extras = plotly
-commands = pytest {posargs}
+commands = pytest \
+                --cov={envsitepackagesdir}/{[base]name} \
+                --cov-report term-missing \
+                --cov-fail-under=100 \
+                --cov-report=xml \
+                {posargs}
 
-[testenv:py38-lint]
+[testenv:lint]
+basepython=python3.8
 deps =
     pycodestyle
     pydocstyle
@@ -26,18 +34,8 @@ commands =
     pydocstyle --match-dir='(?!test).*' {toxinidir}/neurom
     pylint --rcfile=pylintrc --extension-pkg-whitelist=numpy --ignore=tests neurom
 
-[testenv:py38-coverage]
-deps =
-    {[base]testdeps}
-    pytest-cov
-commands =
-    pytest tests \
-    --cov={envsitepackagesdir}/{[base]name} \
-    --cov-report term-missing \
-    --cov-fail-under=100 \
-    --cov-report=xml
-
-[testenv:py38-docs]
+[testenv:docs]
+basepython=python3.8
 changedir = doc
 extras = docs
 commands =
@@ -57,7 +55,7 @@ convention = google
 
 [gh-actions]
 python =
-  3.8: py38
+  3.8: py38, lint, docs
   3.9: py39
   3.10: py310
   3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     pylint --rcfile=pylintrc --extension-pkg-whitelist=numpy --ignore=tests neurom
 
 [testenv:docs]
-basepython=python3.8
+basepython=python3.9
 changedir = doc
 extras = docs
 commands =


### PR DESCRIPTION
Also, incorporate coverage into tests that are already executed.