### PR TITLE
Move soma methods to functions

### DIFF
--- a/neurom/core/morphology.py
+++ b/neurom/core/morphology.py
@@ -408,7 +408,7 @@ def graft_morphology(section):
 class Neurite:
     """Class representing a neurite tree."""
 
-    def __init__(self, root_node, process_subtrees=False):
+    def __init__(self, root_node, *, process_subtrees=False):
         """Constructor.
 
         Args:
@@ -538,7 +538,7 @@ class Neurite:
 class Morphology:
     """Class representing a simple morphology."""
 
-    def __init__(self, morphio_morph, name=None, process_subtrees=False):
+    def __init__(self, morphio_morph, name=None, *, process_subtrees=False):
         """Morphology constructor.
 
         Args:

--- a/neurom/core/population.py
+++ b/neurom/core/population.py
@@ -53,7 +53,13 @@ class Population:
     """
 
     def __init__(
-        self, files, name='Population', ignored_exceptions=(), cache=False, process_subtrees=False
+        self,
+        files,
+        name='Population',
+        ignored_exceptions=(),
+        *,
+        cache=False,
+        process_subtrees=False,
     ):
         """Construct a morphology population.
 
@@ -67,6 +73,7 @@ class Population:
                 will be loaded everytime it is accessed within the population. Which is good when
                 population is big. If true then all morphs will be loaded upon the construction
                 and kept in memory.
+            process_subtrees (bool): enable mixed tree processing if set to True
 
         Notes:
             symlinks in paths are not resolved.

--- a/neurom/core/soma.py
+++ b/neurom/core/soma.py
@@ -89,12 +89,7 @@ class Soma:
 
     def overlaps(self, points, exclude_boundary=False):
         """Check that the given points are located inside the soma."""
-        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
-        if exclude_boundary:
-            mask = np.linalg.norm(points - self.center, axis=1) < self.radius
-        else:
-            mask = np.linalg.norm(points - self.center, axis=1) <= self.radius
-        return mask
+        return soma_overlaps(self, points, exclude_boundary=exclude_boundary)
 
 
 class SomaSinglePoint(Soma):
@@ -143,29 +138,6 @@ class SomaCylinders(Soma):
             self.center,
             self.radius,
         )
-
-    def overlaps(self, points, exclude_boundary=False):
-        """Check that the given points are located inside the soma."""
-        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
-        mask = np.ones(len(points)).astype(bool)
-        for p1, p2 in zip(self.points[:-1], self.points[1:]):
-            vec = p2[COLS.XYZ] - p1[COLS.XYZ]
-            vec_norm = np.linalg.norm(vec)
-            dot = (points[mask] - p1[COLS.XYZ]).dot(vec) / vec_norm
-
-            cross = np.linalg.norm(np.cross(vec, points[mask]), axis=1) / vec_norm
-            dot_clipped = np.clip(dot / vec_norm, a_min=0, a_max=1)
-            radii = p1[COLS.R] * (1 - dot_clipped) + p2[COLS.R] * dot_clipped
-
-            if exclude_boundary:
-                in_cylinder = (dot > 0) & (dot < vec_norm) & (cross < radii)
-            else:
-                in_cylinder = (dot >= 0) & (dot <= vec_norm) & (cross <= radii)
-            mask[np.where(mask)] = ~in_cylinder
-            if not mask.any():
-                break
-
-        return ~mask
 
 
 class SomaNeuromorphoThreePointCylinders(SomaCylinders):
@@ -229,58 +201,6 @@ class SomaSimpleContour(Soma):
             self.center,
             self.radius,
         )
-
-    def overlaps(self, points, exclude_boundary=False):
-        """Check that the given points are located inside the soma.
-
-        The contour is supposed to be in the plane XY, the Z component is ignored.
-        """
-        # pylint: disable=too-many-locals
-        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
-
-        # Convert points to angles from the center
-        relative_pts = points - self.center
-        pt_angles = np.arctan2(relative_pts[:, COLS.Y], relative_pts[:, COLS.X])
-
-        # Convert soma points to angles from the center
-        relative_soma_pts = self.points[:, COLS.XYZ] - self.center
-        soma_angles = np.arctan2(relative_soma_pts[:, COLS.Y], relative_soma_pts[:, COLS.X])
-
-        # Order the soma points by ascending angles
-        soma_angle_order = np.argsort(soma_angles)
-        ordered_soma_angles = soma_angles[soma_angle_order]
-        ordered_relative_soma_pts = relative_soma_pts[soma_angle_order]
-
-        # Find the two soma points which form the segment crossed by the one from the center
-        # to the point
-        angles = np.atleast_2d(pt_angles).T - ordered_soma_angles
-        closest_indices = np.argmin(np.abs(angles), axis=1)
-        neighbors = np.ones_like(closest_indices)
-        neighbors[angles[np.arange(len(closest_indices)), closest_indices] < 0] = -1
-        signs = (neighbors == 1) * 2.0 - 1.0
-        neighbors[(closest_indices >= len(relative_soma_pts) - 1) & (neighbors == 1)] = (
-            -len(relative_soma_pts) + 1
-        )
-
-        # Compute the cross product and multiply by neighbors to get the same result as if all
-        # vectors were clockwise
-        cross_z = (
-            np.cross(
-                (
-                    ordered_relative_soma_pts[closest_indices + neighbors]
-                    - ordered_relative_soma_pts[closest_indices]
-                ),
-                relative_pts - ordered_relative_soma_pts[closest_indices],
-            )[:, COLS.Z]
-            * signs
-        )
-
-        if exclude_boundary:
-            interior_side = cross_z > 0
-        else:
-            interior_side = cross_z >= 0
-
-        return interior_side
 
 
 def soma_center(soma):
@@ -441,6 +361,127 @@ def soma_volume(soma):
     }[morphio_soma.type]
 
     return soma_algo(morphio_soma)
+
+
+def soma_overlaps(soma, points, exclude_boundary=False):
+    """Check if soma overlaps with points."""
+
+    if hasattr(soma, "to_morphio"):
+        morphio_soma = soma.to_morphio()
+    else:
+        morphio_soma = soma
+
+    def _soma_undefined_overlaps(morphio_soma, points, exclude_boundary):
+        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
+
+        center = soma_center(morphio_soma)
+        radius = soma_radius(morphio_soma)
+
+        if exclude_boundary:
+            return np.linalg.norm(points - center, axis=1) < radius
+
+        return np.linalg.norm(points - center, axis=1) <= radius
+
+    def _soma_cylinders_overlaps(morphio_soma, points, exclude_boundary):
+
+        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
+
+        soma_points = np.concatenate(
+            (
+                morphio_soma.points,
+                0.5 * morphio_soma.diameters[:, np.newaxis],
+            ),
+            axis=1,
+        )
+
+        mask = np.ones(len(points)).astype(bool)
+        for p1, p2 in zip(soma_points[:-1], soma_points[1:]):
+            vec = p2[COLS.XYZ] - p1[COLS.XYZ]
+            vec_norm = np.linalg.norm(vec)
+            dot = (points[mask] - p1[COLS.XYZ]).dot(vec) / vec_norm
+
+            cross = np.linalg.norm(np.cross(vec, points[mask]), axis=1) / vec_norm
+            dot_clipped = np.clip(dot / vec_norm, a_min=0, a_max=1)
+            radii = p1[COLS.R] * (1 - dot_clipped) + p2[COLS.R] * dot_clipped
+
+            if exclude_boundary:
+                in_cylinder = (dot > 0) & (dot < vec_norm) & (cross < radii)
+            else:
+                in_cylinder = (dot >= 0) & (dot <= vec_norm) & (cross <= radii)
+            mask[np.where(mask)] = ~in_cylinder
+            if not mask.any():
+                break
+
+        return ~mask
+
+    def _soma_simple_contour_overlaps(morphio_soma, points, exclude_boundary):
+
+        soma_points = np.concatenate(
+            (
+                morphio_soma.points,
+                0.5 * morphio_soma.diameters[:, np.newaxis],
+            ),
+            axis=1,
+        )
+        center = soma_center(morphio_soma)
+    
+        # pylint: disable=too-many-locals
+        points = np.atleast_2d(np.asarray(points, dtype=np.float64))
+
+        # Convert points to angles from the center
+        relative_pts = points - center
+        pt_angles = np.arctan2(relative_pts[:, COLS.Y], relative_pts[:, COLS.X])
+
+        # Convert soma points to angles from the center
+        relative_soma_pts = soma_points[:, COLS.XYZ] - center
+        soma_angles = np.arctan2(relative_soma_pts[:, COLS.Y], relative_soma_pts[:, COLS.X])
+
+        # Order the soma points by ascending angles
+        soma_angle_order = np.argsort(soma_angles)
+        ordered_soma_angles = soma_angles[soma_angle_order]
+        ordered_relative_soma_pts = relative_soma_pts[soma_angle_order]
+
+        # Find the two soma points which form the segment crossed by the one from the center
+        # to the point
+        angles = np.atleast_2d(pt_angles).T - ordered_soma_angles
+        closest_indices = np.argmin(np.abs(angles), axis=1)
+        neighbors = np.ones_like(closest_indices)
+        neighbors[angles[np.arange(len(closest_indices)), closest_indices] < 0] = -1
+        signs = (neighbors == 1) * 2.0 - 1.0
+        neighbors[(closest_indices >= len(relative_soma_pts) - 1) & (neighbors == 1)] = (
+            -len(relative_soma_pts) + 1
+        )
+
+        # Compute the cross product and multiply by neighbors to get the same result as if all
+        # vectors were clockwise
+        cross_z = (
+            np.cross(
+                (
+                    ordered_relative_soma_pts[closest_indices + neighbors]
+                    - ordered_relative_soma_pts[closest_indices]
+                ),
+                relative_pts - ordered_relative_soma_pts[closest_indices],
+            )[:, COLS.Z]
+            * signs
+        )
+
+        if exclude_boundary:
+            interior_side = cross_z > 0
+        else:
+            interior_side = cross_z >= 0
+
+        return interior_side
+
+    soma_algo = {
+        SomaType.SOMA_UNDEFINED: _soma_undefined_overlaps,
+        SomaType.SOMA_SINGLE_POINT: _soma_undefined_overlaps,
+        SomaType.SOMA_CYLINDERS: _soma_cylinders_overlaps,
+        SomaType.SOMA_NEUROMORPHO_THREE_POINT_CYLINDERS: _soma_cylinders_overlaps,
+        SomaType.SOMA_SIMPLE_CONTOUR: _soma_simple_contour_overlaps,
+    }[morphio_soma.type]
+
+    return soma_algo(morphio_soma, points, exclude_boundary=exclude_boundary)
+
 
 
 

--- a/neurom/core/soma.py
+++ b/neurom/core/soma.py
@@ -60,13 +60,13 @@ class Soma:
     @property
     def center(self):
         """Obtain the center from the first stored point."""
-        return soma_center(self)
+        return get_center(self)
 
     @property
     def radius(self):
         """Return radius of soma."""
         # this radius is used only for `volume` method, please avoid using it for anything else.
-        return soma_radius(self)
+        return get_radius(self)
 
     def iter(self):
         """Iterator to soma contents."""
@@ -82,16 +82,16 @@ class Soma:
     @property
     def area(self):
         """Calculate soma area."""
-        return soma_area(self)
+        return get_area(self)
 
     @property
     def volume(self):
         """Calculate soma volume."""
-        return soma_volume(self)
+        return get_volume(self)
 
     def overlaps(self, points, exclude_boundary=False):
         """Check that the given points are located inside the soma."""
-        return soma_overlaps(self, points, exclude_boundary=exclude_boundary)
+        return check_overlaps(self, points, exclude_boundary=exclude_boundary)
 
 
 class SomaSinglePoint(Soma):
@@ -222,7 +222,7 @@ def _dispatch_soma_functions(soma, dispatch_mapping, **kwargs):
     return soma_algo(morphio_soma, **kwargs)
 
 
-def soma_center(soma):
+def get_center(soma):
     """Calculate soma center."""
     dispatch_mapping = {
         SomaType.SOMA_UNDEFINED: _first_point_or_none,
@@ -250,7 +250,7 @@ def _centroid(morphio_soma):
     return np.mean(morphio_soma.points, axis=0)
 
 
-def soma_radius(soma):
+def get_radius(soma):
     """Calculate soma radius."""
     dispatch_mapping = {
         SomaType.SOMA_UNDEFINED: lambda _: 0,
@@ -279,15 +279,15 @@ def _soma_cylinders_radius(morphio_soma):
 
 def _soma_three_point_cylinders_radius(morphio_soma):
     """Calculate three-point-cylinder radius."""
-    return math.sqrt(soma_area(morphio_soma) / (4.0 * math.pi))
+    return math.sqrt(get_area(morphio_soma) / (4.0 * math.pi))
 
 
 def _soma_simple_contour_radius(morphio_soma):
     """Calculate average contour distance from center of soma."""
-    return morphmath.average_points_dist(soma_center(morphio_soma), morphio_soma.points)
+    return morphmath.average_points_dist(get_center(morphio_soma), morphio_soma.points)
 
 
-def soma_area(soma):
+def get_area(soma):
     """Calculate soma area."""
     dispatch_mapping = {
         SomaType.SOMA_UNDEFINED: _soma_undefined_area,
@@ -301,7 +301,7 @@ def soma_area(soma):
 
 def _soma_single_point_area(morphio_soma):
     """Calculate soma area as a sphere."""
-    return 4.0 * math.pi * soma_radius(morphio_soma) ** 2
+    return 4.0 * math.pi * get_radius(morphio_soma) ** 2
 
 
 def _soma_undefined_area(morphio_soma):
@@ -329,7 +329,7 @@ def _soma_three_point_cylinders_area(morphio_soma):
     return 2.0 * math.pi * r * h  # ignores the 'end-caps' of the cylinder
 
 
-def soma_volume(soma):
+def get_volume(soma):
     """Calculate soma volume."""
     dispatch_mapping = {
         SomaType.SOMA_UNDEFINED: _soma_undefined_volume,
@@ -343,7 +343,7 @@ def soma_volume(soma):
 
 def _soma_single_point_volume(morphio_soma):
     """Calculate soma volume as a sphere."""
-    return 4.0 / 3 * math.pi * soma_radius(morphio_soma) ** 3
+    return 4.0 / 3 * math.pi * get_radius(morphio_soma) ** 3
 
 
 def _soma_undefined_volume(morphio_soma):
@@ -366,10 +366,10 @@ def _soma_cylinders_volume(morphio_soma):
 
 def _soma_three_point_cylinders_volume(morphio_soma):
     """Calculate soma volume as a cylinder of three points and same radius."""
-    return 2.0 * math.pi * soma_radius(morphio_soma) ** 3
+    return 2.0 * math.pi * get_radius(morphio_soma) ** 3
 
 
-def soma_overlaps(soma, points, exclude_boundary=False):
+def check_overlaps(soma, points, exclude_boundary=False):
     """Check if soma overlaps with points."""
     dispatch_mapping = {
         SomaType.SOMA_UNDEFINED: _soma_undefined_overlaps,
@@ -390,8 +390,8 @@ def _soma_undefined_overlaps(morphio_soma, points, exclude_boundary):
     """Check if points overlap with soma approximated as a sphere."""
     points = np.atleast_2d(np.asarray(points, dtype=np.float64))
 
-    center = soma_center(morphio_soma)
-    radius = soma_radius(morphio_soma)
+    center = get_center(morphio_soma)
+    radius = get_radius(morphio_soma)
 
     if exclude_boundary:
         return np.linalg.norm(points - center, axis=1) < radius
@@ -442,7 +442,7 @@ def _soma_simple_contour_overlaps(morphio_soma, points, exclude_boundary):
         ),
         axis=1,
     )
-    center = soma_center(morphio_soma)
+    center = get_center(morphio_soma)
 
     points = np.atleast_2d(np.asarray(points, dtype=np.float64))
 

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -43,7 +43,6 @@ The features mechanism does not allow you to apply these features to neurites.
 For more details see :ref:`features`.
 """
 
-import math
 import warnings
 from collections.abc import Iterable
 from functools import partial

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -50,6 +50,7 @@ from functools import partial
 
 import numpy as np
 
+import neurom.core.soma
 from neurom import morphmath
 from neurom.core.dataformat import COLS
 from neurom.core.morphology import (
@@ -121,7 +122,7 @@ def _get_points(morph, neurite_type):
 @feature(shape=())
 def soma_volume(morph):
     """Get the volume of a morphology's soma."""
-    return morph.soma.volume
+    return neurom.core.soma.soma_volume(morph.soma)
 
 
 @feature(shape=())
@@ -131,13 +132,13 @@ def soma_surface_area(morph):
     Note:
         The surface area is calculated by assuming the soma is spherical.
     """
-    return 4.0 * math.pi * morph.soma.radius**2
+    return neurom.core.soma.soma_area(morph.soma)
 
 
 @feature(shape=())
 def soma_radius(morph):
     """Get the radius of a morphology's soma."""
-    return morph.soma.radius
+    return neurom.core.soma.soma_radius(morph.soma)
 
 
 @feature(shape=())

--- a/neurom/features/morphology.py
+++ b/neurom/features/morphology.py
@@ -121,7 +121,7 @@ def _get_points(morph, neurite_type):
 @feature(shape=())
 def soma_volume(morph):
     """Get the volume of a morphology's soma."""
-    return neurom.core.soma.soma_volume(morph.soma)
+    return neurom.core.soma.get_volume(morph.soma)
 
 
 @feature(shape=())
@@ -131,13 +131,13 @@ def soma_surface_area(morph):
     Note:
         The surface area is calculated by assuming the soma is spherical.
     """
-    return neurom.core.soma.soma_area(morph.soma)
+    return neurom.core.soma.get_area(morph.soma)
 
 
 @feature(shape=())
 def soma_radius(morph):
     """Get the radius of a morphology's soma."""
-    return neurom.core.soma.soma_radius(morph.soma)
+    return neurom.core.soma.get_radius(morph.soma)
 
 
 @feature(shape=())

--- a/neurom/io/utils.py
+++ b/neurom/io/utils.py
@@ -120,7 +120,7 @@ def _get_file(stream, extension):
     return temp_file
 
 
-def load_morphology(morph, reader=None, mutable=None, process_subtrees=False):
+def load_morphology(morph, reader=None, *, mutable=None, process_subtrees=False):
     """Build section trees from a morphology or a h5, swc or asc file.
 
     Args:
@@ -132,11 +132,12 @@ def load_morphology(morph, reader=None, mutable=None, process_subtrees=False):
             - a morphio mutable or immutable Morphology object
             - a stream that can be put into a io.StreamIO object. In this case, the READER argument
               must be passed with the corresponding file format (asc, swc and h5)
+        reader (str): Optional, must be provided if morphology is a stream to
+                      specify the file format (asc, swc, h5)
         mutable (bool|None): Whether to enforce mutability. If None and a morphio/neurom object is
                              passed, the initial mutability will be maintained. If None and the
                              morphology is loaded, then it will be immutable by default.
-        reader (str): Optional, must be provided if morphology is a stream to
-                      specify the file format (asc, swc, h5)
+        process_subtrees (bool): enable mixed tree processing if set to True
 
     Returns:
         A Morphology object
@@ -181,7 +182,7 @@ def load_morphology(morph, reader=None, mutable=None, process_subtrees=False):
 
 
 def load_morphologies(
-    morphs, name=None, ignored_exceptions=(), cache=False, process_subtrees=False
+    morphs, name=None, ignored_exceptions=(), *, cache=False, process_subtrees=False
 ):
     """Create a population object.
 
@@ -195,6 +196,7 @@ def load_morphologies(
         ignored_exceptions (tuple): NeuroM and MorphIO exceptions that you want to ignore when
             loading morphologies
         cache (bool): whether to cache the loaded morphologies in memory
+        process_subtrees (bool): enable mixed tree processing if set to True
 
     Returns:
         Population: population object
@@ -205,4 +207,6 @@ def load_morphologies(
     else:
         files = morphs
         name = name or 'Population'
-    return Population(files, name, ignored_exceptions, cache, process_subtrees=process_subtrees)
+    return Population(
+        files, name, ignored_exceptions, cache=cache, process_subtrees=process_subtrees
+    )


### PR DESCRIPTION
* Expose soma methods as free functions that work on both morphio an neurom soma objects.
* Keep backward compatibility with the soma methods.
* Disallow storing soma values, such as radius or area, as attributes because the underlying morphio soma can be mutated.