### PR TITLE
Make has_no_back_tracking() compatible with generate_annotation()

### DIFF
--- a/neurom/check/morphology_checks.py
+++ b/neurom/check/morphology_checks.py
@@ -359,5 +359,9 @@ def has_no_single_children(morph):
 
 def has_no_back_tracking(morph):
     """Check if the morphology has sections with back-tracks."""
-    bad_ids = [i for neurite in iter_neurites(morph) for i in back_tracking_segments(neurite)]
+    bad_ids = [
+        (i, morph.section(i[0]).points[np.newaxis, i[1]])
+        for neurite in iter_neurites(morph)
+        for i in back_tracking_segments(neurite)
+    ]
     return CheckResult(len(bad_ids) == 0, bad_ids)

--- a/tests/check/test_morphology_checks.py
+++ b/tests/check/test_morphology_checks.py
@@ -483,4 +483,8 @@ def test_has_no_back_tracking():
 """, "asc")
     result = morphology_checks.has_no_back_tracking(m)
     assert result.status is False
-    assert result.info == [(2, 1, 0), (2, 1, 1)]
+    info = result.info
+    assert_array_equal(info[0][0], [2, 1, 0])
+    assert_array_equal(info[0][1], [[1, -3, 0]])
+    assert_array_equal(info[1][0], [2, 1, 1])
+    assert_array_equal(info[1][1], [[1, -3, 0]])


### PR DESCRIPTION
The `has_no_back_tracking()` function could not be used by the `generate_annotation()` function because the output was not formatted as expected. This PR fixes this issue.