### PR TITLE
Add has_no_back_tracking function

### DIFF
--- a/neurom/check/morphology_checks.py
+++ b/neurom/check/morphology_checks.py
@@ -35,7 +35,7 @@ from itertools import islice
 import numpy as np
 from neurom import NeuriteType
 from neurom.check import CheckResult
-from neurom.check.morphtree import get_flat_neurites
+from neurom.check.morphtree import get_flat_neurites, back_tracking_segments
 from neurom.core.morphology import Section, iter_neurites, iter_sections, iter_segments
 from neurom.core.dataformat import COLS
 from neurom.exceptions import NeuroMError
@@ -354,4 +354,10 @@ def has_unifurcation(neuron):
 def has_no_single_children(morph):
     """Check if the morphology has sections with only one child section."""
     bad_ids = [section.id for section in iter_sections(morph) if len(section.children) == 1]
+    return CheckResult(len(bad_ids) == 0, bad_ids)
+
+
+def has_no_back_tracking(morph):
+    """Check if the morphology has sections with back-tracks."""
+    bad_ids = [i for neurite in iter_neurites(morph) for i in back_tracking_segments(neurite)]
     return CheckResult(len(bad_ids) == 0, bad_ids)

--- a/tests/check/test_morphology_checks.py
+++ b/tests/check/test_morphology_checks.py
@@ -458,3 +458,29 @@ def test_single_children():
     result = morphology_checks.has_no_single_children(m)
     assert result.status is False
     assert result.info == [0]
+
+
+def test_has_no_back_tracking():
+    m = load_morphology("""
+    ((CellBody) (-1 0 0 2) (1 0 0 2))
+
+    ((Dendrite)
+    (0 0 0 0.4)
+    (0 1 0 0.3)
+    (0 2 0 0.28)
+    (
+      (0 2 0 0.28)
+      (1 3 0 0.3)
+      (2 4 0 0.22)
+      |
+      (0 2 0 0.28)
+      (1 -3 0 0.3)
+      (2 -4 0 0.24)
+      (1 -3 0 0.52)
+      (3 -5 0 0.2)
+      (4 -6 0 0.2)
+    ))
+""", "asc")
+    result = morphology_checks.has_no_back_tracking(m)
+    assert result.status is False
+    assert result.info == [(2, 1, 0), (2, 1, 1)]


### PR DESCRIPTION
Following #1112 : add a morphology checker (return all back-tracking points of the morphology when the check fails).